### PR TITLE
Add `TaskManger`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
   hooks:
   - id: mypy
     additional_dependencies:
-    - git+https://github.com/cocotb/cocotb.git@af7f0ed955bd871fc3ce1008ec3a15792b96e0de
+    - cocotb@git+https://github.com/cocotb/cocotb.git
     - pytest
     - nox
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ ignore = [
 
 [tool.ruff.lint.isort]
 required-imports = ["from __future__ import annotations"]
+known-first-party = ["coconext"]
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/src/coconext/_task_manager.py
+++ b/src/coconext/_task_manager.py
@@ -1,0 +1,180 @@
+"""TaskManager and related code."""
+
+from __future__ import annotations
+
+import sys
+from asyncio import CancelledError
+from collections.abc import Awaitable, Callable, Coroutine
+from typing import Any, TypeVar
+
+import cocotb
+from cocotb.task import Task, current_task
+from cocotb.triggers import Event, Trigger
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+
+if sys.version_info < (3, 11):
+    from exceptiongroup import BaseExceptionGroup
+
+if sys.version_info >= (3, 10):
+    from typing import ParamSpec
+
+    P = ParamSpec("P")
+
+
+T = TypeVar("T")
+
+
+async def _waiter(aw: Awaitable[T]) -> T:
+    return await aw
+
+
+class TaskManager:
+    r"""An :term:`asynchronous context manager` which enables the user to run :term:`coroutine function`\ s or :keyword:`await` :term:`awaitable`\ s concurrently and wait for them all to finish.
+
+    :term:`!awaitables` can be added to the :class:`!TaskManager` using :meth:`start_soon`.
+    Likewise, :meth:`fork` can be used to add :term:`coroutine function`\ s.
+    Both methods return the :class:`!Task` which is running the concurrent behavior.
+
+    When control reaches the end of the context block
+    the :class:`!TaskManager` blocks the :class:`!Task` using it until all children :class:`!Task`\ s of the :class:`!TaskManager` complete.
+
+    .. code-block:: python
+
+        async with TaskManager() as tm:
+
+            @tm.fork
+            async def drive(): ...
+
+            rising_edge = cocotb.start_soon(RisingEdge(dut.clk))
+
+            await drive  # wait for drive() to end
+            rising_edge.cancel()  # cancel a child Task
+
+        # Control returns here when all child Tasks have completed
+
+    """
+
+    def __init__(self) -> None:
+        self._tasks: list[Task[Any]] = []
+        self._parent_task: Task[Any]
+        self._in_exit: bool = False
+        self._cancelling: bool = False
+
+    def _done_callback(self, task: Task[Any]) -> None:
+        if not task.cancelled() and task.exception() is not None:
+            self._cancel()
+
+    def _cancel(self) -> None:
+        """Cancel all unfinished child :class:`!Tasks`."""
+        if self._cancelling:
+            return
+        self._cancelling = True
+
+        # If a child Task fails while we are in the middle of a TaskManager block,
+        # cancel the parent Task to force the block to end.
+        if not self._in_exit:
+            # We can't use `_parent_task.cancel()` because that requires the Task to
+            # fully cancel or else cause a RuntimeError, but we only want the
+            # cancellation to propagate up to the TaskManager.
+            self._parent_task._schedule_resume(CancelledError())
+
+        # Cancel all child Tasks.
+        for task in self._tasks:
+            task.cancel()
+
+    def start_soon(self, aw: Awaitable[T], *, name: str | None = None) -> Task[T]:
+        """Awaits its argument concurrently to other calls to this function.
+
+        Args:
+            aw: A :class:`~collections.abc.Awaitable` to :keyword:`await` concurrently.
+            name: A name to associate with the :class:`!Task` awaiting *aw*.
+
+        Returns:
+            A :class:`~cocotb.task.Task` which is awaiting *aw* concurrently.
+        """
+        if self._cancelling:
+            raise RuntimeError(
+                "Cannot add new Tasks to TaskManager that is cancelled"
+            ) from None
+        task = Task[Any](_waiter(aw), name=name)
+        task._add_done_callback(self._done_callback)
+        self._tasks.append(task)
+        cocotb.start_soon(task)
+        return task
+
+    def fork(
+        self,
+        coro: Callable[P, Coroutine[Trigger, None, T]],
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> Task[T]:
+        """Decorate a coroutine function to run it concurrently.
+
+        Args:
+            coro: A :term:`coroutine function` to run concurrently.
+            args: Positional args to pass to the call of *coro*.
+            kwargs: Keyword args to pass to the call of *coro*.
+
+        Returns:
+            A :class:`~cocotb.task.Task` which is running *coro* concurrently.
+
+        .. code-block:: python
+
+            async with TaskManager() as tm:
+
+                @tm.fork
+                async def my_func():
+                    # Do stuff
+                    ...
+
+                @tb.fork
+                async def other_func():
+                    # Do other stuff in parallel to my_func
+                    ...
+        """
+        return self.start_soon(coro(*args, **kwargs), name=coro.__name__)
+
+    async def __aenter__(self) -> Self:
+        self._parent_task = current_task()
+        return self
+
+    async def __aexit__(
+        self, exc_type: object, exc_value: BaseException | None, traceback: object
+    ) -> None:
+        self._in_exit = True
+        if exc_value is not None:
+            self._cancel()
+
+        remaining = {task for task in self._tasks if not task.done()}
+
+        # Wait for all Tasks to finish / finish cancelling.
+        if remaining:
+            done = Event()
+
+            def on_done(task: Task[Any]) -> None:
+                remaining.remove(task)
+                if not remaining:
+                    done.set()
+
+            for task in remaining:
+                task._add_done_callback(on_done)
+
+            try:
+                await done.wait()
+            except CancelledError:
+                self._cancel()
+                raise
+
+        # Build BaseExceptionGroup if there are any errors.
+        errors = []
+        if exc_value is not None and not isinstance(exc_value, CancelledError):
+            errors.append(exc_value)
+        errors.extend(
+            exc
+            for task in self._tasks
+            if not task.cancelled() and (exc := task.exception()) is not None
+        )
+        if errors:
+            raise BaseExceptionGroup("TaskManager finished with errors", errors)

--- a/src/coconext/triggers.py
+++ b/src/coconext/triggers.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from coconext._concurrent_waiters import gather, select, wait
 from coconext._synchronization_primitives import Notify
+from coconext._task_manager import TaskManager
 
 __all__ = (
     "Notify",
+    "TaskManager",
     "gather",
     "select",
     "wait",

--- a/tests/test_coconext/task_manager_tests.py
+++ b/tests/test_coconext/task_manager_tests.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import sys
+from asyncio import CancelledError
+from collections.abc import Generator
+
+import cocotb
+from cocotb.triggers import Timer, Trigger
+
+from coconext.triggers import TaskManager
+
+if sys.version_info < (3, 11):
+    from exceptiongroup import BaseExceptionGroup
+
+
+async def coro(wait: int, ret: int = 0) -> int:
+    await Timer(wait)
+    return ret
+
+
+class AwaitableThing:
+    def __init__(self, wait: int, ret: int = 0) -> None:
+        self._wait = wait
+        self._ret = ret
+
+    def __await__(self) -> Generator[Trigger, None, int]:
+        yield from coro(self._wait).__await__()
+        return self._ret
+
+
+class MyException(Exception): ...
+
+
+async def raises_after(wait: int) -> None:
+    await Timer(wait)
+    raise MyException()
+
+
+@cocotb.test
+async def test_TaskManager_basic(_: object) -> None:
+    timer = Timer(2)
+
+    async with TaskManager() as tm:
+        task1 = tm.start_soon(timer)
+        task2 = tm.start_soon(AwaitableThing(3, ret=123))
+        task3 = tm.start_soon(coro(4, ret=456))
+
+        @tm.fork
+        async def task4() -> int:
+            await Timer(5)
+            return 789
+
+    assert task1.done()
+    assert task1.result() == timer
+    assert task2.done()
+    assert task2.result() == 123
+    assert task3.done()
+    assert task3.result() == 456
+    assert task4.done()
+    assert task4.result() == 789
+
+
+@cocotb.test
+async def test_TaskManager_failure_in_block(_: object) -> None:
+    try:
+        async with TaskManager() as tm:
+
+            @tm.fork
+            async def stuff() -> int:
+                await Timer(5)
+                return 789
+
+            raise MyException()
+
+    except BaseExceptionGroup as e:
+        my_exc, rest = e.split(MyException)
+        assert rest is None
+        assert my_exc is not None
+        assert len(my_exc.exceptions) == 1
+
+    assert stuff.cancelled()
+
+
+@cocotb.test
+async def test_TaskManager_child_failure_in_block(_: object) -> None:
+    try:
+        async with TaskManager() as tm:
+            tm.start_soon(raises_after(1))
+
+            @tm.fork
+            async def stuff() -> int:
+                await Timer(5)
+                return 789
+
+            try:
+                await Timer(5)
+            except CancelledError:
+                raise
+            else:
+                assert False, "Didn't see CancelledError"
+
+    except BaseExceptionGroup as e:
+        my_exc, rest = e.split(MyException)
+        assert rest is None
+        assert my_exc is not None
+        assert len(my_exc.exceptions) == 1
+
+    assert stuff.cancelled()
+
+
+@cocotb.test
+async def test_TaskManager_child_failure_in_exit(_: object) -> None:
+    try:
+        async with TaskManager() as tm:
+            tm.start_soon(raises_after(2))
+
+            @tm.fork
+            async def stuff() -> int:
+                await Timer(5)
+                return 789
+
+    except BaseExceptionGroup as e:
+        my_exc, rest = e.split(MyException)
+        assert rest is None
+        assert my_exc is not None
+        assert len(my_exc.exceptions) == 1
+
+    assert stuff.cancelled()
+
+
+@cocotb.test
+async def test_TaskManager_start_soon_after_cancel(_: object) -> None:
+    try:
+        async with TaskManager() as tm:
+            task = tm.start_soon(raises_after(1))
+
+            try:
+                await task
+            finally:
+                tm.start_soon(coro(2))
+
+    except BaseExceptionGroup as e:
+        runtime_error, rest = e.split(RuntimeError)
+        assert runtime_error is not None
+        assert len(runtime_error.exceptions) == 1
+        assert rest is not None
+        my_exc, rest = rest.split(MyException)
+        assert my_exc is not None
+        assert len(my_exc.exceptions) == 1
+        assert rest is None

--- a/tests/test_coconext/test_coconext.py
+++ b/tests/test_coconext/test_coconext.py
@@ -37,3 +37,11 @@ def test_queues(runner: Runner) -> None:
         hdl_toplevel="top",
         test_dir=runner.build_dir / "queue_tests",
     )
+
+
+def test_task_manager(runner: Runner) -> None:
+    runner.test(
+        test_module="task_manager_tests",
+        hdl_toplevel="top",
+        test_dir=runner.build_dir / "task_manager_tests",
+    )


### PR DESCRIPTION
Blocked by https://github.com/cocotb/cocotb/pull/4790. Inspired by trio's nurseries, asyncio's TaskGroup and similar things done behind closed doors at previous employers. This provides structured asymmetric concurrency to cocotb.