### PR TITLE
Polish Direction

### DIFF
--- a/cpp/include/coconext/types/direction.hpp
+++ b/cpp/include/coconext/types/direction.hpp
@@ -1,7 +1,6 @@
 #ifndef COCONEXT_DIRECTION_HPP
 #define COCONEXT_DIRECTION_HPP
 
-#include <algorithm>
 #include <cstdint>
 #include <stdexcept>
 #include <string_view>
@@ -10,31 +9,19 @@ namespace coconext::types {
 
 class Direction {
 public:
-    enum class value_type : uint8_t {
-        TO,
-        DOWNTO,
+    enum class value_type : int8_t {
+        TO = 1,
+        DOWNTO = -1,
     };
     using enum value_type;
 
 public:
-    // ensures that these are constexpr since enum classes are not literal types
     constexpr Direction() noexcept = default;
-    constexpr Direction(const Direction&) noexcept = default;
-    constexpr Direction& operator=(const Direction&) noexcept = default;
-    constexpr Direction(Direction&&) noexcept = default;
-    constexpr Direction& operator=(Direction&&) noexcept = default;
-
     constexpr Direction(value_type value) noexcept : value_(value) {}
-    template <typename T>
-        requires requires { to_direction(std::declval<T>()); }
-    explicit constexpr Direction(T&& value)
-        : value_(to_direction(std::forward<T>(value)).value()) {}
-
-public:
     constexpr value_type value() const noexcept { return value_; }
 
 private:
-    value_type value_ = TO;
+    value_type value_{TO};
 };
 
 constexpr bool operator==(const Direction& lhs, const Direction& rhs) noexcept {
@@ -50,11 +37,24 @@ constexpr std::string_view to_string(const Direction& direction) noexcept {
 }
 
 constexpr Direction to_direction(std::string_view value) {
-    std::string str(value);
-    std::transform(str.begin(), str.end(), str.begin(), ::tolower);
-    if (str == "to") {
+    auto to_lower = [](char c) { return c | 0x20; };
+
+    auto equal = [&](std::string_view a, std::string_view b) {
+        if (a.size() != b.size()) {
+            return false;
+        }
+        for (size_t i = 0; i < b.size(); ++i) {
+            // we deliberately only lower a since we know b to be the literal
+            if (to_lower(a[i]) != b[i]) {
+                return false;
+            }
+        }
+        return true;
+    };
+
+    if (equal(value, "to")) {
         return Direction::TO;
-    } else if (str == "downto") {
+    } else if (equal(value, "downto")) {
         return Direction::DOWNTO;
     } else {
         throw std::invalid_argument("Invalid direction string");
@@ -66,8 +66,7 @@ constexpr Direction to_direction(std::string_view value) {
 namespace std {
 
 template <>
-class hash<coconext::types::Direction> {
-public:
+struct hash<coconext::types::Direction> {
     size_t operator()(
         const coconext::types::Direction& direction) const noexcept {
         return std::hash<coconext::types::Direction::value_type>()(

--- a/cpp/tests/test_range.cpp
+++ b/cpp/tests/test_range.cpp
@@ -71,6 +71,8 @@ TEST(TestRange, NullRange) {
 TEST(TestRange, BadArgumentsEquivalent) {
     EXPECT_THROW((void)to_direction("BAD DIRECTION"), std::invalid_argument);
     EXPECT_THROW((void)to_direction("nope"), std::invalid_argument);
+    EXPECT_THROW((void)to_direction("xx"), std::invalid_argument);
+    EXPECT_THROW((void)to_direction("nottto"), std::invalid_argument);
 }
 
 TEST(TestRange, Equality) {


### PR DESCRIPTION
Use TO=1/DOWNTO=-1 so the underlying value can serve as an iterator stride (needed by the upcoming CountIterator/Range refactor). Drop the dead templated T&& constructor (broken two-phase lookup), rewrite to_direction as in-place ASCII case-insensitive compare (no allocation, no signed-char UB), and remove the redundant defaulted special members.