### PR TITLE
First pass at `Array` binding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ nanobind_add_module(
     nanobind/src/types/bind.cpp
     nanobind/src/types/bind_logic.cpp
     nanobind/src/types/bind_range.cpp
+    nanobind/src/types/bind_array.cpp
 )
 target_link_libraries(types PRIVATE coconext_nb)
 

--- a/cpp/include/coconext/types.hpp
+++ b/cpp/include/coconext/types.hpp
@@ -2,6 +2,7 @@
 #define COCONEXT_TYPES_HPP
 
 // NOLINTBEGIN(unused-includes)
+#include "./types/array.hpp"
 #include "./types/concepts.hpp"
 #include "./types/direction.hpp"
 #include "./types/logic.hpp"

--- a/cpp/include/coconext/types/array.hpp
+++ b/cpp/include/coconext/types/array.hpp
@@ -1,0 +1,378 @@
+#ifndef COCONEXT_ARRAY_HPP
+#define COCONEXT_ARRAY_HPP
+
+#include <coconext/types/range.hpp>
+#include <concepts>
+#include <cstddef>
+#include <initializer_list>
+#include <iterator>
+#include <ranges>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace coconext::types {
+
+namespace {
+
+template <typename R>
+concept sized_input_range =
+    std::ranges::sized_range<R> && std::ranges::input_range<R>;
+
+}  // namespace
+
+template <typename ArrayT>
+class ArraySlice {
+public:
+    using value_type = typename ArrayT::value_type;
+    static_assert(!std::is_reference_v<value_type>);
+    using index_type = Range::value_type;
+
+public:                               // constructor
+    constexpr ArraySlice() = delete;  // no default constructor
+    constexpr ArraySlice(const ArraySlice&) = default;
+    constexpr ArraySlice(ArraySlice&&) = default;
+
+    constexpr ArraySlice(ArrayT* arr, Range range) noexcept
+        : arr_(arr), range_(range) {}
+
+public:  // attributes
+    constexpr const Range& range() const noexcept { return range_; }
+
+public:  // indexing and slicing
+    constexpr const value_type& operator[](index_type index) const {
+        return index(*this, index);
+    }
+    constexpr value_type& operator[](index_type index) {
+        return index(*this, index);
+    }
+    constexpr auto operator()(index_type start, index_type end) const {
+        return slice(*this, start, end);
+    }
+    constexpr auto operator()(index_type start, index_type end) {
+        return slice(*this, start, end);
+    }
+#if __cplusplus >= 202302L
+    constexpr auto operator[](index_type start, index_type stop) const {
+        return slice(*this, start, stop);
+    }
+    constexpr auto operator[](index_type start, index_type stop) {
+        return slice(*this, start, stop);
+    }
+#endif
+
+public:  // assignment
+    template <sized_input_range R>
+        requires std::convertible_to<std::ranges::range_value_t<R>, value_type>
+    constexpr auto& operator=(const R& obj) {
+        if (std::ranges::size(obj) != range_.length()) {
+            throw std::invalid_argument(
+                "Value of length " + std::to_string(std::ranges::size(obj)) +
+                " cannot be assigned to array slice of length " +
+                std::to_string(range_.length()));
+        }
+        std::ranges::copy(obj, begin());
+        return *this;
+    }
+
+    template <typename T>
+        requires std::convertible_to<T, value_type>
+    constexpr auto& operator=(std::initializer_list<T> init) {
+        if (init.size() != static_cast<size_t>(range_.length())) {
+            throw std::invalid_argument(
+                "Initializer list of size " + std::to_string(init.size()) +
+                " cannot be assigned to array slice of length " +
+                std::to_string(range_.length()));
+        }
+        std::ranges::copy(init, begin());
+        return *this;
+    }
+
+public:  // iterators
+    constexpr auto begin() const noexcept {
+        // we can make the assumption that find will always return a valid
+        // offset since the slice range is guaranteed to be a subrange of the
+        // array range by construction.
+        return arr_->begin() + *find(range_, range_.left());
+    }
+    constexpr auto begin() noexcept {
+        return arr_->begin() + *find(range_, range_.left());
+    }
+    constexpr auto end() const noexcept { return begin() + range_.length(); }
+    constexpr auto end() noexcept { return begin() + range_.length(); }
+    constexpr auto rbegin() const noexcept {
+        return std::reverse_iterator(end());
+    }
+    constexpr auto rbegin() noexcept { return std::reverse_iterator(end()); }
+    constexpr auto rend() const noexcept {
+        return std::reverse_iterator(begin());
+    }
+    constexpr auto rend() noexcept { return std::reverse_iterator(begin()); }
+
+private:
+    ArrayT* arr_;
+    Range range_;
+};
+
+template <typename ValueT>
+    requires requires { !std::is_reference_v<ValueT>; }
+class Array {
+public:
+    using value_type = ValueT;
+    using index_type = Range::value_type;
+
+public:
+    constexpr Array() = delete;  // no default constructor
+
+public:  // ensure these are constexpr
+    constexpr Array(Array&& other) = default;
+    constexpr Array(const Array& other) = default;
+    constexpr Array& operator=(const Array& other) = default;
+    constexpr Array& operator=(Array&& other) = default;
+
+public:  // construct with just range
+    explicit constexpr Array(Range range)
+        requires std::default_initializable<value_type>
+        : data_(), range_(range) {
+        data_.resize(range.length());
+    }
+
+    explicit constexpr Array(size_t length)
+        requires std::default_initializable<value_type>
+        : data_(),
+          range_(0, Direction::TO, static_cast<index_type>(length) - 1) {
+        data_.resize(length);
+    }
+
+public:  // constructor from initializer list
+    template <typename T>
+        requires std::convertible_to<T, value_type>
+    constexpr Array(std::initializer_list<T> init)
+        : data_(init), range_(0, Direction::TO, data_.size() - 1) {}
+
+public:  // move from vector
+    template <typename T>
+        requires std::convertible_to<T, value_type>
+    explicit constexpr Array(std::vector<T>&& vec)
+        : data_(vec), range_(0, Direction::TO, data_.size() - 1) {}
+
+public:  // construct from range
+    template <std::ranges::input_range T>
+        requires std::convertible_to<std::ranges::range_value_t<T>, value_type>
+    explicit constexpr Array(const T& obj, Range range)
+        : data_(), range_(range) {
+        data_.reserve(range.length());
+        data_.assign(std::ranges::begin(obj), std::ranges::end(obj));
+        if (data_.size() != range.length()) {
+            throw std::invalid_argument("Input of size " +
+                                        std::to_string(data_.size()) +
+                                        " does not match range length " +
+                                        std::to_string(range.length()));
+        }
+    }
+    template <std::ranges::input_range T>
+        requires std::convertible_to<std::ranges::range_value_t<T>, value_type>
+    explicit constexpr Array(const T& obj, size_t length)
+        : data_(), range_(0, Direction::TO, length - 1) {
+        data_.reserve(length);
+        data_.assign(std::ranges::begin(obj), std::ranges::end(obj));
+        if (data_.size() != length) {
+            throw std::invalid_argument(
+                "Input of size " + std::to_string(data_.size()) +
+                " does not match range length " + std::to_string(length));
+        }
+    }
+
+public:  // construct from iterator
+    template <std::input_iterator It>
+        requires std::convertible_to<
+                     typename std::iterator_traits<It>::value_type, value_type>
+    explicit constexpr Array(It begin, It end, Range range)
+        : data_(), range_(range) {
+        data_.reserve(range.length());
+        data_.assign(begin, end);
+        if (data_.size() != range.length()) {
+            throw std::invalid_argument("Iterator of size " +
+                                        std::to_string(data_.size()) +
+                                        " does not match range length " +
+                                        std::to_string(range.length()));
+        }
+    }
+    template <std::input_iterator It>
+        requires std::convertible_to<
+                     typename std::iterator_traits<It>::value_type, value_type>
+    explicit constexpr Array(It begin, It end, size_t length)
+        : data_(),
+          range_(0, Direction::TO, static_cast<index_type>(length) - 1) {
+        data_.reserve(length);
+        data_.assign(begin, end);
+        if (data_.size() != length) {
+            throw std::invalid_argument(
+                "Iterator of size " + std::to_string(data_.size()) +
+                " does not match range length " + std::to_string(length));
+        }
+    }
+
+public:  // attributes
+    constexpr const Range& range() const noexcept { return range_; }
+    constexpr void set_range(const Range& range) {
+        if (range.length() != this->range().length()) {
+            throw std::invalid_argument(
+                "New range length " + std::to_string(range.length()) +
+                " does not match current range length " +
+                std::to_string(this->range().length()));
+        }
+        range_ = range;
+    }
+
+public:  // indexing and slicing
+    constexpr auto operator[](index_type idx);
+    constexpr auto operator[](index_type idx) const;
+    constexpr auto operator()(index_type start, index_type end);
+    constexpr auto operator()(index_type start, index_type end) const;
+#if __cplusplus >= 202302L
+    constexpr auto operator[](index_type start, index_type stop);
+    constexpr auto operator[](index_type start, index_type stop);
+#endif
+
+public:  // iterators
+    constexpr auto begin() const noexcept { return data_.begin(); }
+    constexpr auto end() const noexcept { return data_.end(); }
+    constexpr auto rbegin() const noexcept { return data_.rbegin(); }
+    constexpr auto rend() const noexcept { return data_.rend(); }
+
+private:
+    // Consider using std::unique_ptr<value_type[]> instead. We don't need to
+    // store the size of the array separately since it's determined by the
+    // range. This is only possible if the type is default initializable. This
+    // might be best implemented as a specialization.
+    std::vector<value_type> data_;
+    Range range_;
+};
+
+template <typename ArrayT>
+    requires requires {
+        {
+            std::declval<typename ArrayT::value_type>() ==
+                std::declval<typename ArrayT::value_type>()
+        } -> std::convertible_to<bool>;
+    }
+constexpr bool operator==(const ArrayT& lhs, const ArrayT& rhs) noexcept {
+    if ((lhs.range().length() == 0) && (rhs.range().length() == 0)) {
+        return true;
+    }
+    if (lhs.range().length() != rhs.range().length()) {
+        return false;
+    }
+    for (auto it1 = lhs.begin(), it2 = rhs.begin(); it1 != lhs.end();
+         ++it1, ++it2) {
+        if (!(*it1 == *it2)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+template <typename ArrayT>
+auto index(ArrayT& arr, typename ArrayT::index_type idx) {
+    auto find_idx = find(arr.range(), idx);
+    if (find_idx == arr.range().end()) {
+        throw std::out_of_range("Index out of bounds");
+    }
+    auto offset = std::distance(arr.range().begin(), find_idx);
+    return *(arr.begin() + offset);
+}
+
+template <typename ArrayT>
+auto slice(ArrayT& arr, typename ArrayT::index_type start,
+           typename ArrayT::index_type end) {
+    auto left_offset = *find(arr.range(), start);
+    if (left_offset < 0 || left_offset >= arr.range().length()) {
+        throw std::out_of_range("slice start out of bounds");
+    }
+    auto right_offset = *find(arr.range(), end);
+    if (right_offset < 0 || right_offset >= arr.range().length()) {
+        throw std::out_of_range("slice end out of bounds");
+    }
+    if (left_offset > right_offset) {
+        throw std::invalid_argument(
+            "Slice direction does not match array range direction");
+    }
+    return ArraySlice(&arr, Range(start, arr.range().direction(), end));
+}
+
+template <typename ValueT>
+    requires requires { !std::is_reference_v<ValueT>; }
+constexpr auto Array<ValueT>::operator[](
+    typename Array<ValueT>::index_type idx) {
+    return index(*this, idx);
+}
+
+template <typename ValueT>
+    requires requires { !std::is_reference_v<ValueT>; }
+constexpr auto Array<ValueT>::operator[](
+    typename Array<ValueT>::index_type idx) const {
+    return index(*this, idx);
+}
+
+template <typename ValueT>
+    requires requires { !std::is_reference_v<ValueT>; }
+constexpr auto Array<ValueT>::operator()(
+    typename Array<ValueT>::index_type start,
+    typename Array<ValueT>::index_type end) {
+    return slice(*this, start, end);
+}
+
+template <typename ValueT>
+    requires requires { !std::is_reference_v<ValueT>; }
+constexpr auto Array<ValueT>::operator()(
+    typename Array<ValueT>::index_type start,
+    typename Array<ValueT>::index_type end) const {
+    return slice(*this, start, end);
+}
+
+#if __cplusplus >= 202302L
+template <typename ValueT>
+    requires requires { !std::is_reference_v<ValueT>; }
+constexpr auto Array<ValueT>::operator[](
+    typename Array<ValueT>::index_type start,
+    typename Array<ValueT>::index_type stop) {
+    return slice(*this, start, stop);
+}
+
+template <typename ValueT>
+    requires requires { !std::is_reference_v<ValueT>; }
+constexpr auto Array<ValueT>::operator[](
+    typename Array<ValueT>::index_type start,
+    typename Array<ValueT>::index_type stop) const {
+    return slice(*this, start, stop);
+}
+#endif
+
+template <typename ValueT>
+    requires requires(ValueT val) {
+        { std::to_string(val) } -> std::convertible_to<std::string>;
+    }
+std::string to_string(const Array<ValueT>& arr) {
+    std::string result = "Array([";
+    for (auto it = arr.begin(); it != arr.end(); ++it) {
+        result += std::to_string(*it);
+        if (std::next(it) != arr.end()) {
+            result += ", ";
+        }
+    }
+    result += "], ";
+    result += to_string(arr.range());
+    result += ")";
+    return result;
+}
+
+static_assert(std::ranges::random_access_range<Array<int>>);
+static_assert(std::ranges::random_access_range<const Array<int>>);
+static_assert(std::ranges::random_access_range<ArraySlice<Array<int>>>);
+static_assert(std::ranges::random_access_range<ArraySlice<const Array<int>>>);
+
+}  // namespace coconext::types
+
+#endif  // COCONEXT_ARRAY_HPP

--- a/nanobind/include/coconext_nb/types.hpp
+++ b/nanobind/include/coconext_nb/types.hpp
@@ -1,0 +1,345 @@
+#ifndef COCONEXT_NANOBIND_TYPES_HPP
+#define COCONEXT_NANOBIND_TYPES_HPP
+
+#include <nanobind/nanobind.h>
+
+#include <coconext/types/array.hpp>
+#include <coconext/types/range.hpp>
+#include <iterator>
+
+namespace nb = nanobind;
+
+namespace coconext::types {
+
+class PyListRandomAccessIterator {
+public:
+    using value_type = nb::object;
+    using difference_type = std::ptrdiff_t;
+
+public:  // constructors
+    PyListRandomAccessIterator() = default;
+    PyListRandomAccessIterator(nb::list arr, size_t pos)
+        : arr_(arr), pos_(pos) {}
+
+    auto operator*() const { return (*arr_)[pos_]; }
+    auto operator*() { return (*arr_)[pos_]; }
+    PyListRandomAccessIterator& operator++() {
+        ++pos_;
+        return *this;
+    }
+    PyListRandomAccessIterator operator++(int) {
+        PyListRandomAccessIterator tmp = *this;
+        ++(*this);
+        return tmp;
+    }
+    PyListRandomAccessIterator& operator--() {
+        --pos_;
+        return *this;
+    }
+    PyListRandomAccessIterator operator--(int) {
+        PyListRandomAccessIterator tmp = *this;
+        --(*this);
+        return tmp;
+    }
+    PyListRandomAccessIterator operator+(difference_type n) const {
+        return PyListRandomAccessIterator(arr_, pos_ + n);
+    }
+    PyListRandomAccessIterator operator-(difference_type n) const {
+        return PyListRandomAccessIterator(arr_, pos_ - n);
+    }
+    PyListRandomAccessIterator& operator+=(difference_type n) {
+        pos_ += n;
+        return *this;
+    }
+    PyListRandomAccessIterator& operator-=(difference_type n) {
+        pos_ -= n;
+        return *this;
+    }
+    difference_type operator-(const PyListRandomAccessIterator& other) const {
+        return static_cast<difference_type>(pos_) -
+               static_cast<difference_type>(other.pos_);
+    }
+    bool operator==(const PyListRandomAccessIterator& other) const {
+        return pos_ == other.pos_;
+    }
+    bool operator!=(const PyListRandomAccessIterator& other) const {
+        return pos_ != other.pos_;
+    }
+    bool operator<(const PyListRandomAccessIterator& other) const {
+        return pos_ < other.pos_;
+    }
+    bool operator>(const PyListRandomAccessIterator& other) const {
+        return pos_ > other.pos_;
+    }
+    bool operator<=(const PyListRandomAccessIterator& other) const {
+        return pos_ <= other.pos_;
+    }
+    bool operator>=(const PyListRandomAccessIterator& other) const {
+        return pos_ >= other.pos_;
+    }
+    auto operator[](difference_type n) const { return (*arr_)[pos_ + n]; }
+
+private:
+    nb::list arr_;
+    size_t pos_ = 0;
+};
+
+inline PyListRandomAccessIterator operator+(
+    typename PyListRandomAccessIterator::difference_type n,
+    const PyListRandomAccessIterator& it) {
+    return it + n;
+}
+
+template <>
+class Array<nb::object> {
+public:
+    using value_type = nb::object;
+    using index_type = Range::value_type;
+
+public:
+    Array() = delete;
+    Array(const Array<nb::object>& arr)
+        : data_(arr.data_), range_(arr.range_) {}
+    template <typename T>
+    Array(const Array<T>& arr) : data_(), range_(arr.range()) {
+        for (const auto& item : arr) {
+            data_.append(item);
+        }
+    }
+    Array(Array<nb::object>&& arr) noexcept
+        : data_(std::move(arr.data_)), range_(arr.range_) {}
+    Array& operator=(const Array<nb::object>& arr) {
+        if (this != &arr) {
+            data_ = arr.data_;
+            range_ = arr.range_;
+        }
+        return *this;
+    }
+    template <typename T>
+    Array& operator=(const Array<T>& arr) {
+        if (this != &arr) {
+            data_.clear();
+            for (const auto& item : arr) {
+                data_.append(item);
+            }
+            range_ = arr.range_;
+        }
+        return *this;
+    }
+    Array& operator=(Array<nb::object>&& arr) noexcept {
+        if (this != &arr) {
+            data_ = std::move(arr.data_);
+            range_ = arr.range_;
+        }
+        return *this;
+    }
+
+public:  // constructor from initializer list
+    template <typename T>
+        requires std::convertible_to<T, value_type>
+    Array(std::initializer_list<T> init)
+        : range_(0, Direction::TO, static_cast<index_type>(init.size()) - 1) {
+        for (const auto& item : init) {
+            data_.append(item);
+        }
+    }
+
+public:  // constructor from range
+    template <std::ranges::input_range R>
+    explicit Array(const R& obj) {
+        size_t count = 0;
+        for (const auto& item : obj) {
+            data_.append(item);
+            count++;
+        }
+        range_ = Range(0, Direction::TO, static_cast<index_type>(count) - 1);
+    }
+    template <std::ranges::input_range R>
+    explicit Array(const R& obj, Range range) : range_(range) {
+        size_t count = 0;
+        for (const auto& item : obj) {
+            data_.append(item);
+            count++;
+        }
+        if (count != range.length()) {
+            throw std::invalid_argument("Input of size " +
+                                        std::to_string(count) +
+                                        " does not match range length " +
+                                        std::to_string(range.length()));
+        }
+    }
+    template <std::ranges::input_range R>
+    explicit Array(const R& obj, size_t length)
+        : range_(0, Direction::TO, length - 1) {
+        size_t count = 0;
+        for (const auto& item : obj) {
+            data_.append(item);
+            count++;
+        }
+        if (count != length) {
+            throw std::invalid_argument(
+                "Input of size " + std::to_string(count) +
+                " does not match range length " + std::to_string(length));
+        }
+    }
+
+public:  // constructor from iterator
+    template <std::input_iterator It>
+    explicit Array(It begin, It end) {
+        size_t count = 0;
+        for (auto it = begin; it != end; ++it) {
+            data_.append(*it);
+            count++;
+        }
+        range_ = Range(0, Direction::TO, static_cast<index_type>(count) - 1);
+    }
+    template <std::input_iterator It>
+    explicit Array(It begin, It end, Range range) : range_(range) {
+        size_t count = 0;
+        for (auto it = begin; it != end; ++it) {
+            data_.append(*it);
+            count++;
+        }
+        if (count != range.length()) {
+            throw std::invalid_argument("Input of size " +
+                                        std::to_string(count) +
+                                        " does not match range length " +
+                                        std::to_string(range.length()));
+        }
+    }
+    template <std::input_iterator It>
+    explicit Array(It begin, It end, size_t length)
+        : range_(0, Direction::TO, length - 1) {
+        size_t count = 0;
+        for (auto it = begin; it != end; ++it) {
+            data_.append(*it);
+            count++;
+        }
+        if (count != length) {
+            throw std::invalid_argument(
+                "Input of size " + std::to_string(count) +
+                " does not match range length " + std::to_string(length));
+        }
+    }
+
+public:  // nb::iterable constructors
+    explicit Array(nb::iterable values)
+        : data_(values), range_(0, Direction::TO, data_.size() - 1) {}
+    explicit Array(nb::iterable values, Range range)
+        : data_(values), range_(range) {
+        if (data_.size() != range.length()) {
+            throw std::invalid_argument("Input of size " +
+                                        std::to_string(data_.size()) +
+                                        " does not match range length " +
+                                        std::to_string(range.length()));
+        }
+    }
+    explicit Array(nb::iterable values, size_t length)
+        : data_(values), range_(0, Direction::TO, length - 1) {
+        if (data_.size() != length) {
+            throw std::invalid_argument(
+                "Input of size " + std::to_string(data_.size()) +
+                " does not match range length " + std::to_string(length));
+        }
+    }
+
+public:  // attributes
+    const Range& range() const noexcept { return range_; }
+    constexpr void set_range(const Range& range) {
+        if (range.length() != this->range().length()) {
+            throw std::invalid_argument(
+                "New range length " + std::to_string(range.length()) +
+                " does not match current range length " +
+                std::to_string(this->range().length()));
+        }
+        range_ = range;
+    }
+
+public:  // iterators
+    auto begin() noexcept { return PyListRandomAccessIterator(data_, 0); };
+    auto begin() const noexcept {
+        return PyListRandomAccessIterator(data_, 0);
+    };
+    auto end() noexcept {
+        return PyListRandomAccessIterator(data_, data_.size());
+    };
+    auto end() const noexcept {
+        return PyListRandomAccessIterator(data_, data_.size());
+    };
+    auto rbegin() noexcept { return std::make_reverse_iterator(end()); };
+    auto rbegin() const noexcept { return std::make_reverse_iterator(end()); };
+    auto rend() noexcept { return std::make_reverse_iterator(begin()); };
+    auto rend() const noexcept { return std::make_reverse_iterator(begin()); };
+
+public:  // indexing and slicing
+    auto operator[](index_type idx) { return index(*this, idx); }
+    auto operator[](index_type idx) const { return index(*this, idx); }
+    auto operator()(index_type start, index_type end) {
+        return slice(*this, start, end);
+    }
+    auto operator()(index_type start, index_type end) const {
+        return slice(*this, start, end);
+    }
+#if __cplusplus >= 202302L
+    auto operator[](index_type start, index_type stop) {
+        return slice(start, stop);
+    }
+    auto operator[](index_type start, index_type stop) const {
+        return slice(start, stop);
+    }
+#endif
+
+private:  // attrs
+    nb::list data_;
+    Range range_;
+};
+
+template <typename RangeT>
+    requires std::is_same_v<
+        std::remove_cv_t<std::ranges::range_value_t<RangeT>>, nb::object>
+bool operator==(const RangeT& lhs, const RangeT& rhs) noexcept {
+    if ((lhs.range().length() == 0) && (rhs.range().length() == 0)) {
+        return true;
+    }
+    if (lhs.range().length() != rhs.range().length()) {
+        return false;
+    }
+    for (auto it1 = lhs.begin(), it2 = rhs.begin(); it1 != lhs.end();
+         ++it1, ++it2) {
+        if (!(*it1).equal(*it2)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+template <typename RangeT>
+    requires std::is_same_v<
+        std::remove_cv_t<std::ranges::range_value_t<RangeT>>, nb::object>
+auto find(const RangeT& arr, const nb::object& value) {
+    auto it = std::ranges::begin(arr);
+    for (; it != std::ranges::end(arr); ++it) {
+        if ((*it).equal(value)) {
+            break;
+        }
+    }
+    return it;
+}
+
+inline std::string to_string(const Array<nb::object>& arr) {
+    std::string repr = "Array([";
+    for (auto it = arr.begin(); it != arr.end(); ++it) {
+        repr += nb::cast<std::string>(nb::repr(*it));
+        if (std::next(it) != arr.end()) {
+            repr += ", ";
+        }
+    }
+    repr += "], " + to_string(arr.range()) + ")";
+    return repr;
+}
+
+static_assert(std::ranges::random_access_range<Array<nb::object>>);
+static_assert(std::ranges::random_access_range<const Array<nb::object>>);
+
+}  // namespace coconext::types
+#endif

--- a/nanobind/src/types/bind.cpp
+++ b/nanobind/src/types/bind.cpp
@@ -8,8 +8,10 @@ using namespace coconext::types;
 
 void register_logic(nb::module_& m);
 void register_range(nb::module_& m);
+void register_array(nb::module_& m);
 
 NB_MODULE(types, m) {
     register_logic(m);
     register_range(m);
+    register_array(m);
 }

--- a/nanobind/src/types/bind_array.cpp
+++ b/nanobind/src/types/bind_array.cpp
@@ -1,0 +1,180 @@
+#include <nanobind/make_iterator.h>  // Required for making iterators
+#include <nanobind/nanobind.h>
+#include <nanobind/operators.h>        // Required for operator overloading
+#include <nanobind/stl/optional.h>     // Required for std::optional conversions
+#include <nanobind/stl/string.h>       // Required for std::string conversions
+#include <nanobind/stl/string_view.h>  // Required for std::string_view conversions
+
+#include <coconext/types/array.hpp>
+#include <coconext/types/range.hpp>
+#include <coconext_nb/types.hpp>  // Include the Array<nb::object> specialization
+#include <stdexcept>
+
+namespace nb = nanobind;
+using namespace nb::literals;
+
+using namespace coconext::types;
+
+using index_type = typename Array<nb::object>::index_type;
+
+void register_array(nb::module_& m) {
+    nb::class_<Array<nb::object>>(m, "Array")
+        .def(
+            "__init__",
+            [](Array<nb::object>& self, nb::iterable value) {
+                new (&self) Array<nb::object>(value);
+            },
+            "value"_a.noconvert())
+        .def(
+            "__init__",
+            [](Array<nb::object>& self, nb::iterable value, Range range) {
+                new (&self) Array<nb::object>(value, range);
+            },
+            "value"_a.noconvert(), "range"_a.noconvert())
+        .def(
+            "__init__",
+            [](Array<nb::object>& self, nb::iterable value, size_t range) {
+                new (&self) Array<nb::object>(value, range);
+            },
+            "value"_a.noconvert(), "range"_a.noconvert())
+        .def_prop_rw("range", &Array<nb::object>::range,
+                     &Array<nb::object>::set_range)
+        .def_prop_ro(
+            "left",
+            [](const Array<nb::object>& self) { return self.range().left(); })
+        .def_prop_ro("direction",
+                     [](const Array<nb::object>& self) {
+                         return to_string(self.range().direction());
+                     })
+        .def_prop_ro(
+            "right",
+            [](const Array<nb::object>& self) { return self.range().right(); })
+        .def(
+            "__len__",
+            [](const Array<nb::object>& self) { return self.range().length(); })
+        .def(
+            "__eq__",
+            [](const Array<nb::object>& self, const Array<nb::object>& other) {
+                return self == other;
+            },
+            ""_a.noconvert(), nb::is_operator())
+        .def(
+            "__eq__",
+            [](const Array<nb::object>& self, const nb::sequence& other) {
+                Array<nb::object> other_array(other);
+                return self == other_array;
+            },
+            ""_a.noconvert(), nb::is_operator())
+        .def(
+            "__iter__",
+            [](const Array<nb::object>& self) {
+                return nb::make_iterator(nb::type<Array<nb::object>>(),
+                                         "iterator", self.begin(), self.end());
+            },
+            nb::keep_alive<0, 1>())
+        .def(
+            "__reversed__",
+            [](const Array<nb::object>& self) {
+                return nb::make_iterator(nb::type<Array<nb::object>>(),
+                                         "reverse_iterator", self.rbegin(),
+                                         self.rend());
+            },
+            nb::keep_alive<0, 1>())
+        .def(
+            "__contains__",
+            [](const Array<nb::object>& self, const nb::object& item) {
+                for (const auto& elem : self) {
+                    if (elem.equal(item)) {
+                        return true;
+                    }
+                }
+                return false;
+            },
+            ""_a.noconvert())
+        .def(
+            "__getitem__",
+            [](const Array<nb::object>& self, index_type index) {
+                return self[index];
+            },
+            ""_a.noconvert())
+        .def("__getitem__",
+             [](const Array<nb::object>& self, nb::slice slice) {
+                 auto maybe_start = nb::object(slice.attr("start"));
+                 auto maybe_stop = nb::object(slice.attr("stop"));
+                 auto step = nb::object(slice.attr("step"));
+                 if (!step.is_none()) {
+                     throw nb::type_error("Slicing with step is not supported");
+                 }
+                 auto start = maybe_start.is_none()
+                                  ? self.range().left()
+                                  : nb::cast<index_type>(maybe_start);
+                 auto stop = maybe_stop.is_none()
+                                 ? self.range().right()
+                                 : nb::cast<index_type>(maybe_stop);
+                 auto sliced_obj = self(start, stop);
+                 return Array<nb::object>(sliced_obj, sliced_obj.range());
+             })
+        .def(
+            "__setitem__",
+            [](Array<nb::object>& self, index_type index,
+               const nb::object& value) { self[index] = value; },
+            ""_a.noconvert(), ""_a.noconvert())
+        .def("__setitem__",
+             [](Array<nb::object>& self, nb::slice slice, nb::iterable values) {
+                 auto maybe_start = slice.attr("start");
+                 auto maybe_stop = slice.attr("stop");
+                 auto step = slice.attr("step");
+                 if (!step.is_none()) {
+                     throw nb::type_error("Slicing with step is not supported");
+                 }
+                 auto start = maybe_start.is_none()
+                                  ? self.range().left()
+                                  : nb::cast<index_type>(maybe_start);
+                 auto stop = maybe_stop.is_none()
+                                 ? self.range().right()
+                                 : nb::cast<index_type>(maybe_stop);
+                 auto values_list = nb::list(values);
+                 auto slice_obj = self(start, stop);
+                 if (values_list.size() != slice_obj.range().length()) {
+                     throw std::invalid_argument(
+                         "Attempt to assign sequence of size " +
+                         std::to_string(values_list.size()) +
+                         " to slice of size " +
+                         std::to_string(slice_obj.range().length()));
+                 }
+                 std::copy(values_list.begin(), values_list.end(),
+                           slice_obj.begin());
+             })
+        .def(
+            "index",
+            [](const Array<nb::object>& self, nb::object value,
+               std::optional<index_type> start,
+               std::optional<index_type> stop) {
+                index_type real_start =
+                    start.has_value() ? start.value() : self.range().left();
+                index_type real_stop =
+                    stop.has_value() ? stop.value() : self.range().right();
+                auto slice = self(real_start, real_stop);
+                auto it = find(slice, value);
+                if (it == self.end()) {
+                    throw nb::value_error("The value is not in the Array");
+                }
+                return std::distance(self.begin(), it);
+            },
+            ""_a.noconvert(), ""_a = nb::none(), ""_a = nb::none())
+        .def("count",
+             [](const Array<nb::object>& self, nb::object value) {
+                 size_t count = 0;
+                 for (const auto& elem : self) {
+                     if (elem.equal(value)) {
+                         count++;
+                     }
+                 }
+                 return count;
+             })
+        .def("__repr__",
+             [](const Array<nb::object>& self) { return to_string(self); })
+        .def("__copy__", [](const Array<nb::object>& self) { return self; })
+        .def("__deepcopy__",
+             [](const Array<nb::object>& self, nb::dict) { return self; });
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,3 +100,6 @@ exclude_also = [
 
 [tool.scikit-build]
 build-dir = "build/{wheel_tag}"
+
+[tool.codespell]
+ignore-words-list = "sting"

--- a/tests/test_coconext/test_array.py
+++ b/tests/test_coconext/test_array.py
@@ -1,0 +1,190 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from coconext.types import Array, Range
+
+
+def test_value_only_construction() -> None:
+    a = Array("1234")
+    assert a.left == 0
+    assert a.direction == "to"
+    assert a.right == 3
+
+
+def test_both_construction() -> None:
+    a = Array("1234", Range(-2, 1))
+    assert a.left == -2
+    assert a.direction == "to"
+    assert a.right == 1
+
+    Array("1234", 4)
+    Array("1234", range=Range(-2, 1))
+
+
+def test_range_int_construction() -> None:
+    assert Array("1234", 4)
+
+
+def test_bad_construction() -> None:
+    with pytest.raises(TypeError):
+        Array()
+    with pytest.raises(TypeError):
+        Array(value=1)
+    with pytest.raises(TypeError):
+        Array(range=Range(0, 1))
+    with pytest.raises(ValueError):
+        Array(value="1234", range=Range(0, 1))
+    with pytest.raises(TypeError):
+        Array(value="1234", range=object())
+    with pytest.raises(TypeError):
+        Array("1234", range(4))
+
+
+def test_length() -> None:
+    a = Array("123456")
+    assert len(a) == 6
+
+
+def test_range() -> None:
+    r = Range(-2, 1)
+    a = Array(value="0123", range=r)
+    assert a.range == r
+
+
+def test_equality() -> None:
+    assert Array("1234", Range(1, 4)) == Array("1234", Range(1, 4))
+    assert Array("1234", Range(1, 4)) == Array("1234", Range(0, -3))
+    assert Array("1234", Range(1, 4)) != Array("4321", Range(1, 4))
+    assert Array("1234") != Array("12")
+    assert Array("1234") != 8
+    assert Array([1, 2, 3, 4]) == [1, 2, 3, 4]
+
+
+def test_repr_eval() -> None:
+    r = Array("1234")
+    assert eval(repr(r)) == r
+
+
+def test_iter() -> None:
+    val = [7, True, object(), "example"]
+    a = Array(val)
+    assert list(a) == val
+
+
+def test_reversed() -> None:
+    val = [7, True, object(), "example"]
+    a = Array(val)
+    assert list(reversed(a)) == list(reversed(val))
+
+
+def test_contains() -> None:
+    a = Array([7, True, object(), "example"])
+    assert True in a
+    assert 89 not in a
+
+
+def test_index() -> None:
+    r = Array(i for j in range(10) for i in range(10))  # 0-9 repeated 10 times
+    assert r.index(5) == 5
+    assert r.index(5, 10, 20) == 15
+    with pytest.raises(ValueError):
+        r.index(object())
+
+
+def test_count() -> None:
+    assert Array("011X1Z").count("1") == 3
+
+
+def test_indexing() -> None:
+    a = Array("1234", Range(8, "to", 11))
+    assert a[8] == "1"
+    with pytest.raises(IndexError):
+        a[0]
+    a[11] = False
+    assert a[11] is False
+
+    b = Array("1234", Range(10, "downto", 7))
+    assert b[8] == "3"
+    with pytest.raises(IndexError):
+        b[-2]
+    b[8] = 9
+    assert b[8] == 9
+
+
+def test_bad_indexing() -> None:
+    with pytest.raises(TypeError):
+        Array("1234")[[]]
+    with pytest.raises(TypeError):
+        Array("1234")[object()] = 9
+
+
+def test_slicing() -> None:
+    a = Array("testingstuff")
+    b = a[2:6]
+    assert b.left == 2
+    assert b.right == 6
+    assert b == Array("sting")
+    a[0:3] = "hack"
+    assert a == Array("hackingstuff")
+
+
+def test_slicing_infered_start_stop() -> None:
+    a = Array([1, 2, 3, 4])
+    assert a[:] == a
+    a[:] = "1234"
+    assert a == Array("1234")
+
+
+def test_dont_specify_step() -> None:
+    with pytest.raises(TypeError):
+        Array("1234")[::1]
+    with pytest.raises(TypeError):
+        Array("7896")[1:2:1] = [1, 2]
+
+
+def test_slice_direction_mismatch() -> None:
+    a = Array([1, 2, 3, 4], Range(10, "downto", 7))
+    with pytest.raises(IndexError):
+        a[7:9]
+    with pytest.raises(IndexError):
+        a[9:10] = ["a", "b"]
+
+
+def test_set_slice_wrong_length() -> None:
+    a = Array("example")
+    with pytest.raises(ValueError):
+        a[2:4] = "real bad"
+
+
+def test_slice_correct_infered() -> None:
+    a = Array("1234")
+    b = a[:0]
+    assert b.right == 0
+
+
+def test_changing_range() -> None:
+    a = Array("1234")
+    a.range = Range(3, "downto", 0)
+    assert a.range == Range(3, "downto", 0)
+    with pytest.raises(TypeError):
+        a.range = range(10)
+    with pytest.raises(ValueError):
+        a.range = Range(7, "downto", 0)
+
+
+def test_copy() -> None:
+    l = Array("abcd", Range(-2, "to", 1))
+
+    c = copy.copy(l)
+    assert l == c
+    assert l.range == c.range
+
+    d = copy.deepcopy(l)
+    assert l == d
+    assert l.range == d.range


### PR DESCRIPTION
The intent of this was to create a single implementation for what is currently `cocotb.types.Array` in C++ and expose it to Python via nanobind. However, I ran into issues.

I tried several different implementations of Array and used nanobind as you would. First a dynamic array, then a vector, but the result was still noticeably slower in Python than the pure Python `Array` implementation was. One of the major culprits was construction. In Python the `Array` type just does `list(iterable)` on the input. This keep everything in Python and is actually quite fast. I'm sure it has been aggressively optimized given how common it is. But in C++, using either implementation required iterating over the `nb::iterable` input which does some iteration in Python and then casts each element to the C++ object. The solution to make this faster was to keep it in Python.

Next I decided the best way to keep it in Python was to have the `Array` implementation just be `nb::list` instead of an array or vector. Because I didn't want to start littering the C++ codebase with nanobind, I split the library (#124) and then created a specialization for `Array<nb::object>` that used `nb::list` for the data storage.

This was tricky to get right. `nb::list` iterators aren't pointers and thus aren't random access, so I have to mock up a random access iterator for it. It also returns `nb::object` instead of a reference to storage space when indexing or iterating, which was really annoying to get `ArraySlice` and everything working with. But I got it done.

Now construction is slightly faster than in Python. But oooof... simply returning the `Range` object is slower. And of course it is. In C++ this is just returning a `const&` to the object and nothing is copied until it need to be stored in an l-value. In Python returning this object is just an attribute access and incref and sharing the pointer. But as soon as you put the binding in there it *must* copy the C++ object into the Python object's storage space because that object needs to be independently ref-counted. And that's a new Python object created *every time that property is accessed*. Of course it's much slower.

After thinking things through I think the best course of action is instead of trying to make one `Array` impl to rule them all, to leave the Python version in Python and the C++ version in C++ and provide all the functionality necessary to bridge the two and use the other in each context.

That's right, `Array` (and eventually `LogicArray` and `BitArray`) will get the full treatment. They will get a wrapper for using `cocotb.types.Array` in C++, a binding generator to use `coconext::types::Array<T>` in Python (much like `nb::bind_vector<int>(...)`), and a type caster to convert `cocotb.types.Array[int]` into `coconext::types::Array<int>`, etc.

But for now, what I have can be merged.