### PR TITLE
Remove coverage exclusions as they are now default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,15 +63,6 @@ warn_unused_ignores = true
 implicit_reexport = false
 show_error_codes = true
 
-[tool.coverage.report]
-exclude_lines = [
-    "pragma: no cover",
-    # for excluding typing stubs
-    "\\.\\.\\.",
-    # excluding type checking blocks
-    "if (typing\\.)?TYPE_CHECKING:"
-]
-
 [dependency-groups]
 dev = [
     "mypy>=1.16.1",


### PR DESCRIPTION
This was causing the entirety of `wait`, `gather`, and `select` to be excluded due to bad regex. But all rules are now included by default in coverage>=7.1.0.