### PR TITLE
Several Improvements to Logic, Bit, Range, Direction

### DIFF
--- a/bind/types/bind_logic.cpp
+++ b/bind/types/bind_logic.cpp
@@ -16,9 +16,9 @@ static Logic to_logic(const nb::int_& value) {
     static nb::int_ zero = nb::int_(0);
     static nb::int_ one = nb::int_(1);
     if (value.equal(zero)) {
-        return '0'_l;
+        return Logic::_0;
     } else if (value.equal(one)) {
-        return '1'_l;
+        return Logic::_1;
     } else {
         throw std::invalid_argument("Invalid logic string");
     }
@@ -28,9 +28,9 @@ static Bit to_bit(const nb::int_& value) {
     static nb::int_ zero = nb::int_(0);
     static nb::int_ one = nb::int_(1);
     if (value.equal(zero)) {
-        return '0'_b;
+        return Logic::_0;
     } else if (value.equal(one)) {
-        return '1'_b;
+        return Logic::_1;
     } else {
         throw std::invalid_argument("Invalid bit string");
     }

--- a/cpp/include/coconext/types/direction.hpp
+++ b/cpp/include/coconext/types/direction.hpp
@@ -22,6 +22,10 @@ public:
             throw std::invalid_argument("Invalid direction value");
         }
     }
+    template <typename T>
+        requires requires { to_direction(std::declval<T>()); }
+    explicit constexpr Direction(T&& value)
+        : value_(to_direction(std::forward<T>(value)).value()) {}
     constexpr value_type value() const noexcept { return value_; }
 
 private:

--- a/cpp/include/coconext/types/direction.hpp
+++ b/cpp/include/coconext/types/direction.hpp
@@ -69,4 +69,18 @@ constexpr Direction operator""_dir(const char* str, size_t len) {
 
 }  // namespace coconext::types
 
+namespace std {
+
+template <>
+class hash<coconext::types::Direction> {
+public:
+    size_t operator()(
+        const coconext::types::Direction& direction) const noexcept {
+        return std::hash<coconext::types::Direction::value_type>()(
+            direction.value());
+    }
+};
+
+}  // namespace std
+
 #endif  // COCONEXT_DIRECTION_HPP

--- a/cpp/include/coconext/types/direction.hpp
+++ b/cpp/include/coconext/types/direction.hpp
@@ -10,33 +10,31 @@ namespace coconext::types {
 
 class Direction {
 public:
-    enum value_type : uint8_t {
+    enum class value_type : uint8_t {
         TO,
         DOWNTO,
     };
+    using enum value_type;
 
 public:
-    constexpr Direction() noexcept : value_(TO) {}
-    constexpr Direction(value_type value) : value_(value) {
-        if (value != TO && value != DOWNTO) {
-            throw std::invalid_argument("Invalid direction value");
-        }
-    }
+    // ensures that these are constexpr since enum classes are not literal types
+    constexpr Direction() noexcept = default;
+    constexpr Direction(const Direction&) noexcept = default;
+    constexpr Direction& operator=(const Direction&) noexcept = default;
+    constexpr Direction(Direction&&) noexcept = default;
+    constexpr Direction& operator=(Direction&&) noexcept = default;
+
+    constexpr Direction(value_type value) noexcept : value_(value) {}
     template <typename T>
         requires requires { to_direction(std::declval<T>()); }
     explicit constexpr Direction(T&& value)
         : value_(to_direction(std::forward<T>(value)).value()) {}
+
+public:
     constexpr value_type value() const noexcept { return value_; }
 
 private:
-    static struct no_check_tag_t {
-    } no_check_tag;
-    constexpr Direction(value_type value, no_check_tag_t) : value_(value) {}
-    friend constexpr Direction to_direction(std::string_view value);
-    friend constexpr Direction operator""_dir(const char* str, size_t len);
-
-private:
-    value_type value_;
+    value_type value_ = TO;
 };
 
 constexpr bool operator==(const Direction& lhs, const Direction& rhs) noexcept {
@@ -55,16 +53,12 @@ constexpr Direction to_direction(std::string_view value) {
     std::string str(value);
     std::transform(str.begin(), str.end(), str.begin(), ::tolower);
     if (str == "to") {
-        return Direction(Direction::TO, Direction::no_check_tag);
+        return Direction::TO;
     } else if (str == "downto") {
-        return Direction(Direction::DOWNTO, Direction::no_check_tag);
+        return Direction::DOWNTO;
     } else {
         throw std::invalid_argument("Invalid direction string");
     }
-}
-
-constexpr Direction operator""_dir(const char* str, size_t len) {
-    return to_direction(std::string_view(str, len));
 }
 
 }  // namespace coconext::types

--- a/cpp/include/coconext/types/logic.hpp
+++ b/cpp/include/coconext/types/logic.hpp
@@ -25,6 +25,10 @@ public:
 public:
     constexpr Logic() noexcept : value_(U) {}
     constexpr Logic(value_type value) noexcept : value_(value) {}
+    template <typename T>
+        requires requires { to_logic(std::declval<T>()); }
+    explicit constexpr Logic(T&& value)
+        : value_(to_logic(std::forward<T>(value)).value()) {}
 
 public:
     constexpr value_type value() const noexcept { return value_; }
@@ -36,7 +40,10 @@ private:
 class Bit : public Logic {
 public:
     constexpr Bit() noexcept : Logic(_0) {}
-    using Logic::Logic;
+    constexpr Bit(value_type value) noexcept : Logic(value) {}
+    template <typename T>
+        requires requires { to_bit(std::declval<T>()); }
+    explicit constexpr Bit(T&& value) : Logic(to_bit(std::forward<T>(value))) {}
 };
 
 constexpr bool operator==(const Logic& lhs, const Logic& rhs) noexcept {

--- a/cpp/include/coconext/types/logic.hpp
+++ b/cpp/include/coconext/types/logic.hpp
@@ -10,7 +10,7 @@ namespace coconext::types {
 
 class Logic {
 public:
-    enum value_type : uint8_t {
+    enum class value_type : uint8_t {
         U,
         X,
         _0,
@@ -21,9 +21,16 @@ public:
         H,
         DC,
     };
+    using enum value_type;
 
 public:
-    constexpr Logic() noexcept : value_(U) {}
+    // ensures that these are constexpr since enum classes are not literal types
+    constexpr Logic() noexcept = default;
+    constexpr Logic(const Logic&) noexcept = default;
+    constexpr Logic& operator=(const Logic&) noexcept = default;
+    constexpr Logic(Logic&&) noexcept = default;
+    constexpr Logic& operator=(Logic&&) noexcept = default;
+
     constexpr Logic(value_type value) noexcept : value_(value) {}
     template <typename T>
         requires requires { to_logic(std::declval<T>()); }
@@ -34,11 +41,17 @@ public:
     constexpr value_type value() const noexcept { return value_; }
 
 private:
-    value_type value_;
+    value_type value_ = U;
 };
 
 class Bit : public Logic {
 public:
+    // ensures that these are constexpr since enum classes are not literal types
+    constexpr Bit(const Bit&) noexcept = default;
+    constexpr Bit& operator=(const Bit&) noexcept = default;
+    constexpr Bit(Bit&&) noexcept = default;
+    constexpr Bit& operator=(Bit&&) noexcept = default;
+
     constexpr Bit() noexcept : Logic(_0) {}
     constexpr Bit(value_type value) noexcept : Logic(value) {}
     template <typename T>
@@ -50,51 +63,16 @@ constexpr bool operator==(const Logic& lhs, const Logic& rhs) noexcept {
     return lhs.value() == rhs.value();
 }
 
-constexpr Logic operator""_l(char c) {
-    switch (c) {
-    case 'U':
-        return Logic::U;
-    case 'X':
-        return Logic::X;
-    case '0':
-        return Logic::_0;
-    case '1':
-        return Logic::_1;
-    case 'Z':
-        return Logic::Z;
-    case 'W':
-        return Logic::W;
-    case 'L':
-        return Logic::L;
-    case 'H':
-        return Logic::H;
-    case '-':
-        return Logic::DC;
-    default:
-        throw std::invalid_argument("Invalid logic value");
-    }
-}
-
-constexpr Bit operator""_b(char c) {
-    switch (c) {
-    case '0':
-        return Logic::_0;
-    case '1':
-        return Logic::_1;
-    default:
-        throw std::invalid_argument("Invalid bit value");
-    }
-}
-
 template <Character CharType>
 constexpr Logic to_logic(CharType value) {
+    using enum Logic::value_type;
     constexpr struct {
         CharType chr;
         Logic val;
     } chr_map[] = {
-        {'U', 'U'_l}, {'u', 'U'_l}, {'X', 'X'_l}, {'x', 'X'_l}, {'0', '0'_l},
-        {'1', '1'_l}, {'Z', 'Z'_l}, {'z', 'Z'_l}, {'W', 'W'_l}, {'w', 'W'_l},
-        {'L', 'L'_l}, {'l', 'L'_l}, {'H', 'H'_l}, {'h', 'H'_l}, {'-', '-'_l},
+        {'U', U},  {'u', U}, {'X', X}, {'x', X}, {'0', _0},
+        {'1', _1}, {'Z', Z}, {'z', Z}, {'W', W}, {'w', W},
+        {'L', L},  {'l', L}, {'H', H}, {'h', H}, {'-', DC},
     };
     for (const auto& [chr, val] : chr_map) {
         if (value == chr) {
@@ -114,9 +92,9 @@ constexpr Logic to_logic(std::string_view value) {
 template <Integer IntType>
 constexpr Logic to_logic(IntType value) {
     if (value == 0) {
-        return '0'_l;
+        return Logic::_0;
     } else if (value == 1) {
-        return '1'_l;
+        return Logic::_1;
     } else {
         throw std::invalid_argument("Invalid logic value");
     }
@@ -127,9 +105,9 @@ constexpr Logic to_logic(const Bit& value) { return value; }
 template <Character CharType>
 constexpr Bit to_bit(CharType value) {
     if (value == '0') {
-        return '0'_b;
+        return Logic::_0;
     } else if (value == '1') {
-        return '1'_b;
+        return Logic::_1;
     } else {
         throw std::invalid_argument("Invalid bit value");
     }
@@ -145,16 +123,16 @@ constexpr Bit to_bit(std::string_view value) {
 template <Integer IntType>
 constexpr Bit to_bit(IntType value) {
     if (value == 0) {
-        return '0'_b;
+        return Logic::_0;
     } else if (value == 1) {
-        return '1'_b;
+        return Logic::_1;
     } else {
         throw std::invalid_argument("Invalid bit value");
     }
 }
 
 constexpr Bit to_bit(const Logic& value) {
-    if (value == '0'_l || value == '1'_l) {
+    if (value == Logic::_0 || value == Logic::_1) {
         return Bit(value.value());
     } else {
         throw std::invalid_argument("Invalid bit value");
@@ -183,19 +161,20 @@ constexpr long long to_int(const Logic& value) {
 }
 
 constexpr Logic operator|(const Logic& lhs, const Logic& rhs) noexcept {
+    using enum Logic::value_type;
     constexpr Logic const table[9][9] = {
         // ---------------------
         //  U X 0 1 Z W L H -
         // ---------------------
-        /* U */ {'U'_l, 'U'_l, 'U'_l, '1'_l, 'U'_l, 'U'_l, 'U'_l, '1'_l, 'U'_l},
-        /* X */ {'U'_l, 'X'_l, 'X'_l, '1'_l, 'X'_l, 'X'_l, 'X'_l, '1'_l, 'X'_l},
-        /* 0 */ {'U'_l, 'X'_l, '0'_l, '1'_l, 'X'_l, 'X'_l, '0'_l, '1'_l, 'X'_l},
-        /* 1 */ {'1'_l, '1'_l, '1'_l, '1'_l, '1'_l, '1'_l, '1'_l, '1'_l, '1'_l},
-        /* Z */ {'U'_l, 'X'_l, 'X'_l, '1'_l, 'X'_l, 'X'_l, 'X'_l, '1'_l, 'X'_l},
-        /* W */ {'U'_l, 'X'_l, 'X'_l, '1'_l, 'X'_l, 'X'_l, 'X'_l, '1'_l, 'X'_l},
-        /* L */ {'U'_l, 'X'_l, '0'_l, '1'_l, 'X'_l, 'X'_l, '0'_l, '1'_l, 'X'_l},
-        /* H */ {'1'_l, '1'_l, '1'_l, '1'_l, '1'_l, '1'_l, '1'_l, '1'_l, '1'_l},
-        /* - */ {'U'_l, 'X'_l, 'X'_l, '1'_l, 'X'_l, 'X'_l, 'X'_l, '1'_l, 'X'_l},
+        /* U */ {U, U, U, _1, U, U, U, _1, U},
+        /* X */ {U, X, X, _1, X, X, X, _1, X},
+        /* 0 */ {U, X, _0, _1, X, X, _0, _1, X},
+        /* 1 */ {_1, _1, _1, _1, _1, _1, _1, _1, _1},
+        /* Z */ {U, X, X, _1, X, X, X, _1, X},
+        /* W */ {U, X, X, _1, X, X, X, _1, X},
+        /* L */ {U, X, _0, _1, X, X, _0, _1, X},
+        /* H */ {_1, _1, _1, _1, _1, _1, _1, _1, _1},
+        /* - */ {U, X, X, _1, X, X, X, _1, X},
     };
     return table[static_cast<size_t>(lhs.value())]
                 [static_cast<size_t>(rhs.value())];
@@ -206,19 +185,20 @@ constexpr Bit operator|(const Bit& lhs, const Bit& rhs) noexcept {
 }
 
 constexpr Logic operator&(const Logic& lhs, const Logic& rhs) noexcept {
+    using enum Logic::value_type;
     constexpr Logic const table[9][9] = {
         // ---------------------
         //  U X 0 1 Z W L H -
         // ---------------------
-        /* U */ {'U'_l, 'U'_l, '0'_l, 'U'_l, 'U'_l, 'U'_l, '0'_l, 'U'_l, 'U'_l},
-        /* X */ {'U'_l, 'X'_l, '0'_l, 'X'_l, 'X'_l, 'X'_l, '0'_l, 'X'_l, 'X'_l},
-        /* 0 */ {'0'_l, '0'_l, '0'_l, '0'_l, '0'_l, '0'_l, '0'_l, '0'_l, '0'_l},
-        /* 1 */ {'U'_l, 'X'_l, '0'_l, '1'_l, 'X'_l, 'X'_l, '0'_l, '1'_l, 'X'_l},
-        /* Z */ {'U'_l, 'X'_l, '0'_l, 'X'_l, 'X'_l, 'X'_l, '0'_l, 'X'_l, 'X'_l},
-        /* W */ {'U'_l, 'X'_l, '0'_l, 'X'_l, 'X'_l, 'X'_l, '0'_l, 'X'_l, 'X'_l},
-        /* L */ {'0'_l, '0'_l, '0'_l, '0'_l, '0'_l, '0'_l, '0'_l, '0'_l, '0'_l},
-        /* H */ {'U'_l, 'X'_l, '0'_l, '1'_l, 'X'_l, 'X'_l, '0'_l, '1'_l, 'X'_l},
-        /* - */ {'U'_l, 'X'_l, '0'_l, 'X'_l, 'X'_l, 'X'_l, '0'_l, 'X'_l, 'X'_l},
+        /* U */ {U, U, _0, U, U, U, _0, U, U},
+        /* X */ {U, X, _0, X, X, X, _0, X, X},
+        /* 0 */ {_0, _0, _0, _0, _0, _0, _0, _0, _0},
+        /* 1 */ {U, X, _0, _1, X, X, _0, _1, X},
+        /* Z */ {U, X, _0, X, X, X, _0, X, X},
+        /* W */ {U, X, _0, X, X, X, _0, X, X},
+        /* L */ {_0, _0, _0, _0, _0, _0, _0, _0, _0},
+        /* H */ {U, X, _0, _1, X, X, _0, _1, X},
+        /* - */ {U, X, _0, X, X, X, _0, X, X},
     };
     return table[static_cast<size_t>(lhs.value())]
                 [static_cast<size_t>(rhs.value())];
@@ -229,19 +209,20 @@ constexpr Bit operator&(const Bit& lhs, const Bit& rhs) noexcept {
 }
 
 constexpr Logic operator^(const Logic& lhs, const Logic& rhs) noexcept {
+    using enum Logic::value_type;
     constexpr Logic const table[9][9] = {
         // ---------------------
         //  U X 0 1 Z W L H -
         // ---------------------
-        /* U */ {'U'_l, 'U'_l, 'U'_l, 'U'_l, 'U'_l, 'U'_l, 'U'_l, 'U'_l, 'U'_l},
-        /* X */ {'U'_l, 'X'_l, 'X'_l, 'X'_l, 'X'_l, 'X'_l, 'X'_l, 'X'_l, 'X'_l},
-        /* 0 */ {'U'_l, 'X'_l, '0'_l, '1'_l, 'X'_l, 'X'_l, '0'_l, '1'_l, 'X'_l},
-        /* 1 */ {'U'_l, 'X'_l, '1'_l, '0'_l, 'X'_l, 'X'_l, '1'_l, '0'_l, 'X'_l},
-        /* Z */ {'U'_l, 'X'_l, 'X'_l, 'X'_l, 'X'_l, 'X'_l, 'X'_l, 'X'_l, 'X'_l},
-        /* W */ {'U'_l, 'X'_l, 'X'_l, 'X'_l, 'X'_l, 'X'_l, 'X'_l, 'X'_l, 'X'_l},
-        /* L */ {'U'_l, 'X'_l, '0'_l, '1'_l, 'X'_l, 'X'_l, '0'_l, '1'_l, 'X'_l},
-        /* H */ {'U'_l, 'X'_l, '1'_l, '0'_l, 'X'_l, 'X'_l, '1'_l, '0'_l, 'X'_l},
-        /* - */ {'U'_l, 'X'_l, 'X'_l, 'X'_l, 'X'_l, 'X'_l, 'X'_l, 'X'_l, 'X'_l},
+        /* U */ {U, U, U, U, U, U, U, U, U},
+        /* X */ {U, X, X, X, X, X, X, X, X},
+        /* 0 */ {U, X, _0, _1, X, X, _0, _1, X},
+        /* 1 */ {U, X, _1, _0, X, X, _1, _0, X},
+        /* Z */ {U, X, X, X, X, X, X, X, X},
+        /* W */ {U, X, X, X, X, X, X, X, X},
+        /* L */ {U, X, _0, _1, X, X, _0, _1, X},
+        /* H */ {U, X, _1, _0, X, X, _1, _0, X},
+        /* - */ {U, X, X, X, X, X, X, X, X},
     };
     return table[static_cast<size_t>(lhs.value())]
                 [static_cast<size_t>(rhs.value())];
@@ -252,11 +233,12 @@ constexpr Bit operator^(const Bit& lhs, const Bit& rhs) noexcept {
 }
 
 constexpr Logic operator~(const Logic& value) noexcept {
+    using enum Logic::value_type;
     constexpr Logic const table[9] = {
         // ----------------
         //  U  X  0  1  Z  W  L  H  -
         // ----------------
-        'U'_l, 'X'_l, '1'_l, '0'_l, 'X'_l, 'X'_l, '1'_l, '0'_l, 'X'_l,
+        U, X, _1, _0, X, X, _1, _0, X,
     };
     return table[static_cast<size_t>(value.value())];
 }
@@ -266,7 +248,8 @@ constexpr Bit operator~(const Bit& value) noexcept {
 }
 
 constexpr bool is_01(const Logic& value) noexcept {
-    return value == '0'_l || value == '1'_l || value == 'L'_l || value == 'H'_l;
+    return value == Logic::_0 || value == Logic::_1 || value == Logic::L ||
+           value == Logic::H;
 }
 
 enum class ResolveMethod {

--- a/cpp/include/coconext/types/logic.hpp
+++ b/cpp/include/coconext/types/logic.hpp
@@ -11,11 +11,11 @@ namespace coconext::types {
 class Logic {
 public:
     enum class value_type : uint8_t {
-        U,
-        X,
         _0,
         _1,
+        X,
         Z,
+        U,
         W,
         L,
         H,
@@ -41,7 +41,7 @@ public:
     constexpr value_type value() const noexcept { return value_; }
 
 private:
-    value_type value_ = U;
+    value_type value_ = _0;
 };
 
 class Bit : public Logic {
@@ -141,7 +141,7 @@ constexpr Bit to_bit(const Logic& value) {
 
 constexpr std::string_view to_string(const Logic& value) noexcept {
     constexpr char const* const str_map[] = {
-        "U", "X", "0", "1", "Z", "W", "L", "H", "-",
+        "0", "1", "X", "Z", "U", "W", "L", "H", "-",
     };
     return str_map[static_cast<size_t>(value.value())];
 }
@@ -163,88 +163,95 @@ constexpr long long to_int(const Logic& value) {
 constexpr Logic operator|(const Logic& lhs, const Logic& rhs) noexcept {
     using enum Logic::value_type;
     constexpr Logic const table[9][9] = {
-        // ---------------------
-        //  U X 0 1 Z W L H -
-        // ---------------------
-        /* U */ {U, U, U, _1, U, U, U, _1, U},
-        /* X */ {U, X, X, _1, X, X, X, _1, X},
-        /* 0 */ {U, X, _0, _1, X, X, _0, _1, X},
+        // clang-format off
+        // ------------------------------------------
+        // ---|   0   1   X   Z   U   W   L   H   -
+        // ------------------------------------------
+        /* 0 */ {_0, _1,  X,  X,  U,  X, _0, _1,  X},
         /* 1 */ {_1, _1, _1, _1, _1, _1, _1, _1, _1},
-        /* Z */ {U, X, X, _1, X, X, X, _1, X},
-        /* W */ {U, X, X, _1, X, X, X, _1, X},
-        /* L */ {U, X, _0, _1, X, X, _0, _1, X},
+        /* X */ { X, _1,  X,  X,  U,  X,  X, _1,  X},
+        /* Z */ { X, _1,  X,  X,  U,  X,  X, _1,  X},
+        /* U */ { U, _1,  U,  U,  U,  U,  U, _1,  U},
+        /* W */ { X, _1,  X,  X,  U,  X,  X, _1,  X},
+        /* L */ {_0, _1,  X,  X,  U,  X, _0, _1,  X},
         /* H */ {_1, _1, _1, _1, _1, _1, _1, _1, _1},
-        /* - */ {U, X, X, _1, X, X, X, _1, X},
+        /* - */ { X, _1,  X,  X,  U,  X,  X, _1,  X},
+        // clang-format on
     };
     return table[static_cast<size_t>(lhs.value())]
                 [static_cast<size_t>(rhs.value())];
 }
 
 constexpr Bit operator|(const Bit& lhs, const Bit& rhs) noexcept {
-    return to_bit(Logic(lhs) | Logic(rhs));
+    return Bit::value_type(int(lhs.value()) | int(rhs.value()));
 }
 
 constexpr Logic operator&(const Logic& lhs, const Logic& rhs) noexcept {
     using enum Logic::value_type;
     constexpr Logic const table[9][9] = {
-        // ---------------------
-        //  U X 0 1 Z W L H -
-        // ---------------------
-        /* U */ {U, U, _0, U, U, U, _0, U, U},
-        /* X */ {U, X, _0, X, X, X, _0, X, X},
+        // clang-format off
+        // ------------------------------------------
+        // ---|   0   1   X   Z   U   W   L   H   -
+        // ------------------------------------------
         /* 0 */ {_0, _0, _0, _0, _0, _0, _0, _0, _0},
-        /* 1 */ {U, X, _0, _1, X, X, _0, _1, X},
-        /* Z */ {U, X, _0, X, X, X, _0, X, X},
-        /* W */ {U, X, _0, X, X, X, _0, X, X},
+        /* 1 */ {_0, _1,  X,  X,  U,  X, _0, _1,  X},
+        /* X */ {_0,  X,  X,  X,  U,  X, _0,  X,  X},
+        /* Z */ {_0,  X,  X,  X,  U,  X, _0,  X,  X},
+        /* U */ {_0,  U,  U,  U,  U,  U, _0,  U,  U},
+        /* W */ {_0,  X,  X,  X,  U,  X, _0,  X,  X},
         /* L */ {_0, _0, _0, _0, _0, _0, _0, _0, _0},
-        /* H */ {U, X, _0, _1, X, X, _0, _1, X},
-        /* - */ {U, X, _0, X, X, X, _0, X, X},
+        /* H */ {_0, _1,  X,  X,  U,  X, _0, _1,  X},
+        /* - */ {_0,  X,  X,  X,  U,  X, _0,  X,  X},
+        // clang-format on
     };
     return table[static_cast<size_t>(lhs.value())]
                 [static_cast<size_t>(rhs.value())];
 }
 
 constexpr Bit operator&(const Bit& lhs, const Bit& rhs) noexcept {
-    return to_bit(Logic(lhs) & Logic(rhs));
+    return Bit::value_type(int(lhs.value()) & int(rhs.value()));
 }
 
 constexpr Logic operator^(const Logic& lhs, const Logic& rhs) noexcept {
     using enum Logic::value_type;
     constexpr Logic const table[9][9] = {
-        // ---------------------
-        //  U X 0 1 Z W L H -
-        // ---------------------
-        /* U */ {U, U, U, U, U, U, U, U, U},
-        /* X */ {U, X, X, X, X, X, X, X, X},
-        /* 0 */ {U, X, _0, _1, X, X, _0, _1, X},
-        /* 1 */ {U, X, _1, _0, X, X, _1, _0, X},
-        /* Z */ {U, X, X, X, X, X, X, X, X},
-        /* W */ {U, X, X, X, X, X, X, X, X},
-        /* L */ {U, X, _0, _1, X, X, _0, _1, X},
-        /* H */ {U, X, _1, _0, X, X, _1, _0, X},
-        /* - */ {U, X, X, X, X, X, X, X, X},
+        // clang-format off
+        // ------------------------------------------
+        // ---|   0   1   X   Z   U   W   L   H   -
+        // ------------------------------------------
+        /* 0 */ {_0, _1,  X,  X,  U,  X, _0, _1,  X},
+        /* 1 */ {_1, _0,  X,  X,  U,  X, _1, _0,  X},
+        /* X */ { X,  X,  X,  X,  U,  X,  X,  X,  X},
+        /* Z */ { X,  X,  X,  X,  U,  X,  X,  X,  X},
+        /* U */ { U,  U,  U,  U,  U,  U,  U,  U,  U},
+        /* W */ { X,  X,  X,  X,  U,  X,  X,  X,  X},
+        /* L */ {_0, _1,  X,  X,  U,  X, _0, _1,  X},
+        /* H */ {_1, _0,  X,  X,  U,  X, _1, _0,  X},
+        /* - */ { X,  X,  X,  X,  U,  X,  X,  X,  X},
+        // clang-format on
     };
     return table[static_cast<size_t>(lhs.value())]
                 [static_cast<size_t>(rhs.value())];
 }
 
 constexpr Bit operator^(const Bit& lhs, const Bit& rhs) noexcept {
-    return to_bit(Logic(lhs) ^ Logic(rhs));
+    return Bit::value_type(int(lhs.value()) ^ int(rhs.value()));
 }
 
 constexpr Logic operator~(const Logic& value) noexcept {
     using enum Logic::value_type;
     constexpr Logic const table[9] = {
-        // ----------------
-        //  U  X  0  1  Z  W  L  H  -
-        // ----------------
-        U, X, _1, _0, X, X, _1, _0, X,
+        // clang-format off
+        /*
+         0   1   X   Z   U   W   L   H   - */
+        _1, _0,  X,  X,  U,  X, _1, _0,  X,
+        // clang-format on
     };
     return table[static_cast<size_t>(value.value())];
 }
 
 constexpr Bit operator~(const Bit& value) noexcept {
-    return to_bit(~Logic(value));
+    return value == Bit::_0 ? Bit::_1 : Bit::_0;
 }
 
 constexpr bool is_01(const Logic& value) noexcept {

--- a/cpp/include/coconext/types/logic.hpp
+++ b/cpp/include/coconext/types/logic.hpp
@@ -282,5 +282,24 @@ Logic resolve(const Logic& value, ResolveMethod method);
 inline Bit resolve(const Bit& value, ResolveMethod method) { return value; }
 
 }  // namespace coconext::types
+namespace std {
+
+template <>
+class hash<coconext::types::Logic> {
+public:
+    size_t operator()(const coconext::types::Logic& logic) const noexcept {
+        return std::hash<coconext::types::Logic::value_type>()(logic.value());
+    }
+};
+
+template <>
+class hash<coconext::types::Bit> {
+public:
+    size_t operator()(const coconext::types::Bit& bit) const noexcept {
+        return std::hash<coconext::types::Bit::value_type>()(bit.value());
+    }
+};
+
+}  // namespace std
 
 #endif  // COCONEXT_LOGIC_HPP

--- a/cpp/include/coconext/types/range.hpp
+++ b/cpp/include/coconext/types/range.hpp
@@ -56,10 +56,6 @@ public:
         Direction direction_;
     };
 
-    using const_iterator = iterator;
-    using reverse_iterator = iterator;
-    using const_reverse_iterator = iterator;
-
 public:
     explicit constexpr Range(value_type left, Direction direction,
                              value_type right) noexcept
@@ -83,29 +79,23 @@ public:
     }
 
 public:
-    constexpr iterator begin() const noexcept {
+    constexpr auto begin() const noexcept {
         return iterator(left_, direction_);
     };
-    constexpr iterator end() const noexcept {
+    constexpr auto end() const noexcept {
         return iterator(
             direction_ == Direction::TO ? left_ + length() : left_ - length(),
             direction_);
     };
-    constexpr const_iterator cbegin() const noexcept { return begin(); }
-    constexpr const_iterator cend() const noexcept { return end(); }
-    constexpr reverse_iterator rbegin() const noexcept {
+    constexpr auto rbegin() const noexcept {
         return iterator(right_, direction_ == Direction::TO ? Direction::DOWNTO
                                                             : Direction::TO);
     };
-    constexpr reverse_iterator rend() const noexcept {
+    constexpr auto rend() const noexcept {
         return iterator(
             direction_ == Direction::TO ? right_ - length() : right_ + length(),
             direction_ == Direction::TO ? Direction::DOWNTO : Direction::TO);
     };
-    constexpr const_reverse_iterator crbegin() const noexcept {
-        return rbegin();
-    }
-    constexpr const_reverse_iterator crend() const noexcept { return rend(); }
 
 public:
     constexpr value_type operator[](size_t index) const {

--- a/cpp/include/coconext/types/range.hpp
+++ b/cpp/include/coconext/types/range.hpp
@@ -21,8 +21,14 @@ public:
 
     public:
         constexpr iterator() noexcept = default;
+        constexpr iterator(const iterator&) noexcept = default;
+        constexpr iterator& operator=(const iterator&) noexcept = default;
+        constexpr iterator(iterator&&) noexcept = default;
+        constexpr iterator& operator=(iterator&&) noexcept = default;
         constexpr iterator(value_type current, Direction direction) noexcept
             : current_(current), direction_(direction) {}
+
+    public:
         constexpr value_type operator*() const noexcept { return current_; }
         constexpr iterator& operator++() noexcept {
             if (direction_ == Direction::TO) {
@@ -57,6 +63,15 @@ public:
     };
 
 public:
+    // not default constructible
+    constexpr Range() noexcept = delete;
+
+    // ensures that these are constexpr since enum classes are not literal types
+    constexpr Range(const Range&) noexcept = default;
+    constexpr Range& operator=(const Range&) noexcept = default;
+    constexpr Range(Range&&) noexcept = default;
+    constexpr Range& operator=(Range&&) noexcept = default;
+
     explicit constexpr Range(value_type left, Direction direction,
                              value_type right) noexcept
         : left_(left), right_(right), direction_(direction) {}

--- a/cpp/include/coconext/types/range.hpp
+++ b/cpp/include/coconext/types/range.hpp
@@ -68,6 +68,10 @@ public:
         : left_(left),
           right_(right),
           direction_(left >= right ? Direction::DOWNTO : Direction::TO) {}
+    template <typename T>
+        requires requires { to_range(std::declval<T>()); }
+    explicit constexpr Range(T&& value)
+        : Range(to_range(std::forward<T>(value))) {}
 
 public:
     constexpr value_type left() const noexcept { return left_; }

--- a/cpp/include/coconext/types/range.hpp
+++ b/cpp/include/coconext/types/range.hpp
@@ -173,4 +173,18 @@ static_assert(std::ranges::bidirectional_range<Range>);
 
 }  // namespace coconext::types
 
+namespace std {
+
+template <>
+class hash<coconext::types::Range> {
+public:
+    size_t operator()(const coconext::types::Range& range) const noexcept {
+        return std::hash<coconext::types::Range::value_type>()(range.left()) ^
+               std::hash<coconext::types::Range::value_type>()(range.right()) ^
+               std::hash<coconext::types::Direction>()(range.direction());
+    }
+};
+
+}  // namespace std
+
 #endif  // COCONEXT_RANGE_HPP

--- a/cpp/src/logic.cpp
+++ b/cpp/src/logic.cpp
@@ -16,9 +16,9 @@ Logic resolve(const Logic& value, ResolveMethod method) {
         case Logic::_1:
             return value;
         case Logic::L:
-            return '0'_l;
+            return Logic::_0;
         case Logic::H:
-            return '1'_l;
+            return Logic::_1;
         default:
             throw std::invalid_argument("Logic value is not resolvable");
         }
@@ -28,11 +28,11 @@ Logic resolve(const Logic& value, ResolveMethod method) {
         case Logic::_1:
             return value;
         case Logic::L:
-            return '0'_l;
+            return Logic::_0;
         case Logic::H:
-            return '1'_l;
+            return Logic::_1;
         case Logic::W:
-            return 'X'_l;
+            return Logic::X;
         default:
             return value;
         }
@@ -42,11 +42,11 @@ Logic resolve(const Logic& value, ResolveMethod method) {
         case Logic::_1:
             return value;
         case Logic::L:
-            return '0'_l;
+            return Logic::_0;
         case Logic::H:
-            return '1'_l;
+            return Logic::_1;
         default:
-            return '0'_l;
+            return Logic::_0;
         }
     case ResolveMethod::ONES:
         switch (value.value()) {
@@ -54,11 +54,11 @@ Logic resolve(const Logic& value, ResolveMethod method) {
         case Logic::_1:
             return value;
         case Logic::L:
-            return '0'_l;
+            return Logic::_0;
         case Logic::H:
-            return '1'_l;
+            return Logic::_1;
         default:
-            return '1'_l;
+            return Logic::_1;
         }
     case ResolveMethod::RANDOM: {
         switch (value.value()) {
@@ -66,11 +66,12 @@ Logic resolve(const Logic& value, ResolveMethod method) {
         case Logic::_1:
             return value;
         case Logic::L:
-            return '0'_l;
+            return Logic::_0;
         case Logic::H:
-            return '1'_l;
+            return Logic::_1;
         default:
-            return (get_rng()() % 2 == 0) ? '0'_l : '1'_l;
+            auto& rng = get_rng();
+            return (rng() % 2 == 0) ? Logic::_0 : Logic::_1;
         }
     }
     default:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,8 @@ dev = [
     "pre-commit",
     "pytest",
     "ruff",
+    "cmake",
+    "scikit-build-core",
 ]
 docs = [
     "sphinx>=8.2",  # Require 8.2+ for :deco: directive


### PR DESCRIPTION
Collection of improvements to existing datatypes. The highlights are:
* Use enum classes in Logic, Bit, and Direction to avoid checking inputs
* Remove UDLs since enum values are perfectly safe
* Add support for user overloadable explicit conversions by type name
* Reimpl Logic for some performance