### PR TITLE
Make `Notify.wait` a coroutine rather than return a Trigger

### DIFF
--- a/src/coconext/triggers.py
+++ b/src/coconext/triggers.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from cocotb.triggers import Event, Trigger
+from cocotb.triggers import Event
 
 
 class Notify:
@@ -29,6 +29,6 @@ class Notify:
         self._event.set()
         self._event.clear()
 
-    def wait(self) -> Trigger:
-        """Return Trigger that blocks until the notify() method is called."""
-        return self._event.wait()
+    async def wait(self) -> None:
+        """Wait until the notify() method is called."""
+        await self._event.wait()

--- a/src/coconext/triggers.py
+++ b/src/coconext/triggers.py
@@ -9,10 +9,13 @@ class Notify:
     """Notify all waiters of an event.
 
     :class:`cocotb.triggers.Event` has state.
-    It can be in a state where :meth:`.Event.is_set` is ``True`` and calling
+    It can be in the state where :meth:`.Event.is_set` is ``False`` and calling
+    :meth:`.Event.wait` will return a Trigger that only fires after :meth:`.Event.set` is called.
+    Or it can be in a state where :meth:`.Event.is_set` is ``True`` and calling
     :meth:`.Event.wait` will return a Trigger that fires immediately.
 
-    This object odes not have a "set" state.
+    This object does not have state.
+    It behaves like :class:`.Event` if it were only ever in the :meth:`.Event.is_set` is ``False`` state.
     All calls to :meth:`wait` will block until the next call to :meth:`notify` occurs.
 
     .. versionadded:: 0.1


### PR DESCRIPTION
Soon `TaskManager` will be added and in general API should avoid returning triggers.