### PR TITLE
Polish Logic

### DIFF
--- a/cpp/include/coconext/types/logic.hpp
+++ b/cpp/include/coconext/types/logic.hpp
@@ -24,13 +24,7 @@ public:
     using enum value_type;
 
 public:
-    // ensures that these are constexpr since enum classes are not literal types
     constexpr Logic() noexcept = default;
-    constexpr Logic(const Logic&) noexcept = default;
-    constexpr Logic& operator=(const Logic&) noexcept = default;
-    constexpr Logic(Logic&&) noexcept = default;
-    constexpr Logic& operator=(Logic&&) noexcept = default;
-
     constexpr Logic(value_type value) noexcept : value_(value) {}
     constexpr value_type value() const noexcept { return value_; }
 
@@ -47,13 +41,7 @@ public:
     using enum value_type;
 
 public:
-    // ensures that these are constexpr since enum classes are not literal types
     constexpr Bit() noexcept = default;
-    constexpr Bit(const Bit&) noexcept = default;
-    constexpr Bit& operator=(const Bit&) noexcept = default;
-    constexpr Bit(Bit&&) noexcept = default;
-    constexpr Bit& operator=(Bit&&) noexcept = default;
-
     constexpr Bit(value_type value) noexcept : value_(value) {}
     constexpr value_type value() const noexcept { return value_; }
 
@@ -66,7 +54,16 @@ private:
     value_type value_ = _0;
 };
 
-constexpr Logic operator""_l(char c) {
+constexpr bool operator==(const Logic& lhs, const Logic& rhs) noexcept {
+    return lhs.value() == rhs.value();
+}
+
+constexpr bool operator==(const Bit& lhs, const Bit& rhs) noexcept {
+    return lhs.value() == rhs.value();
+}
+
+template <Character CharType>
+constexpr Logic to_logic(CharType c) {
     switch (c) {
     case '0':
         return Logic::_0;
@@ -97,30 +94,26 @@ constexpr Logic operator""_l(char c) {
     }
 }
 
-constexpr Bit operator""_b(char c) {
-    if (c == '0') {
+template <Character CharType>
+constexpr Bit to_bit(CharType value) {
+    if (value == '0') {
         return Bit::_0;
-    } else if (c == '1') {
+    } else if (value == '1') {
         return Bit::_1;
     } else {
-        throw std::invalid_argument("Invalid bit literal");
+        throw std::invalid_argument("Invalid bit value");
     }
 }
 
-constexpr bool operator==(const Logic& lhs, const Logic& rhs) noexcept {
-    return lhs.value() == rhs.value();
-}
+constexpr Logic operator""_l(char c) { return to_logic(c); }
 
-template <Character CharType>
-constexpr Logic to_logic(CharType value) {
-    return operator""_l(value);
-}
+constexpr Bit operator""_b(char c) { return to_bit(c); }
 
 constexpr Logic to_logic(std::string_view value) {
     if (value.size() != 1) {
         throw std::invalid_argument("Invalid logic value");
     }
-    return operator""_l(value[0]);
+    return to_logic(value[0]);
 }
 
 constexpr Logic to_logic(char const* value) {
@@ -144,17 +137,6 @@ constexpr Logic to_logic(IntType value) {
 constexpr Logic to_logic(bool value) { return value ? Logic::_1 : Logic::_0; }
 
 constexpr Logic to_logic(const Bit& value) { return value; }
-
-template <Character CharType>
-constexpr Bit to_bit(CharType value) {
-    if (value == '0') {
-        return Bit::_0;
-    } else if (value == '1') {
-        return Bit::_1;
-    } else {
-        throw std::invalid_argument("Invalid bit value");
-    }
-}
 
 constexpr Bit to_bit(std::string_view value) {
     if (value.size() != 1) {
@@ -207,7 +189,7 @@ constexpr char to_char(const Logic& value) noexcept {
     return char_map[static_cast<size_t>(value.value())];
 }
 
-constexpr bool to_int(const Logic& value) {
+constexpr int to_int(const Logic& value) {
     if (value.value() == Logic::_0 || value.value() == Logic::L) {
         return 0;
     } else if (value.value() == Logic::_1 || value.value() == Logic::H) {
@@ -317,7 +299,7 @@ constexpr bool is_01(const Logic& value) noexcept {
            value == Logic::H;
 }
 
-constexpr bool is_01(const Bit& value) noexcept { return true; }
+constexpr bool is_01(const Bit&) noexcept { return true; }
 
 enum class ResolveMethod {
     ERROR,
@@ -332,19 +314,18 @@ Logic resolve(const Logic& value, ResolveMethod method);
 inline Bit resolve(const Bit& value, ResolveMethod method) { return value; }
 
 }  // namespace coconext::types
+
 namespace std {
 
 template <>
-class hash<coconext::types::Logic> {
-public:
+struct hash<coconext::types::Logic> {
     size_t operator()(const coconext::types::Logic& logic) const noexcept {
         return std::hash<coconext::types::Logic::value_type>()(logic.value());
     }
 };
 
 template <>
-class hash<coconext::types::Bit> {
-public:
+struct hash<coconext::types::Bit> {
     size_t operator()(const coconext::types::Bit& bit) const noexcept {
         return std::hash<coconext::types::Bit::value_type>()(bit.value());
     }

--- a/cpp/src/logic.cpp
+++ b/cpp/src/logic.cpp
@@ -65,9 +65,10 @@ Logic resolve(const Logic& value, ResolveMethod method) {
             return Logic::_0;
         case Logic::H:
             return Logic::_1;
-        default:
+        default: {
             auto& rng = get_rng();
             return (rng() % 2 == 0) ? Logic::_0 : Logic::_1;
+        }
         }
     }
     default:

--- a/cpp/tests/test_logic.cpp
+++ b/cpp/tests/test_logic.cpp
@@ -3,6 +3,7 @@
 #include <coconext/types.hpp>
 #include <stdexcept>
 #include <unordered_set>
+#include <vector>
 
 using namespace coconext::types;
 
@@ -265,6 +266,28 @@ TEST(TestLogic, LogicResolve) {
 
     auto resolved_dc = resolve('-'_l, ResolveMethod::RANDOM);
     EXPECT_TRUE(resolved_dc == '0'_l || resolved_dc == '1'_l);
+
+    // Test ERROR resolution
+    EXPECT_EQ(resolve('0'_l, ResolveMethod::ERROR), '0'_l);
+    EXPECT_EQ(resolve('1'_l, ResolveMethod::ERROR), '1'_l);
+    EXPECT_THROW((void)resolve('U'_l, ResolveMethod::ERROR),
+                 std::invalid_argument);
+    EXPECT_THROW((void)resolve('X'_l, ResolveMethod::ERROR),
+                 std::invalid_argument);
+    EXPECT_THROW((void)resolve('Z'_l, ResolveMethod::ERROR),
+                 std::invalid_argument);
+    EXPECT_THROW((void)resolve('W'_l, ResolveMethod::ERROR),
+                 std::invalid_argument);
+    EXPECT_THROW((void)resolve('L'_l, ResolveMethod::ERROR),
+                 std::invalid_argument);
+    EXPECT_THROW((void)resolve('H'_l, ResolveMethod::ERROR),
+                 std::invalid_argument);
+    EXPECT_THROW((void)resolve('-'_l, ResolveMethod::ERROR),
+                 std::invalid_argument);
+
+    // Out-of-range ResolveMethod hits the outer `default:` arm.
+    EXPECT_THROW((void)resolve('0'_l, static_cast<ResolveMethod>(99)),
+                 std::invalid_argument);
 }
 
 TEST(TestBit, BitResolve) {
@@ -279,6 +302,24 @@ TEST(TestBit, BitResolve) {
 
     EXPECT_EQ(resolve('0'_b, ResolveMethod::RANDOM), '0'_b);
     EXPECT_EQ(resolve('1'_b, ResolveMethod::RANDOM), '1'_b);
+}
+
+// Stores values in std::vector to force runtime evaluation of conversions.
+// These can be evaluated at compile time and reduce observed coverage.
+TEST(TestLogic, RuntimeIntAndBitConversions) {
+    const std::vector<int> ints{0, 1, 2};
+    EXPECT_EQ(to_logic(ints[0]), '0'_l);
+    EXPECT_EQ(to_logic(ints[1]), '1'_l);
+    EXPECT_THROW((void)to_logic(ints[2]), std::invalid_argument);
+    EXPECT_EQ(to_bit(ints[0]), '0'_b);
+    EXPECT_EQ(to_bit(ints[1]), '1'_b);
+    EXPECT_THROW((void)to_bit(ints[2]), std::invalid_argument);
+
+    const std::vector<Bit> bits{'0'_b, '1'_b};
+    EXPECT_EQ(to_logic(bits[0]), '0'_l);
+    EXPECT_EQ(to_logic(bits[1]), '1'_l);
+    EXPECT_EQ(resolve(bits[0], ResolveMethod::WEAK), '0'_b);
+    EXPECT_EQ(resolve(bits[1], ResolveMethod::ZEROS), '1'_b);
 }
 
 // Test Logic is_resolvable (checked via is_01)

--- a/nanobind/src/types/bind_logic.cpp
+++ b/nanobind/src/types/bind_logic.cpp
@@ -152,7 +152,7 @@ void register_logic(nb::module_& m) {
                  res += "')";
                  return res;
              })
-        .def("__len__", [](const Logic&) { return 1; })
+        .def("__len__", [](const Bit&) { return 1; })
         .def(
             "__eq__", [](const Bit& lhs, const Bit& rhs) { return lhs == rhs; },
             nb::is_operator())


### PR DESCRIPTION
Define ADL-friendly to_logic/to_bit char helpers up front and have the UDLs delegate to them (instead of the reverse). Add direct Logic/Bit operator==, collapse the redundant defaulted special members, fix to_int's return type (was bool, name implies int), wrap the random-resolve switch's default branch in braces, and convert std::hash specializations from class to struct.