### PR TITLE
Don't use TYPE_CHECKING in sources

### DIFF
--- a/src/coconext/_concurrent_waiters.py
+++ b/src/coconext/_concurrent_waiters.py
@@ -2,14 +2,12 @@ from __future__ import annotations
 
 import sys
 from asyncio import CancelledError
-from typing import TYPE_CHECKING, Any, Literal, TypeVar, overload
+from collections.abc import Awaitable
+from typing import Any, Literal, TypeVar, overload
 
 import cocotb
 from cocotb.task import Task
 from cocotb.triggers import Event
-
-if TYPE_CHECKING:
-    from collections.abc import Awaitable
 
 if sys.version_info >= (3, 10):
     from typing import TypeAlias

--- a/src/coconext/_task_manager.py
+++ b/src/coconext/_task_manager.py
@@ -4,14 +4,12 @@ from __future__ import annotations
 
 import sys
 from asyncio import CancelledError
-from typing import TYPE_CHECKING, Any, TypeVar
+from collections.abc import Awaitable, Coroutine
+from typing import Any, Callable, TypeVar
 
 import cocotb
 from cocotb.task import Task, current_task
 from cocotb.triggers import Event, Trigger
-
-if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable, Coroutine
 
 if sys.version_info >= (3, 11):
     from typing import Self

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -10,6 +10,11 @@ ignore = [
     "D107",  # missing docstring in __init__ (preference)
     "D203",  # missing blank line before docstring (incompatible with D211)
     "D213",  # missing newline before first line of docstring (incompatible with D212)
+    # We don't want to use TYPE_CHECKING blocks so autodoc can resolve symbols
+    # since it doesn't set TYPE_CHECKING.
+    "TC001", # typing-only first-party import
+    "TC002", # typing-only third-party import
+    "TC003", # typing-only standard library import
 ]
 
 [tool.ruff.lint.pydocstyle]


### PR DESCRIPTION
Using TYPE_CHECKING prevents autodoc from resolving symbols since it doesn't set TYPE_CHECKING to True.