### PR TITLE
Add `wait()`, `gather()`, and `select()`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,8 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "coconext"
 dependencies = [
-    "cocotb@git+https://github.com/cocotb/cocotb.git"
+    "cocotb@git+https://github.com/cocotb/cocotb.git",
+    'exceptiongroup; python_version < "3.11"',
 ]
 requires-python = ">=3.9"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ dev = [
     "nox[uv]>=2025.5.1",
     "pre-commit>=4.2.0",
     "pytest>=8.4.1",
+    "pytest-cov>=6.2.1",
     "ruff>=0.12.1",
 ]
 docs = [

--- a/src/coconext/simtime.py
+++ b/src/coconext/simtime.py
@@ -9,7 +9,7 @@ from typing import Literal
 from cocotb.triggers import Timer
 from cocotb.utils import get_sim_steps, get_time_from_sim_steps
 
-if sys.version_info >= (3, 11):
+if sys.version_info >= (3, 10):
     from typing import TypeAlias
 
 TimeUnit: TypeAlias = Literal["fs", "ps", "ns", "us", "ms", "sec", "step"]

--- a/src/coconext/triggers.py
+++ b/src/coconext/triggers.py
@@ -2,6 +2,17 @@
 
 from __future__ import annotations
 
+import sys
+from asyncio import CancelledError
+from collections.abc import Awaitable
+from typing import Any, Literal, TypeVar, overload
+
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+
+
+import cocotb
+from cocotb.task import Task
 from cocotb.triggers import Event
 
 
@@ -32,3 +43,281 @@ class Notify:
     async def wait(self) -> None:
         """Wait until the notify() method is called."""
         await self._event.wait()
+
+
+ReturnWhenType: TypeAlias = Literal[
+    "FIRST_COMPLETED", "FIRST_EXCEPTION", "ALL_COMPLETED"
+]
+
+T = TypeVar("T")
+T2 = TypeVar("T2")
+T3 = TypeVar("T3")
+T4 = TypeVar("T4")
+
+
+@overload
+async def wait(
+    a: Awaitable[T],
+    /,
+    *,
+    return_when: ReturnWhenType,
+) -> tuple[Task[T]]: ...
+
+
+@overload
+async def wait(
+    a: Awaitable[T],
+    b: Awaitable[T2],
+    /,
+    *,
+    return_when: ReturnWhenType,
+) -> tuple[Task[T], Task[T2]]: ...
+
+
+@overload
+async def wait(
+    a: Awaitable[T],
+    b: Awaitable[T2],
+    c: Awaitable[T3],
+    /,
+    *,
+    return_when: ReturnWhenType,
+) -> tuple[Task[T], Task[T2], Task[T3]]: ...
+
+
+@overload
+async def wait(
+    a: Awaitable[T],
+    b: Awaitable[T2],
+    c: Awaitable[T3],
+    d: Awaitable[T4],
+    /,
+    *,
+    return_when: ReturnWhenType,
+) -> tuple[Task[T], Task[T2], Task[T3], Task[T4]]: ...
+
+
+@overload
+async def wait(
+    *aw: Awaitable[T], return_when: ReturnWhenType
+) -> tuple[Task[T], ...]: ...
+
+
+async def wait(
+    *awaitables: Awaitable[Any], return_when: ReturnWhenType
+) -> tuple[Task[Any], ...]:
+    r"""Awaits on all given *awaitables* concurrently and blocks until the *return_when* condition is met.
+
+    Every :class:`~collections.abc.Awaitable` given to the function is :keyword:`await`\ ed concurrently in its own :class:`~cocotb.task.Task`.
+    When the return conditions specified by *return_when* are met, this function returns those :class:`!Task`\ s.
+    Once the return conditions are met,
+    any :class:`!Task`\ s which are still running are :meth:`~cocotb.task.Task.cancel`\ ed.
+
+    The *return_when* conditions must be one of the following:
+
+    - ``"FIRST_COMPLETED"``: Returns after the first *awaitable* completes, regardless if that was due to an exception or not.
+    - ``"FIRST_EXCEPTION"``: Returns after all *awaitables* complete or after the first *awaitable* that completes due to an exception.
+    - ``"ALL_COMPLETED"``: Returns after all *awaitables* complete.
+
+    Args:
+        awaitables: The :class:`Awaitable`\ s to concurrently :keyword:`!await` upon.
+        return_when:
+            The condition that must be met before returning.
+            One of ``"FIRST_COMPLETED"``, ``"FIRST_EXCEPTION"``, or ``"ALL_COMPLETED"``.
+
+    Returns:
+        A tuple of waiter :class:`~cocotb.task.Task`\ s.
+        The order of the return tuple corresponds to the order of the input.
+    """
+
+    async def waiter(aw: Awaitable[T]) -> T:
+        return await aw
+
+    tasks = tuple(Task[Any](waiter(a)) for a in awaitables)
+
+    # Event which is set by done_callback when return condition is met.
+    done = Event()
+
+    # order of cancellation may matter, so we use dict(), which is ordered unlike set()
+    remaining = dict.fromkeys(tasks)
+
+    # Define done_callbacks which set the "done" Event when the return condition is met.
+    if return_when == "FIRST_COMPLETED":
+
+        def done_callback(task: Task[Any]) -> None:
+            del remaining[task]
+            done.set()
+
+            # Cancel remaining before they have a chance to resume.
+            for t in remaining:
+                t.cancel()
+
+    elif return_when == "FIRST_EXCEPTION":
+
+        def done_callback(task: Task[Any]) -> None:
+            del remaining[task]
+            if not remaining:
+                done.set()
+            elif not task.cancelled() and task.exception() is not None:
+                done.set()
+                # Cancel remaining before they have a chance to resume.
+                for t in remaining:
+                    t.cancel()
+
+    else:
+
+        def done_callback(task: Task[Any]) -> None:
+            del remaining[task]
+            if not remaining:
+                done.set()
+
+    # Register done_callback to all waiter tasks.
+    for task in tasks:
+        task._add_done_callback(done_callback)
+        cocotb.start_soon(task)
+
+    try:
+        await done.wait()
+    except CancelledError:
+        # Cancel waiter tasks if this coroutine was cancelled.
+        for task in tasks:
+            task.cancel()
+        raise
+
+    return tasks
+
+
+@overload
+async def select(
+    *awaitables: Awaitable[T], return_exception: Literal[False] = False
+) -> tuple[int, T]: ...
+
+
+@overload
+async def select(
+    *awaitables: Awaitable[T], return_exception: Literal[True]
+) -> tuple[int, T | BaseException]: ...
+
+
+async def select(
+    *awaitables: Awaitable[T], return_exception: bool = False
+) -> tuple[int, T | BaseException]:
+    r"""Awaits on all given *awaitables* concurrently and returns the index and result of the first to complete.
+
+    After the first *awaitable* completes, remaining waiter tasks are cancelled.
+    This does not cancel :class:`~cocotb.task.Task`\ s passed as arguments,
+    only the internal tasks awaiting upon their completion.
+
+    Args:
+        awaitables: The :class:`~cocotb.abc.Awaitable`\ s to concurrently :keyword:`!await` upon.
+        return_exception:
+            If ``False`` (default), re-raises the exception when an *awaitable* results in an exception.
+            If ``True``, returns the exception rather than re-raising when an *awaitable* results in an exception.
+
+    Returns:
+        A tuple of the index into the argument list (0-based) of the first *awaitable* to complete and its result.
+    """
+    tasks = await wait(*awaitables, return_when="FIRST_COMPLETED")
+
+    # Find which awaitable completed.
+    for idx, task in enumerate(tasks):
+        if task.done() and not task.cancelled():
+            break
+
+    if return_exception and (exc := task.exception()) is not None:
+        return idx, exc
+    else:
+        return idx, task.result()
+
+
+@overload
+async def gather(
+    a: Awaitable[T],
+    /,
+    *,
+    return_exceptions: Literal[False] = False,
+) -> tuple[T]: ...
+
+
+@overload
+async def gather(
+    a: Awaitable[T],
+    b: Awaitable[T2],
+    /,
+    *,
+    return_exceptions: Literal[False] = False,
+) -> tuple[T, T2]: ...
+
+
+@overload
+async def gather(
+    a: Awaitable[T],
+    b: Awaitable[T2],
+    c: Awaitable[T3],
+    /,
+    *,
+    return_exceptions: Literal[False] = False,
+) -> tuple[T, T2, T3]: ...
+
+
+@overload
+async def gather(
+    a: Awaitable[T],
+    b: Awaitable[T2],
+    c: Awaitable[T3],
+    d: Awaitable[T4],
+    /,
+    *,
+    return_exceptions: Literal[False] = False,
+) -> tuple[T, T2, T3, T4]: ...
+
+
+@overload
+async def gather(
+    *aw: Awaitable[T], return_exceptions: Literal[False] = False
+) -> tuple[T, ...]: ...
+
+
+@overload
+async def gather(
+    *aw: Awaitable[T], return_exceptions: Literal[True]
+) -> tuple[T | BaseException, ...]: ...
+
+
+async def gather(
+    *awaitables: Awaitable[Any],
+    return_exceptions: bool = False,
+) -> tuple[Any, ...]:
+    r"""Awaits on all given *awaitables* concurrently and returns their results once all have completed.
+
+    After the return conditions, based on *return_exceptions* is met, remaining waiter tasks are cancelled.
+    This does not cancel :class:`~cocotb.task.Task`\ s passed as arguments,
+    only the internal tasks awaiting upon their completion.
+
+    Args:
+        awaitables: The :class:`~collection.abc.Awaitable`\ s to concurrently :keyword:`!await` upon.
+        return_exceptions:
+            If ``False`` (default), after the first *awaitable* results in an exception, cancels the remaining *awaitables* and re-raises the exception.
+            If ``True``, returns the exception rather than the result value when an *awaitable* results in an exception.
+
+    Returns:
+        A tuple of the results of awaiting each *awaitable* in the same order they were given.
+        The order of the return tuple corresponds to the order of the input.
+    """
+    tasks = await wait(
+        *awaitables,
+        return_when="ALL_COMPLETED" if return_exceptions else "FIRST_EXCEPTION",
+    )
+    if return_exceptions:
+        # We now know there were no cancelled Tasks, so get all exceptions or results.
+        return tuple(
+            exc if (exc := task.exception()) is not None else task.result()
+            for task in tasks
+        )
+    else:
+        # Find first error if there is one.
+        for task in tasks:
+            if not task.cancelled() and (exc := task.exception()) is not None:
+                raise exc
+        # We now know there were no cancelled Tasks and no exceptions, so get all results.
+        return tuple(task.result() for task in tasks)

--- a/tests/test_coconext/trigger_tests.py
+++ b/tests/test_coconext/trigger_tests.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
-import cocotb
-from cocotb.task import Task
-from cocotb.triggers import Timer
+from collections.abc import Generator
 
-from coconext.triggers import Notify
+import cocotb
+import pytest
+from cocotb.task import Task
+from cocotb.triggers import NullTrigger, Timer, Trigger
+
+from coconext.triggers import Notify, gather, select, wait
 
 
 @cocotb.test
@@ -28,7 +31,7 @@ async def test_notify(_: object) -> None:
     await Timer(1, "step")
     assert all(w.done() for w in waiters)
 
-    # start up more wiaters
+    # start up more waiters
     waiters.clear()
     for _ in range(100):
         waiters.append(cocotb.start_soon(waiter()))
@@ -36,3 +39,158 @@ async def test_notify(_: object) -> None:
     # ensure none have finished just because previous notify happened
     await Timer(1, "step")
     assert not any(w.done() for w in waiters)
+
+
+async def coro(wait: int, ret: int = 0) -> int:
+    await Timer(wait)
+    return ret
+
+
+class AwaitableThing:
+    def __init__(self, wait: int, ret: int = 0) -> None:
+        self._wait = wait
+        self._ret = ret
+
+    def __await__(self) -> Generator[Trigger, None, int]:
+        yield from coro(self._wait).__await__()
+        return self._ret
+
+
+class MyException(Exception): ...
+
+
+async def raises_after(wait: int) -> None:
+    await Timer(wait)
+    raise MyException()
+
+
+@cocotb.test
+async def test_wait(_: object) -> None:
+    a1, b1, c1, d1 = await wait(
+        coro(1),
+        Timer(2),
+        AwaitableThing(3),
+        raises_after(4),
+        return_when="ALL_COMPLETED",
+    )
+    assert a1.done()
+    assert b1.done()
+    assert c1.done()
+    assert d1.exception() is not None
+
+    a2, b2, c2 = await wait(
+        coro(1), Timer(2), AwaitableThing(3), return_when="FIRST_EXCEPTION"
+    )
+    assert a2.done()
+    assert b2.done()
+    assert c2.done()
+
+    a3, b3, c3, d3 = await wait(
+        Timer(1),
+        raises_after(2),
+        AwaitableThing(3),
+        coro(4),
+        return_when="FIRST_EXCEPTION",
+    )
+    # Wait for cancellations to finish
+    await NullTrigger()
+    assert a3.done()
+    assert b3.exception() is not None
+    assert c3.cancelled()
+    assert d3.cancelled()
+
+    a4, b4, c4, d4 = await wait(
+        coro(1),
+        Timer(2),
+        AwaitableThing(3),
+        raises_after(4),
+        return_when="FIRST_COMPLETED",
+    )
+    # Wait for cancellations to finish
+    await NullTrigger()
+    assert a4.done()
+    assert b4.cancelled()
+    assert c4.cancelled()
+    assert d4.cancelled()
+
+
+@cocotb.test
+async def test_wait_doesnt_cancel_tasks(_: object) -> None:
+    async def completes() -> int:
+        await Timer(10)
+        return 123
+
+    task = cocotb.start_soon(completes())
+    await wait(task, Timer(1), return_when="FIRST_COMPLETED")
+    await NullTrigger()
+    assert not task.cancelled()
+    assert await task == 123
+
+
+@cocotb.test
+async def test_gather(_: object) -> None:
+    timer1 = Timer(1)
+    a1, b1, c1 = await gather(
+        coro(wait=3, ret=123),
+        AwaitableThing(2, ret=9),
+        timer1,
+    )
+    assert a1 == 123
+    assert b1 == 9
+    assert c1 == timer1
+
+    with pytest.raises(MyException):
+        await gather(
+            raises_after(wait=3),
+            AwaitableThing(2, ret=9),
+            Timer(1),
+        )
+
+    timer2 = Timer(2)
+    a2, b2, c2 = await gather(
+        raises_after(wait=3),
+        AwaitableThing(1, ret=56),
+        timer2,
+        return_exceptions=True,
+    )
+    assert isinstance(a2, MyException)
+    assert b2 == 56
+    assert c2 == timer2
+
+
+@cocotb.test
+async def test_select(_: object) -> None:
+    timer1 = Timer(1)
+    idx, res1 = await select(
+        coro(wait=3, ret=123),
+        AwaitableThing(2, ret=9),
+        timer1,
+    )
+    assert idx == 2
+    assert res1 == timer1
+
+    idx, res2 = await select(
+        raises_after(wait=3),
+        AwaitableThing(1, ret=31),
+        Timer(2),
+        return_exception=True,
+    )
+    assert idx == 1
+    assert res2 == 31
+    await Timer(5)  # ensure failing task was killed
+
+    with pytest.raises(MyException):
+        await select(
+            raises_after(wait=1),
+            AwaitableThing(2, ret=9),
+            Timer(3),
+        )
+
+    idx, res3 = await select(
+        raises_after(wait=1),
+        AwaitableThing(2, ret=12),
+        Timer(3),
+        return_exception=True,
+    )
+    assert idx == 0
+    assert isinstance(res3, MyException)


### PR DESCRIPTION
These functions are inspired by asyncio and will be used as a basis to replace cocotb's `First` and `Combine`.