### PR TITLE
Re-enable Python 3.8

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         simulator: [nvc]
         os: [ubuntu-24.04]
         nvc-version: ["1.16.2"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
   hooks:
   - id: mypy
     additional_dependencies:
-    - cocotb@git+https://github.com/cocotb/cocotb.git
+    - cocotb>=2.0b
     - pytest
     - nox
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
       - asdf plugin add uv
       - asdf install uv latest
       - asdf global uv latest
-      - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync --all-extras --group docs
+      - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync --all-extras --group docs --prerelease=allow
     install:
       - "true"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "coconext"
 dependencies = [
-    "cocotb@git+https://github.com/cocotb/cocotb.git",
+    "cocotb~=2.0b",
     'exceptiongroup; python_version < "3.11"',
 ]
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "cocotb~=2.0b",
     'exceptiongroup; python_version < "3.11"',
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 authors = [
     {name="Kaleb Barrett", email="dev.ktbarrett@gmail.com"},
 ]
@@ -17,11 +17,7 @@ maintainers = [
 ]
 description = "Features for future versions of cocotb"
 readme = "README.md"
-license = "BSD-3-Clause"
-license-files = [
-    "LICENSE",
-]
-dynamic = ["version"]
+dynamic = ["version", "license"]
 
 [project.urls]
 Repository = "https://github.com/ktbarrett/coconext.git"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,21 +65,21 @@ show_error_codes = true
 
 [dependency-groups]
 dev = [
-    "mypy>=1.16.1",
-    "nox[uv]>=2025.5.1",
-    "pre-commit>=4.2.0",
-    "pytest>=8.4.1",
-    "pytest-cov>=6.2.1",
-    "ruff>=0.12.1",
+    "mypy",
+    "nox[uv]",
+    "pre-commit",
+    "pytest",
+    "pytest-cov",
+    "ruff",
 ]
 docs = [
-    "sphinx>=7.4.7",
-    "sphinx-rtd-theme>=3.0.2",
-    "sphinxcontrib-prettyspecialmethods@https://github.com/sphinx-contrib/prettyspecialmethods.git",
+    "sphinx>=8.2 ; python_version >= '3.11'",  # Require 8.2+ for :deco: directive
+    "sphinx-rtd-theme ; python_version >= '3.11'",
+    "sphinxcontrib-prettyspecialmethods @ https://github.com/sphinx-contrib/prettyspecialmethods.git ; python_version >= '3.11'",
 ]
 tests = [
-    "coverage[toml]>=7.9.1",
-    "pytest>=8.4.1",
+    "coverage[toml]>=7.2",  # Require 7.2+ for builtin coverage excludes and "exclude_also"
+    "pytest",
 ]
 
 [tool.coverage.report]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[metadata]
+license = BSD-3-Clause
+license_files =
+    LICENSE

--- a/src/coconext/queue.py
+++ b/src/coconext/queue.py
@@ -51,7 +51,7 @@ class AbstractQueue(Generic[T]):
 
         def __init__(self) -> None:
             self._current_acquirer: Task[object] | None = None
-            self._acquirers = deque[tuple[Event, Task]]()
+            self._acquirers: deque[tuple[Event, Task]] = deque()
 
         def locked(self) -> bool:
             """Return ``True`` if the lock is *locked*."""
@@ -272,7 +272,7 @@ class Queue(AbstractQueue[T]):
 
     def __init__(self, maxsize: int = 0) -> None:
         super().__init__(maxsize)
-        self._queue = deque[T]()
+        self._queue: deque[T] = deque()
 
     def _put(self, item: T) -> None:
         self._queue.append(item)
@@ -320,7 +320,7 @@ class LifoQueue(AbstractQueue[T]):
 
     def __init__(self, maxsize: int = 0) -> None:
         super().__init__(maxsize)
-        self._queue = deque[T]()
+        self._queue: deque[T] = deque()
 
     def _put(self, item: T) -> None:
         self._queue.append(item)

--- a/tests/test_coconext/queue_tests.py
+++ b/tests/test_coconext/queue_tests.py
@@ -54,7 +54,7 @@ async def test_queue_basic(_: object, queue_type: type[AbstractQueue[int]]) -> N
         q.put_nowait(3)
 
     # Save outputs in unordered collection since each queue type has different behavior.
-    outputs = set[int]()
+    outputs: set[int] = set()
 
     outputs.add(q.get_nowait())
     assert q.qsize() == 1
@@ -89,7 +89,7 @@ async def test_queue_async(_: object, queue_type: type[AbstractQueue[int]]) -> N
     with pytest.raises(SimTimeoutError):
         await with_timeout(q.put(3), 1, "step")
 
-    outputs = set[int]()
+    outputs: set[int] = set()
     outputs.add(await q.get())
     outputs.add(await q.get())
     with pytest.raises(SimTimeoutError):
@@ -190,7 +190,7 @@ async def test_queue_lock_multi_op(
         for i in range(10):
             q.put_nowait(i)
 
-    outputs = set[int]()
+    outputs: set[int] = set()
     async with q.read_lock:
         for _ in range(10):
             outputs.add(q.get_nowait())
@@ -259,7 +259,7 @@ async def test_queue_random_contention(
     class Checker:
         def __init__(self) -> None:
             self._last_seen = [0, 0]
-            self._cancelleds = (set[int](), set[int]())
+            self._cancelleds: tuple[set[int], set[int]] = (set(), set())
             self._tasks: list[Task[Any]] = []
             self._task_info: dict[Task[Any], tuple[bool, int]] = {}
             self._task_info_reversed: dict[tuple[bool, int], Task[Any]] = {}


### PR DESCRIPTION
Also uses cocotb beta release in dependencies. Closes #4.

cocotb 2.1+ will be Python 3.8+ and this is 3.9+. Try to bridge that gap.