### PR TITLE
Add Queue

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,7 +42,7 @@ github_url = "https://github.com/ktbarrett/coconext/"
 # Options for autodoc
 ################################################################################
 
-autoclass_content = "both"
+autoclass_content = "class"
 autodoc_member_order = "bysource"
 autodoc_default_options = {
     "members": True,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@
 coconext documentation
 ======================
 
-A staging area for new `cocotb <https://github.com/cocotb/cocotb>` features.
+A staging area for new `cocotb <https://github.com/cocotb/cocotb>`_ features.
 This project will move faster and include more experimental features than may end up in the main repo.
 
 .. toctree::

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -10,3 +10,16 @@ SimTime
 =======
 
 .. automodule:: coconext.simtime
+
+Queue
+=====
+
+.. automodule:: coconext.queue
+    :exclude-members: AbstractQueue
+
+    .. autoclass:: AbstractQueue
+        :exclude-members: Lock, __weakref__
+
+        .. autoclass:: coconext.queue.AbstractQueue.Lock
+            :exclude-members: __init__, __weakref__
+            :member-order: bysource

--- a/src/coconext/queue.py
+++ b/src/coconext/queue.py
@@ -1,0 +1,335 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Collection of asynchronous queues."""
+
+from __future__ import annotations
+
+import heapq
+import sys
+from abc import abstractmethod
+from asyncio import QueueEmpty, QueueFull
+from collections import deque
+from typing import Any, Generic, TypeVar
+
+from cocotb.task import Task, current_task
+from cocotb.triggers import Event
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+
+T = TypeVar("T")
+
+
+class AbstractQueue(Generic[T]):
+    """An asynchronous queue, useful for coordinating producer and consumer tasks.
+
+    Queues can have various semantics with respect to the values :meth:`put` and :meth:`get` from them.
+    This class does not enforce any particular semantics,
+    but leaves the implementation and semantics abstract.
+    A concrete queue class can be created by subclassing :class:`!AbstractQueue`
+    and filling in the :meth:`_size`, :meth:`_put`, :meth:`_get`, and :meth:`_peek` methods.
+
+    Additionally, there are common implementations included in this module:
+    :class:`Queue` (FIFO semantics), :class:`LifoQueue` (LIFO semantics), and :class:`PriorityQueue` (min-heap semantics).
+
+    .. versionadded:: 0.2
+    """
+
+    class Lock:
+        r"""A mutex lock specialized for use by asynchronous Queue.
+
+        This class is not intended to be instantiated by the user,
+        but rather be acquired via :attr:`.AbstractQueue.write_lock`
+        or :attr:`.AbstractQueue.read_lock`.
+
+        In addition to all the functionality available on :class:`~cocotb.triggers.Lock`,
+        these locks are aware of the associated queue's *availability*,
+        i.e. whether the read or write side has data or space available to either get or put, respectively.
+        """
+
+        def __init__(self) -> None:
+            self._current_acquirer: Task[object] | None = None
+            self._acquirers = deque[tuple[Event, Task]]()
+
+        def locked(self) -> bool:
+            """Return ``True`` if the lock is *locked*."""
+            return self._current_acquirer is not None
+
+        @abstractmethod
+        def _is_available(self) -> bool: ...
+
+        def available(self) -> bool:
+            """Return ``True`` if the lock is *available* for acquiring."""
+            return self._is_available()
+
+        async def acquire(self) -> None:
+            """Acquire the lock.
+
+            Waits until the lock is *available* and *unlocked*, sets it to *locked* and returns.
+            Multiple Tasks may attempt to acquire the Lock, but only one will proceed.
+            Tasks are guaranteed to acquire the Lock in the order each attempts to acquire it.
+            """
+            acquirer_task = current_task()
+            if not self.available() or self.locked():
+                if acquirer_task is self._current_acquirer:
+                    # User tried acquiring a Lock they already acquired. Return to prevent deadlock.
+                    return
+                e = Event()
+                self._acquirers.append((e, acquirer_task))
+                await e.wait()
+            else:
+                self._current_acquirer = acquirer_task
+
+        def release(self) -> None:
+            """Release the lock.
+
+            Sets the lock to *unlocked*.
+
+            Raises:
+                RuntimeError: If called when the lock is *unlocked*.
+            """
+            if not self.locked():
+                raise RuntimeError("Lock is not acquired")
+            self._current_acquirer = None
+            self._wakeup_next()
+
+        def _wakeup_next(self) -> None:
+            if self.locked():
+                # Already locked/pending, don't wake up another waiter.
+                return
+            if not self.available():
+                # Nothing available, don't wake up a waiter.
+                return
+            # Find first living waiter and wake it.
+            while self._acquirers:
+                e, task = self._acquirers.popleft()
+                if not task.done():
+                    self._current_acquirer = task
+                    return e.set()
+
+        async def __aenter__(self) -> Self:
+            await self.acquire()
+            return self
+
+        async def __aexit__(self, *_: object) -> None:
+            self.release()
+
+    class _WriteLock(Lock):
+        def __init__(self, queue: AbstractQueue[Any]) -> None:
+            super().__init__()
+            self._queue = queue
+
+        def _is_available(self) -> bool:
+            return not self._queue.full()
+
+    class _ReadLock(Lock):
+        def __init__(self, queue: AbstractQueue[Any]) -> None:
+            super().__init__()
+            self._queue = queue
+
+        def _is_available(self) -> bool:
+            return not self._queue.empty()
+
+    def __init__(self, maxsize: int = 0) -> None:
+        """Construct a queue with the given *maxsize*.
+
+        If *maxsize* is less than or equal to 0, the queue size is infinite. If it
+        is an integer greater than 0, then :meth:`put` will block when the queue
+        reaches *maxsize*, until an item is removed by :meth:`get`.
+        """
+        self._maxsize: int = maxsize
+
+        self._write_lock = self._WriteLock(self)
+        self._read_lock = self._ReadLock(self)
+
+    @property
+    def write_lock(self) -> Lock:
+        """Lock for exclusive write access.
+
+        After acquiring this lock, the user has exclusive access to the write-side of the queue until the lock is released.
+        Calling :meth:`put` while the write lock is acquired will result in a :exc:`RuntimeError` to prevent deadlock.
+        """
+        return self._write_lock
+
+    @property
+    def read_lock(self) -> Lock:
+        """Lock for exclusive read access.
+
+        After acquiring this lock, the user has exclusive access to the read-side of the queue until the lock is released.
+        Calling :meth:`get` while the read lock is acquired will result in a :exc:`RuntimeError` to prevent deadlock.
+        """
+        return self._read_lock
+
+    @abstractmethod
+    def _get(self) -> T:
+        """Remove and return the next element from the queue."""
+
+    @abstractmethod
+    def _peek(self) -> T:
+        """Return the next element from the queue without removing it."""
+
+    @abstractmethod
+    def _put(self, item: T) -> None:
+        """Place a new element on the queue."""
+
+    @abstractmethod
+    def _size(self) -> int:
+        """Return the number of elements in the queue."""
+
+    def qsize(self) -> int:
+        """Number of items in the queue."""
+        return self._size()
+
+    @property
+    def maxsize(self) -> int:
+        """Number of items allowed in the queue."""
+        return self._maxsize
+
+    def empty(self) -> bool:
+        """Return ``True`` if the queue is empty, ``False`` otherwise."""
+        return self._size() == 0
+
+    def full(self) -> bool:
+        """Return ``True`` if there are :meth:`maxsize` items in the queue.
+
+        .. note::
+            If the Queue was initialized with ``maxsize=0`` (the default), then
+            :meth:`!full` is never ``True``.
+        """
+        if self._maxsize <= 0:
+            return False
+        else:
+            return self.qsize() >= self._maxsize
+
+    async def put(self, item: T) -> None:
+        """Put an *item* into the queue.
+
+        If the queue is full, wait until a free
+        slot is available before adding the item.
+        """
+        async with self._write_lock:
+            self.put_nowait(item)
+
+    def put_nowait(self, item: T) -> None:
+        """Put an *item* into the queue without blocking.
+
+        If no free slot is immediately available, raise :exc:`~cocotb.queue.QueueFull`.
+        """
+        if self.full():
+            raise QueueFull()
+        self._put(item)
+        # This changes availability, so inform the read side Lock.
+        self._read_lock._wakeup_next()
+
+    async def get(self) -> T:
+        """Remove and return an item from the queue.
+
+        If the queue is empty, wait until an item is available.
+        """
+        async with self._read_lock:
+            return self.get_nowait()
+
+    def get_nowait(self) -> T:
+        """Remove and return an item from the queue.
+
+        Returns an item if one is immediately available,
+        otherwise raises :exc:`~cocotb.queue.QueueEmpty`.
+        """
+        if self.empty():
+            raise QueueEmpty()
+        item = self._get()
+        # This changes availability, so inform the write side Lock.
+        self._write_lock._wakeup_next()
+        return item
+
+    async def peek(self) -> T:
+        """Return the next item from the queue without removing it.
+
+        If the queue is empty, wait until an item is available.
+        """
+        async with self._read_lock:
+            return self.peek_nowait()
+
+    def peek_nowait(self) -> T:
+        """Return the next item from the queue without removing it.
+
+        Returns an item if one is immediately available,
+        otherwise raises :exc:`~cocotb.queue.QueueEmpty`.
+        """
+        if self.empty():
+            raise QueueEmpty()
+        item = self._peek()
+        return item
+
+
+class Queue(AbstractQueue[T]):
+    """A subclass of :class:`AbstractQueue`; retrieves oldest entries first (FIFO).
+
+    .. versionadded:: 2.0
+    """
+
+    def __init__(self, maxsize: int = 0) -> None:
+        super().__init__(maxsize)
+        self._queue = deque[T]()
+
+    def _put(self, item: T) -> None:
+        self._queue.append(item)
+
+    def _get(self) -> T:
+        return self._queue.popleft()
+
+    def _peek(self) -> T:
+        return self._queue[0]
+
+    def _size(self) -> int:
+        return len(self._queue)
+
+
+class PriorityQueue(AbstractQueue[T]):
+    r"""A subclass of :class:`AbstractQueue`; retrieves entries in priority order (smallest item first).
+
+    Entries are typically tuples of the form ``(priority number, data)``.
+
+    .. versionadded:: 2.0
+    """
+
+    def __init__(self, maxsize: int = 0) -> None:
+        super().__init__(maxsize)
+        self._queue: list[T] = []
+
+    def _put(self, item: T) -> None:
+        heapq.heappush(self._queue, item)
+
+    def _get(self) -> T:
+        return heapq.heappop(self._queue)
+
+    def _peek(self) -> T:
+        return self._queue[0]
+
+    def _size(self) -> int:
+        return len(self._queue)
+
+
+class LifoQueue(AbstractQueue[T]):
+    """A subclass of :class:`AbstractQueue`; retrieves most recently added entries first (LIFO).
+
+    .. versionadded:: 2.0
+    """
+
+    def __init__(self, maxsize: int = 0) -> None:
+        super().__init__(maxsize)
+        self._queue = deque[T]()
+
+    def _put(self, item: T) -> None:
+        self._queue.append(item)
+
+    def _get(self) -> T:
+        return self._queue.pop()
+
+    def _peek(self) -> T:
+        return self._queue[-1]
+
+    def _size(self) -> int:
+        return len(self._queue)

--- a/tests/test_coconext/queue_tests.py
+++ b/tests/test_coconext/queue_tests.py
@@ -1,0 +1,404 @@
+from __future__ import annotations
+
+import heapq
+import random
+from asyncio import QueueEmpty, QueueFull
+from collections.abc import Coroutine
+from typing import Any
+
+import cocotb
+import pytest
+from cocotb.task import Task
+from cocotb.triggers import (
+    Combine,
+    NullTrigger,
+    SimTimeoutError,
+    Timer,
+    Trigger,
+    with_timeout,
+)
+
+from coconext.queue import AbstractQueue, LifoQueue, PriorityQueue, Queue
+
+
+@cocotb.test(timeout_time=10, timeout_unit="ns")
+@cocotb.parametrize(queue_type=(Queue, LifoQueue, PriorityQueue))
+async def test_queue_basic(_: object, queue_type: type[AbstractQueue[int]]) -> None:
+    q = queue_type(maxsize=2)
+
+    assert q.maxsize == 2
+
+    assert q.qsize() == 0
+    assert not q.full()
+    assert q.empty()
+
+    with pytest.raises(QueueEmpty):
+        q.get_nowait()
+    with pytest.raises(QueueEmpty):
+        q.peek_nowait()
+    assert q.qsize() == 0
+
+    q.put_nowait(1)
+    assert q.qsize() == 1
+    assert not q.full()
+    assert not q.empty()
+
+    assert q.peek_nowait() == 1
+
+    q.put_nowait(2)
+    assert q.qsize() == 2
+    assert q.full()
+    assert not q.empty()
+
+    with pytest.raises(QueueFull):
+        q.put_nowait(3)
+
+    # Save outputs in unordered collection since each queue type has different behavior.
+    outputs = set[int]()
+
+    outputs.add(q.get_nowait())
+    assert q.qsize() == 1
+    assert not q.full()
+    assert not q.empty()
+
+    outputs.add(q.get_nowait())
+    assert q.qsize() == 0
+    assert not q.full()
+    assert q.empty()
+
+    with pytest.raises(QueueEmpty):
+        q.get_nowait()
+    assert q.qsize() == 0
+
+    assert outputs == {1, 2}  # 3 was pushed when full and we shouldn't get it.
+
+
+@cocotb.test(timeout_time=10, timeout_unit="ns")
+@cocotb.parametrize(queue_type=(Queue, LifoQueue, PriorityQueue))
+async def test_queue_async(_: object, queue_type: type[AbstractQueue[int]]) -> None:
+    q = queue_type(maxsize=2)
+
+    assert q.maxsize == 2
+
+    await q.put(1)
+
+    # We know it can only be `1`, while after 2 puts the behavior between the queue types differs.
+    assert await q.peek() == 1
+
+    await q.put(2)
+    with pytest.raises(SimTimeoutError):
+        await with_timeout(q.put(3), 1, "step")
+
+    outputs = set[int]()
+    outputs.add(await q.get())
+    outputs.add(await q.get())
+    with pytest.raises(SimTimeoutError):
+        await with_timeout(q.get(), 1, "step")
+
+    assert outputs == {1, 2}
+
+
+@cocotb.test(timeout_time=10, timeout_unit="ns")
+@cocotb.parametrize(queue_type=(Queue, LifoQueue, PriorityQueue))
+async def test_queue_lock_direct(
+    _: object, queue_type: type[AbstractQueue[int]]
+) -> None:
+    """Test Lock acquire/release."""
+    q = queue_type(maxsize=2)
+
+    assert not q.write_lock.locked()
+    await q.write_lock.acquire()
+    assert q.write_lock.locked()
+
+    await q.write_lock.acquire()  # already acquired should no-op
+    assert q.write_lock.locked()
+
+    q.write_lock.release()
+    assert not q.write_lock.locked()
+
+    with pytest.raises(RuntimeError):
+        q.write_lock.release()
+    assert not q.write_lock.locked()
+
+    async with q.write_lock:
+        assert q.write_lock.locked()
+        await NullTrigger()
+        assert q.write_lock.locked()
+
+    assert not q.write_lock.locked()
+
+
+@cocotb.test(timeout_time=10, timeout_unit="ns")
+@cocotb.parametrize(queue_type=(Queue, LifoQueue, PriorityQueue))
+async def test_queue_lock_no_op(
+    _: object, queue_type: type[AbstractQueue[int]]
+) -> None:
+    q = queue_type()
+
+    async def writer(value: int) -> None:
+        await q.put(value)
+
+    task = cocotb.start_soon(writer(20))
+
+    assert q.write_lock.available()
+    assert not q.write_lock.locked()
+
+    async with q.write_lock:
+        assert q.write_lock.locked()
+        await Timer(1)
+
+    assert q.write_lock.available()
+    # locked because of pending writer() Task
+    assert not task.done()
+    assert q.qsize() == 0
+
+    await NullTrigger()
+    assert task.done()
+    assert q.qsize() == 1
+
+    async def reader() -> int:
+        return await q.get()
+
+    task2 = cocotb.start_soon(reader())
+
+    assert q.read_lock.available()
+    assert not q.read_lock.locked()
+
+    async with q.read_lock:
+        assert q.read_lock.locked()
+        await Timer(1)
+
+    assert q.read_lock.available()
+    # locked because of pending reader() Task
+    assert not task2.done()
+    assert q.qsize() == 1
+
+    await NullTrigger()
+    assert task2.done()
+    assert q.qsize() == 0
+    assert task2.result() == 20
+
+
+@cocotb.test(timeout_time=10, timeout_unit="ns")
+@cocotb.parametrize(queue_type=(Queue, LifoQueue, PriorityQueue))
+async def test_queue_lock_multi_op(
+    _: object, queue_type: type[AbstractQueue[int]]
+) -> None:
+    q = queue_type()
+
+    async with q.write_lock:
+        for i in range(10):
+            q.put_nowait(i)
+
+    outputs = set[int]()
+    async with q.read_lock:
+        for _ in range(10):
+            outputs.add(q.get_nowait())
+
+    assert outputs == set(range(10))
+
+
+@cocotb.test(timeout_time=10, timeout_unit="ns")
+@cocotb.parametrize(queue_type=(Queue, LifoQueue, PriorityQueue))
+async def test_queue_lock_contenting(
+    _: object, queue_type: type[AbstractQueue[int]]
+) -> None:
+    """Test Queue with multiple simultaneous readers/writers."""
+    q = queue_type()
+
+    async def writer(value: int) -> None:
+        await q.put(value)
+
+    task = cocotb.start_soon(writer(20))
+
+    async with q.write_lock:
+        await NullTrigger()
+        assert not task.done()  # blocking
+        q.put_nowait(1)
+        q.put_nowait(2)
+        q.put_nowait(3)
+
+    assert not task.done()  # scheduled
+    assert q.qsize() == 3
+
+    await NullTrigger()
+    assert task.done()  # acquired lock and finished
+    assert q.qsize() == 4
+
+    async def reader() -> None:
+        await q.get()
+
+    task = cocotb.start_soon(reader())
+
+    async with q.read_lock:
+        await NullTrigger()
+        assert not task.done()  # blocking
+        q.get_nowait()
+        q.get_nowait()
+        q.get_nowait()
+        q.get_nowait()
+
+    assert not task.done()  # scheduled
+    assert q.qsize() == 0
+
+    # This should block forever since we are empty, so ensure timeout
+    with pytest.raises(SimTimeoutError):
+        await with_timeout(task, 1, "step")
+
+
+@cocotb.test(timeout_time=10, timeout_unit="ns")
+@cocotb.parametrize(queue_type=(Queue, LifoQueue, PriorityQueue))
+async def test_queue_random_contention(
+    _: object, queue_type: type[AbstractQueue[int]]
+) -> None:
+    TEST_LEN = 10000
+    MAX_WAIT = 10
+
+    q = queue_type(10)
+
+    class Checker:
+        def __init__(self) -> None:
+            self._last_seen = [0, 0]
+            self._cancelleds = (set[int](), set[int]())
+            self._tasks: list[Task[Any]] = []
+            self._task_info: dict[Task[Any], tuple[bool, int]] = {}
+            self._task_info_reversed: dict[tuple[bool, int], Task[Any]] = {}
+
+        @property
+        def tasks(self) -> tuple[Task[Any], ...]:
+            return tuple(self._tasks)
+
+        def add(
+            self, coro: Coroutine[Trigger, None, Any], idx: int, is_writer: bool
+        ) -> None:
+            cocotb.log.info(f"added {is_writer=} {idx=}")
+            task = cocotb.start_soon(coro)
+            self._task_info[task] = (is_writer, idx)
+            self._task_info_reversed[(is_writer, idx)] = task
+            self._tasks.append(task)
+
+        def acquired(self, idx: int, is_writer: bool) -> None:
+            cocotb.log.info(f"acquired {is_writer=} {idx=}")
+            task = self._task_info_reversed[(is_writer, idx)]
+            self._tasks.remove(task)
+
+            for i in range(self._last_seen[is_writer] + 1, idx):
+                if i not in self._cancelleds[is_writer]:
+                    assert False, f"Out of order, expected {i}, got {idx}"
+                else:
+                    self._cancelleds[is_writer].remove(i)
+            self._last_seen[is_writer] = idx
+
+        def cancel(self, task: Task[Any]) -> None:
+            task.cancel()
+            is_writer, idx = self._task_info[task]
+            self._cancelleds[is_writer].add(idx)
+            cocotb.log.info(f"cancelled {is_writer=} {idx=}")
+
+    checker = Checker()
+
+    async def start_writers() -> None:
+        async def writer(idx: int) -> None:
+            async with q.write_lock:
+                checker.acquired(idx, is_writer=True)
+                q.put_nowait(0)
+                await Timer(random.randint(1, MAX_WAIT))
+
+        for idx in range(TEST_LEN):
+            checker.add(writer(idx), idx, is_writer=True)
+            await Timer(random.randint(1, MAX_WAIT))
+
+    async def start_readers() -> None:
+        async def reader(idx: int) -> None:
+            async with q.read_lock:
+                checker.acquired(idx, is_writer=False)
+                q.get_nowait()
+                await Timer(random.randint(1, MAX_WAIT))
+
+        for idx in range(TEST_LEN):
+            checker.add(reader(idx), idx, is_writer=False)
+            await Timer(random.randint(1, MAX_WAIT))
+
+    async def random_canceller() -> None:
+        while True:
+            await Timer(random.randint(1, MAX_WAIT) * 20)
+            if tasks := checker.tasks:
+                task = random.choice(tasks)
+                checker.cancel(task)
+
+    canceller = cocotb.start_soon(random_canceller())
+    await Combine(
+        cocotb.start_soon(start_writers()), cocotb.start_soon(start_readers())
+    )
+    await Combine(*checker.tasks)
+    canceller.cancel()
+    await NullTrigger()
+
+
+@cocotb.test
+async def test_queue_behavior(_: object) -> None:
+    q = Queue[int]()
+
+    curr_in_val = 0
+    curr_out_val = 0
+
+    for _ in range(10):
+        for _ in range(random.randrange(100)):
+            q.put_nowait(curr_in_val)
+            curr_in_val += 1
+
+        for _ in range(random.randrange(100)):
+            if q.empty():
+                break
+            assert q.get_nowait() == curr_out_val
+            curr_out_val += 1
+
+    while not q.empty():
+        assert q.get_nowait() == curr_out_val
+        curr_out_val += 1
+
+
+@cocotb.test
+async def test_lifo_queue_behavior(_: object) -> None:
+    q = LifoQueue[int]()
+
+    curr_in_val = 0
+    stack: list[int] = []
+
+    for _ in range(10):
+        for _ in range(random.randrange(100)):
+            q.put_nowait(curr_in_val)
+            stack.append(curr_in_val)
+            curr_in_val += 1
+
+        for _ in range(random.randrange(100)):
+            if q.empty():
+                break
+            expected_val = stack.pop()
+            assert q.get_nowait() == expected_val
+
+    while not q.empty():
+        expected_val = stack.pop()
+        assert q.get_nowait() == expected_val
+
+
+@cocotb.test
+async def test_priority_queue_behavior(_: object) -> None:
+    q = PriorityQueue[int]()
+
+    heap: list[int] = []
+
+    for _ in range(10):
+        for _ in range(random.randrange(100)):
+            random_val = random.getrandbits(32)
+            heapq.heappush(heap, random_val)
+
+        for _ in range(random.randrange(100)):
+            if q.empty():
+                break
+            expected_val = heapq.heappop(heap)
+            assert q.get_nowait() == expected_val
+
+    while not q.empty():
+        expected_val = heapq.heappop(heap)
+        assert q.get_nowait() == expected_val

--- a/tests/test_coconext/simtime_tests.py
+++ b/tests/test_coconext/simtime_tests.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Any
-
 import cocotb
 import pytest
 from cocotb.triggers import with_timeout
@@ -10,7 +8,7 @@ from coconext.simtime import SimTime
 
 
 @cocotb.test
-async def test_simtime(_: Any) -> None:
+async def test_simtime(_: object) -> None:
     # constructing SimTime
     assert SimTime(1, "fs").fs == 1
     assert SimTime(5, "ps").ps == 5

--- a/tests/test_coconext/test_coconext.py
+++ b/tests/test_coconext/test_coconext.py
@@ -29,3 +29,11 @@ def test_simtime(runner: Runner) -> None:
         hdl_toplevel="top",
         test_dir=runner.build_dir / "simtime_tests",
     )
+
+
+def test_queues(runner: Runner) -> None:
+    runner.test(
+        test_module="queue_tests",
+        hdl_toplevel="top",
+        test_dir=runner.build_dir / "queue_tests",
+    )

--- a/tests/test_coconext/trigger_tests.py
+++ b/tests/test_coconext/trigger_tests.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Any
-
 import cocotb
 from cocotb.task import Task
 from cocotb.triggers import Timer
@@ -10,7 +8,7 @@ from coconext.triggers import Notify
 
 
 @cocotb.test
-async def test_notify(_: Any) -> None:
+async def test_notify(_: object) -> None:
     n = Notify()
 
     # start up a bunch of waiters on the notify


### PR DESCRIPTION
Closes #21. Closes #22.

This extends the functionality of cocotb.triggers.Queue and
asyncio.Queue on which it was based by adding support for peeking and
support for directly interacting with the read and write-side locks.

Acquiring the read and write locks allows the user to wait until a side
of the queue is available and they have exclusive access to it, allowing
them to anywhere from 0 to N operations on that side of the queue,
rather than the "strictly 1" semantics of `get()` and `put()`.