### PR TITLE
Make Bit a free class

### DIFF
--- a/bind/types/bind_logic.cpp
+++ b/bind/types/bind_logic.cpp
@@ -12,30 +12,6 @@ using namespace nb::literals;
 
 using namespace coconext::types;
 
-static Logic to_logic(const nb::int_& value) {
-    static nb::int_ zero = nb::int_(0);
-    static nb::int_ one = nb::int_(1);
-    if (value.equal(zero)) {
-        return Logic::_0;
-    } else if (value.equal(one)) {
-        return Logic::_1;
-    } else {
-        throw std::invalid_argument("Invalid logic string");
-    }
-}
-
-static Bit to_bit(const nb::int_& value) {
-    static nb::int_ zero = nb::int_(0);
-    static nb::int_ one = nb::int_(1);
-    if (value.equal(zero)) {
-        return Logic::_0;
-    } else if (value.equal(one)) {
-        return Logic::_1;
-    } else {
-        throw std::invalid_argument("Invalid bit string");
-    }
-}
-
 static ResolveMethod string_to_resolve_method(std::string_view method) {
     if (method == "error") {
         return ResolveMethod::ERROR;
@@ -65,16 +41,19 @@ void register_logic(nb::module_& m) {
         .value("RANDOM", ResolveMethod::RANDOM);
 
     nb::class_<Logic>(m, "Logic")
+        .def(nb::init<const Logic&>())
+        .def("__init__",
+             [](Logic* self, const Bit& value) {
+                 new (self) Logic(to_logic(value));
+             })
         .def("__init__",
              [](Logic* self, std::string_view value) {
                  new (self) Logic(to_logic(value));
              })
         .def("__init__",
-             [](Logic* self, nb::int_ value) {
+             [](Logic* self, long long value) {
                  new (self) Logic(to_logic(value));
              })
-        .def(nb::init<const Logic&>())
-        .def(nb::init<const Bit&>())
         .def("__str__", &to_string)
         .def("__index__", &to_int)
         .def("__bool__", [](const Logic& self) { return to_int(self) != 0; })
@@ -86,12 +65,17 @@ void register_logic(nb::module_& m) {
                  return res;
              })
         .def("__len__", [](const Logic&) { return 1; })
-        .def("__eq__",
-             nb::overload_cast<const Logic&, const Logic&>(&operator==),
-             nb::is_operator())
         .def(
             "__eq__",
-            [](const Logic& self, nb::int_ other) {
+            [](const Logic& lhs, const Logic& rhs) { return lhs == rhs; },
+            nb::is_operator())
+        .def(
+            "__eq__",
+            [](const Logic& lhs, const Bit& rhs) { return lhs == rhs; },
+            nb::is_operator())
+        .def(
+            "__eq__",
+            [](const Logic& self, long long other) {
                 try {
                     return self == to_logic(other);
                 } catch (const std::invalid_argument&) {
@@ -109,18 +93,30 @@ void register_logic(nb::module_& m) {
                 }
             },
             nb::is_operator())
-        .def("__or__",
-             nb::overload_cast<const Logic&, const Logic&>(&operator|),
-             nb::is_operator())
-        .def("__and__",
-             nb::overload_cast<const Logic&, const Logic&>(&operator&),
-             nb::is_operator())
-        .def("__xor__",
-             nb::overload_cast<const Logic&, const Logic&>(&operator^),
-             nb::is_operator())
+        .def(
+            "__or__",
+            [](const Logic& lhs, const Logic& rhs) { return lhs | rhs; },
+            nb::is_operator())
+        .def(
+            "__or__", [](const Logic& a, const Bit& b) { return a | b; },
+            nb::is_operator())
+        .def(
+            "__and__",
+            [](const Logic& lhs, const Logic& rhs) { return lhs & rhs; },
+            nb::is_operator())
+        .def(
+            "__and__", [](const Logic& a, const Bit& b) { return a & b; },
+            nb::is_operator())
+        .def(
+            "__xor__",
+            [](const Logic& lhs, const Logic& rhs) { return lhs ^ rhs; },
+            nb::is_operator())
+        .def(
+            "__xor__", [](const Logic& a, const Bit& b) { return a ^ b; },
+            nb::is_operator())
         .def("__invert__", nb::overload_cast<const Logic&>(&operator~),
              nb::is_operator())
-        .def_prop_ro("is_resolvable", &is_01)
+        .def_prop_ro("is_resolvable", nb::overload_cast<const Logic&>(&is_01))
         .def("resolve",
              [](const Logic& value, std::string_view method) {
                  return resolve(value, string_to_resolve_method(method));
@@ -134,18 +130,21 @@ void register_logic(nb::module_& m) {
             return Logic(self);
         });
 
-    nb::class_<Bit, Logic>(m, "Bit")
+    nb::class_<Bit>(m, "Bit")
+        .def(nb::init<const Bit&>())
+        .def("__init__",
+             [](Bit* self, const Logic& value) {
+                 new (self) Bit(to_bit(value));
+             })
         .def("__init__",
              [](Bit* self, std::string_view value) {
                  new (self) Bit(to_bit(value));
              })
         .def("__init__",
-             [](Bit* self, nb::int_ value) { new (self) Bit(to_bit(value)); })
-        .def("__init__",
-             [](Bit* self, const Logic& value) {
-                 new (self) Bit(to_bit(value));
-             })
-        .def(nb::init<const Bit&>())
+             [](Bit* self, long long value) { new (self) Bit(to_bit(value)); })
+        .def("__str__", &to_string)
+        .def("__index__", &to_int)
+        .def("__bool__", [](const Bit& self) { return to_int(self) != 0; })
         .def("__repr__",
              [](const Bit& self) {
                  auto res = std::string("Bit('");
@@ -153,27 +152,58 @@ void register_logic(nb::module_& m) {
                  res += "')";
                  return res;
              })
-        .def("__or__", nb::overload_cast<const Bit&, const Bit&>(&operator|),
-             nb::is_operator())
-        .def("__or__",
-             nb::overload_cast<const Logic&, const Logic&>(&operator|),
-             nb::is_operator())
-        .def("__and__", nb::overload_cast<const Bit&, const Bit&>(&operator&),
-             nb::is_operator())
-        .def("__and__",
-             nb::overload_cast<const Logic&, const Logic&>(&operator&),
-             nb::is_operator())
+        .def("__len__", [](const Logic&) { return 1; })
         .def(
-            // not sure why overload_cast won't work here.
-            "__and__", [](const Bit& a, const Logic& b) { return a & b; },
+            "__eq__", [](const Bit& lhs, const Bit& rhs) { return lhs == rhs; },
             nb::is_operator())
-        .def("__xor__", nb::overload_cast<const Bit&, const Bit&>(&operator^),
-             nb::is_operator())
-        .def("__xor__",
-             nb::overload_cast<const Logic&, const Logic&>(&operator^),
-             nb::is_operator())
-        .def("__invert__", nb::overload_cast<const Bit&>(&operator~),
-             nb::is_operator())
+        .def(
+            "__eq__",
+            [](const Bit& lhs, const Logic& rhs) { return lhs == rhs; },
+            nb::is_operator())
+        .def(
+            "__eq__",
+            [](const Bit& self, long long other) {
+                try {
+                    return self == to_bit(other);
+                } catch (const std::invalid_argument&) {
+                    return false;
+                }
+            },
+            nb::is_operator())
+        .def(
+            "__eq__",
+            [](const Bit& self, std::string_view other) {
+                try {
+                    return self == to_bit(other);
+                } catch (const std::invalid_argument&) {
+                    return false;
+                }
+            },
+            nb::is_operator())
+        .def(
+            "__or__", [](const Bit& lhs, const Bit& rhs) { return lhs | rhs; },
+            nb::is_operator())
+        .def(
+            "__or__", [](const Bit& a, const Logic& b) { return a | b; },
+            nb::is_operator())
+        .def(
+            "__and__", [](const Bit& lhs, const Bit& rhs) { return lhs & rhs; },
+            nb::is_operator())
+        .def(
+            "__and__",
+            [](const Bit& lhs, const Logic& rhs) { return lhs & rhs; },
+            nb::is_operator())
+        .def(
+            "__xor__", [](const Bit& lhs, const Bit& rhs) { return lhs ^ rhs; },
+            nb::is_operator())
+        .def(
+            "__xor__",
+            [](const Bit& lhs, const Logic& rhs) { return lhs ^ rhs; },
+            nb::is_operator())
+        .def(
+            "__invert__", [](const Bit& self) { return ~self; },
+            nb::is_operator())
+        .def_prop_ro("is_resolvable", [](const Bit&) { return true; })
         .def("resolve",
              [](const Bit& value, std::string_view method) {
                  return resolve(value, string_to_resolve_method(method));

--- a/cpp/include/coconext/types/logic.hpp
+++ b/cpp/include/coconext/types/logic.hpp
@@ -32,32 +32,80 @@ public:
     constexpr Logic& operator=(Logic&&) noexcept = default;
 
     constexpr Logic(value_type value) noexcept : value_(value) {}
-    template <typename T>
-        requires requires { to_logic(std::declval<T>()); }
-    explicit constexpr Logic(T&& value)
-        : value_(to_logic(std::forward<T>(value)).value()) {}
-
-public:
     constexpr value_type value() const noexcept { return value_; }
 
 private:
     value_type value_ = _0;
 };
 
-class Bit : public Logic {
+class Bit {
+public:
+    enum class value_type : uint8_t {
+        _0,
+        _1,
+    };
+    using enum value_type;
+
 public:
     // ensures that these are constexpr since enum classes are not literal types
+    constexpr Bit() noexcept = default;
     constexpr Bit(const Bit&) noexcept = default;
     constexpr Bit& operator=(const Bit&) noexcept = default;
     constexpr Bit(Bit&&) noexcept = default;
     constexpr Bit& operator=(Bit&&) noexcept = default;
 
-    constexpr Bit() noexcept : Logic(_0) {}
-    constexpr Bit(value_type value) noexcept : Logic(value) {}
-    template <typename T>
-        requires requires { to_bit(std::declval<T>()); }
-    explicit constexpr Bit(T&& value) : Logic(to_bit(std::forward<T>(value))) {}
+    constexpr Bit(value_type value) noexcept : value_(value) {}
+    constexpr value_type value() const noexcept { return value_; }
+
+    // Implicit conversion from Bit to Logic mimics subtype upcasting.
+    constexpr operator Logic() const noexcept {
+        return value_ == _0 ? Logic::_0 : Logic::_1;
+    }
+
+private:
+    value_type value_ = _0;
 };
+
+constexpr Logic operator""_l(char c) {
+    switch (c) {
+    case '0':
+        return Logic::_0;
+    case '1':
+        return Logic::_1;
+    case 'X':
+    case 'x':
+        return Logic::X;
+    case 'Z':
+    case 'z':
+        return Logic::Z;
+    case 'U':
+    case 'u':
+        return Logic::U;
+    case 'W':
+    case 'w':
+        return Logic::W;
+    case 'L':
+    case 'l':
+        return Logic::L;
+    case 'H':
+    case 'h':
+        return Logic::H;
+    case '-':
+        return Logic::DC;
+    default:
+        throw std::invalid_argument("Invalid logic literal");
+    }
+}
+
+constexpr Bit operator""_b(char c) {
+    if (c == '0') {
+        return Bit::_0;
+    } else if (c == '1') {
+        return Bit::_1;
+    } else {
+        throw std::invalid_argument("Invalid bit literal");
+    }
+}
 
 constexpr bool operator==(const Logic& lhs, const Logic& rhs) noexcept {
     return lhs.value() == rhs.value();
@@ -65,28 +113,14 @@ constexpr bool operator==(const Logic& lhs, const Logic& rhs) noexcept {
 
 template <Character CharType>
 constexpr Logic to_logic(CharType value) {
-    using enum Logic::value_type;
-    constexpr struct {
-        CharType chr;
-        Logic val;
-    } chr_map[] = {
-        {'U', U},  {'u', U}, {'X', X}, {'x', X}, {'0', _0},
-        {'1', _1}, {'Z', Z}, {'z', Z}, {'W', W}, {'w', W},
-        {'L', L},  {'l', L}, {'H', H}, {'h', H}, {'-', DC},
-    };
-    for (const auto& [chr, val] : chr_map) {
-        if (value == chr) {
-            return val;
-        }
-    }
-    throw std::invalid_argument("Invalid logic value");
+    return operator""_l(value);
 }
 
 constexpr Logic to_logic(std::string_view value) {
     if (value.size() != 1) {
         throw std::invalid_argument("Invalid logic value");
     }
-    return to_logic(value[0]);
+    return operator""_l(value[0]);
 }
 
 template <Integer IntType>
@@ -105,9 +139,9 @@ constexpr Logic to_logic(const Bit& value) { return value; }
 template <Character CharType>
 constexpr Bit to_bit(CharType value) {
     if (value == '0') {
-        return Logic::_0;
+        return Bit::_0;
     } else if (value == '1') {
-        return Logic::_1;
+        return Bit::_1;
     } else {
         throw std::invalid_argument("Invalid bit value");
     }
@@ -123,17 +157,19 @@ constexpr Bit to_bit(std::string_view value) {
 template <Integer IntType>
 constexpr Bit to_bit(IntType value) {
     if (value == 0) {
-        return Logic::_0;
+        return Bit::_0;
     } else if (value == 1) {
-        return Logic::_1;
+        return Bit::_1;
     } else {
         throw std::invalid_argument("Invalid bit value");
     }
 }
 
 constexpr Bit to_bit(const Logic& value) {
-    if (value == Logic::_0 || value == Logic::_1) {
-        return Bit(value.value());
+    if (value == Logic::_0) {
+        return Bit::_0;
+    } else if (value == Logic::_1) {
+        return Bit::_1;
     } else {
         throw std::invalid_argument("Invalid bit value");
     }
@@ -147,14 +183,11 @@ constexpr std::string_view to_string(const Logic& value) noexcept {
 }
 
 constexpr long long to_int(const Logic& value) {
-    switch (value.value()) {
-    case Logic::_0:
-    case Logic::L:
+    if (value.value() == Logic::_0 || value.value() == Logic::L) {
         return 0;
-    case Logic::_1:
-    case Logic::H:
+    } else if (value.value() == Logic::_1 || value.value() == Logic::H) {
         return 1;
-    default:
+    } else {
         throw std::invalid_argument(
             "Cannot convert Logic with non-binary value to integer");
     }
@@ -251,13 +284,15 @@ constexpr Logic operator~(const Logic& value) noexcept {
 }
 
 constexpr Bit operator~(const Bit& value) noexcept {
-    return value == Bit::_0 ? Bit::_1 : Bit::_0;
+    return value.value() == Bit::_0 ? Bit::_1 : Bit::_0;
 }
 
 constexpr bool is_01(const Logic& value) noexcept {
     return value == Logic::_0 || value == Logic::_1 || value == Logic::L ||
            value == Logic::H;
 }
+
+constexpr bool is_01(const Bit& value) noexcept { return true; }
 
 enum class ResolveMethod {
     ERROR,


### PR DESCRIPTION
Making Bit inherit from Logic meant that `Bit::X` existed, which isn't great. This also means we can easily add new subtype ad-hoc with implicit upcasts to subtype types. While the types don't have subtype relation in Python anymore, they otherwise behave as such.

Additionally, brought back UDLs because we want this to be ergonomic for C++, not just Python users.