### PR TITLE
Pin cocotb version until beta release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
   hooks:
   - id: mypy
     additional_dependencies:
-    - git+https://github.com/cocotb/cocotb.git
+    - git+https://github.com/cocotb/cocotb.git@af7f0ed955bd871fc3ce1008ec3a15792b96e0de
     - pytest
     - nox
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 sphinx
 sphinx_rtd_theme
 git+https://github.com/ktbarrett/prettyspecialmethods
-git+https://github.com/cocotb/cocotb.git
+git+https://github.com/cocotb/cocotb.git@af7f0ed955bd871fc3ce1008ec3a15792b96e0de

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
 pytest
 coverage
-git+https://github.com/cocotb/cocotb.git
+git+https://github.com/cocotb/cocotb.git@af7f0ed955bd871fc3ce1008ec3a15792b96e0de


### PR DESCRIPTION
This should prevent the current failures in pre-commit.ci.