### PR TITLE
Refactor iterator out of Range and polish the Range object

### DIFF
--- a/cpp/include/coconext/types/array.hpp
+++ b/cpp/include/coconext/types/array.hpp
@@ -1,6 +1,7 @@
 #ifndef COCONEXT_ARRAY_HPP
 #define COCONEXT_ARRAY_HPP
 
+#include <algorithm>
 #include <coconext/types/range.hpp>
 #include <concepts>
 #include <cstddef>
@@ -9,7 +10,6 @@
 #include <ranges>
 #include <stdexcept>
 #include <type_traits>
-#include <utility>
 #include <vector>
 
 namespace coconext::types {

--- a/cpp/include/coconext/types/count_iterator.hpp
+++ b/cpp/include/coconext/types/count_iterator.hpp
@@ -1,0 +1,126 @@
+#ifndef COCONEXT_COUNT_ITERATOR_HPP
+#define COCONEXT_COUNT_ITERATOR_HPP
+
+#include <cassert>
+#include <coconext/types/direction.hpp>
+#include <concepts>
+#include <iterator>
+
+namespace coconext::types {
+
+template <std::signed_integral IntT>
+class CountIterator {
+public:
+    using value_type = IntT;
+    using difference_type =
+        std::conditional_t<(sizeof(IntT) > sizeof(std::ptrdiff_t)), IntT,
+                           std::ptrdiff_t>;
+    using reference = value_type;
+    using pointer = void;
+    using iterator_category = std::random_access_iterator_tag;
+    using iterator_concept = std::random_access_iterator_tag;
+
+public:
+    constexpr CountIterator() noexcept = default;
+    constexpr CountIterator(const CountIterator&) noexcept = default;
+    constexpr CountIterator& operator=(const CountIterator&) noexcept = default;
+    constexpr CountIterator(CountIterator&&) noexcept = default;
+    constexpr CountIterator& operator=(CountIterator&&) noexcept = default;
+    constexpr CountIterator(value_type current, Direction direction) noexcept
+        : current_(current), direction_(direction) {}
+
+public:
+    constexpr value_type operator*() const noexcept { return current_; }
+    constexpr CountIterator& operator++() noexcept {
+        if (direction_ == Direction::TO) {
+            ++current_;
+        } else {
+            --current_;
+        }
+        return *this;
+    }
+    constexpr CountIterator operator++(int) noexcept {
+        CountIterator temp = *this;
+        ++(*this);
+        return temp;
+    }
+    constexpr CountIterator& operator--() noexcept {
+        if (direction_ == Direction::TO) {
+            --current_;
+        } else {
+            ++current_;
+        }
+        return *this;
+    }
+    constexpr CountIterator operator--(int) noexcept {
+        CountIterator temp = *this;
+        --(*this);
+        return temp;
+    }
+    constexpr CountIterator operator+(difference_type n) const noexcept {
+        return direction_ == Direction::TO
+                   ? CountIterator(current_ + n, direction_)
+                   : CountIterator(current_ - n, direction_);
+    }
+    constexpr CountIterator operator-(difference_type n) const noexcept {
+        return direction_ == Direction::TO
+                   ? CountIterator(current_ - n, direction_)
+                   : CountIterator(current_ + n, direction_);
+    }
+    constexpr difference_type operator-(
+        const CountIterator& other) const noexcept {
+        assert(direction_ == other.direction_ &&
+               "Iterators from different ranges");
+        return direction_ == Direction::TO ? current_ - other.current_
+                                           : other.current_ - current_;
+    }
+    constexpr CountIterator& operator+=(difference_type n) noexcept {
+        if (direction_ == Direction::TO) {
+            current_ += n;
+        } else {
+            current_ -= n;
+        }
+        return *this;
+    }
+    constexpr CountIterator& operator-=(difference_type n) noexcept {
+        if (direction_ == Direction::TO) {
+            current_ -= n;
+        } else {
+            current_ += n;
+        }
+        return *this;
+    }
+    constexpr reference operator[](difference_type n) const noexcept {
+        return direction_ == Direction::TO ? current_ + n : current_ - n;
+    }
+    friend constexpr auto operator<=>(const CountIterator& lhs,
+                                      const CountIterator& rhs) noexcept {
+        assert(lhs.direction_ == rhs.direction_ &&
+               "Iterators from different ranges");
+        // For DOWNTO, current_ decreases as we advance, so the natural ordering
+        // on current_ is inverted relative to iteration order.
+        return lhs.direction_ == Direction::TO
+                   ? (lhs.current_ <=> rhs.current_)
+                   : (rhs.current_ <=> lhs.current_);
+    }
+    friend constexpr bool operator==(const CountIterator& lhs,
+                                     const CountIterator& rhs) noexcept {
+        assert(lhs.direction_ == rhs.direction_ &&
+               "Iterators from different ranges");
+        return lhs.current_ == rhs.current_;
+    }
+    friend constexpr CountIterator operator+(difference_type n,
+                                             const CountIterator& it) noexcept {
+        return it + n;
+    }
+
+private:
+    value_type current_{0};
+    Direction direction_{Direction::TO};
+};
+
+static_assert(std::random_access_iterator<CountIterator<int>>);
+
+}  // namespace coconext::types
+
+#endif  // COCONEXT_COUNT_ITERATOR_HPP

--- a/cpp/include/coconext/types/hash.hpp
+++ b/cpp/include/coconext/types/hash.hpp
@@ -1,0 +1,22 @@
+#ifndef COCONEXT_HASH_HPP
+#define COCONEXT_HASH_HPP
+
+#include <cstddef>
+#include <functional>
+
+namespace coconext::types::detail {
+
+constexpr size_t hash_mix(size_t seed, size_t value) noexcept {
+    return seed ^ (value + 0x9e3779b97f4a7c15ULL + (seed << 6) + (seed >> 2));
+}
+
+template <typename... Args>
+constexpr size_t hash_combine(const Args&... args) noexcept {
+    size_t seed = 0;
+    ((seed = hash_mix(seed, std::hash<Args>{}(args))), ...);
+    return seed;
+}
+
+}  // namespace coconext::types::detail
+
+#endif  // COCONEXT_HASH_HPP

--- a/cpp/include/coconext/types/range.hpp
+++ b/cpp/include/coconext/types/range.hpp
@@ -1,9 +1,11 @@
 #ifndef COCONEXT_RANGE_HPP
 #define COCONEXT_RANGE_HPP
 
-#include <algorithm>
+#include <cassert>
 #include <coconext/types/concepts.hpp>
+#include <coconext/types/count_iterator.hpp>
 #include <coconext/types/direction.hpp>
+#include <coconext/types/hash.hpp>
 #include <cstdint>
 #include <ranges>
 #include <stdexcept>
@@ -13,106 +15,10 @@ namespace coconext::types {
 class Range {
 public:
     using value_type = int32_t;
-
-    class iterator {
-    public:
-        using difference_type = int32_t;
-        using value_type = int32_t;
-
-    public:
-        constexpr iterator() noexcept = default;
-        constexpr iterator(const iterator&) noexcept = default;
-        constexpr iterator& operator=(const iterator&) noexcept = default;
-        constexpr iterator(iterator&&) noexcept = default;
-        constexpr iterator& operator=(iterator&&) noexcept = default;
-        constexpr iterator(value_type current, Direction direction) noexcept
-            : current_(current), direction_(direction) {}
-
-    public:
-        constexpr value_type operator*() const noexcept { return current_; }
-        constexpr iterator& operator++() noexcept {
-            if (direction_ == Direction::TO) {
-                ++current_;
-            } else {
-                --current_;
-            }
-            return *this;
-        }
-        constexpr iterator operator++(int) noexcept {
-            iterator temp = *this;
-            ++(*this);
-            return temp;
-        }
-        constexpr iterator& operator--() noexcept {
-            if (direction_ == Direction::TO) {
-                --current_;
-            } else {
-                ++current_;
-            }
-            return *this;
-        }
-        constexpr iterator operator--(int) noexcept {
-            iterator temp = *this;
-            --(*this);
-            return temp;
-        }
-        constexpr iterator operator+(difference_type n) const noexcept {
-            if (direction_ == Direction::TO) {
-                return iterator(current_ + n, direction_);
-            } else {
-                return iterator(current_ - n, direction_);
-            }
-        }
-        constexpr iterator operator-(difference_type n) const noexcept {
-            if (direction_ == Direction::TO) {
-                return iterator(current_ - n, direction_);
-            } else {
-                return iterator(current_ + n, direction_);
-            }
-        }
-        constexpr difference_type operator-(
-            const iterator& other) const noexcept {
-            if (direction_ == Direction::TO) {
-                return current_ - other.current_;
-            } else {
-                return other.current_ - current_;
-            }
-        }
-        constexpr iterator& operator+=(difference_type n) noexcept {
-            if (direction_ == Direction::TO) {
-                current_ += n;
-            } else {
-                current_ -= n;
-            }
-            return *this;
-        }
-        constexpr iterator& operator-=(difference_type n) noexcept {
-            if (direction_ == Direction::TO) {
-                current_ -= n;
-            } else {
-                current_ += n;
-            }
-            return *this;
-        }
-        constexpr value_type operator[](difference_type n) const noexcept {
-            return *(*this + n);
-        }
-        friend constexpr bool operator<(const iterator& lhs,
-                                        const iterator& rhs) noexcept;
-
-    private:
-        value_type current_;
-        Direction direction_;
-    };
+    using iterator = CountIterator<value_type>;
 
 public:
-    // ensures that these are constexpr since enum classes are not literal types
     constexpr Range() noexcept = default;
-    constexpr Range(const Range&) noexcept = default;
-    constexpr Range& operator=(const Range&) noexcept = default;
-    constexpr Range(Range&&) noexcept = default;
-    constexpr Range& operator=(Range&&) noexcept = default;
-
     explicit constexpr Range(value_type left, Direction direction,
                              value_type right) noexcept
         : left_(left), right_(right), direction_(direction) {}
@@ -120,63 +26,68 @@ public:
         : left_(left),
           right_(right),
           direction_(left >= right ? Direction::DOWNTO : Direction::TO) {}
-    template <typename T>
-        requires requires { to_range(std::declval<T>()); }
-    explicit constexpr Range(T&& value)
-        : Range(to_range(std::forward<T>(value))) {}
 
 public:
     constexpr value_type left() const noexcept { return left_; }
     constexpr value_type right() const noexcept { return right_; }
     constexpr Direction direction() const noexcept { return direction_; }
     constexpr size_t length() const noexcept {
-        return std::max(0, direction_ == Direction::TO ? right_ - left_ + 1
-                                                       : left_ - right_ + 1);
+        int64_t len = direction_ == Direction::TO
+                          ? static_cast<int64_t>(right_) - left_ + 1
+                          : static_cast<int64_t>(left_) - right_ + 1;
+        if (len < 0) {
+            return 0;
+        }
+        return static_cast<size_t>(len);
     }
 
 public:
-    constexpr auto begin() const noexcept {
+    constexpr iterator begin() const noexcept {
         return iterator(left_, direction_);
-    };
-    constexpr auto end() const noexcept {
-        return iterator(
-            direction_ == Direction::TO ? left_ + length() : left_ - length(),
-            direction_);
-    };
-    constexpr auto rbegin() const noexcept {
-        return iterator(right_, direction_ == Direction::TO ? Direction::DOWNTO
-                                                            : Direction::TO);
-    };
-    constexpr auto rend() const noexcept {
-        return iterator(
-            direction_ == Direction::TO ? right_ - length() : right_ + length(),
-            direction_ == Direction::TO ? Direction::DOWNTO : Direction::TO);
-    };
+    }
+    constexpr iterator end() const noexcept {
+        const auto len = static_cast<value_type>(length());
+        const auto end_value =
+            direction_ == Direction::TO ? left_ + len : left_ - len;
+        return iterator(end_value, direction_);
+    }
+    constexpr iterator rbegin() const noexcept {
+        return iterator(right_, reversed_());
+    }
+    constexpr iterator rend() const noexcept {
+        const auto len = static_cast<value_type>(length());
+        const auto rend_value =
+            direction_ == Direction::TO ? right_ - len : right_ + len;
+        return iterator(rend_value, reversed_());
+    }
 
 public:
     constexpr value_type operator[](size_t index) const {
-        if (index >= static_cast<size_t>(length())) {
+        if (index >= length()) {
             throw std::out_of_range("Index out of range");
-        } else if (direction_ == Direction::TO) {
-            if (index >= length()) {
-                throw std::out_of_range("Index out of range");
-            }
-            return left_ + index;
-        } else {
-            if (index >= length()) {
-                throw std::out_of_range("Index out of range");
-            }
-            return left_ - index;
         }
+        if (direction_ == Direction::TO) {
+            return left_ + index;
+        }
+        return left_ - index;
     }
 
     constexpr Range operator()(size_t start, size_t stop) const {
+        if (stop > length()) {
+            throw std::out_of_range("Stop index out of range");
+        }
         if (start > stop) {
             throw std::invalid_argument(
                 "Start index must be less than or equal to stop index");
         }
-        auto new_left = this->operator[](start);
-        auto new_right = this->operator[](stop - 1);
+        const auto from_start = static_cast<int64_t>(start);
+        const auto from_last = static_cast<int64_t>(stop) - 1;
+        const auto new_left = static_cast<value_type>(
+            direction_ == Direction::TO ? left_ + from_start
+                                        : left_ - from_start);
+        const auto new_right = static_cast<value_type>(
+            direction_ == Direction::TO ? left_ + from_last
+                                        : left_ - from_last);
         return Range(new_left, direction_, new_right);
     }
 
@@ -186,61 +97,18 @@ public:
     }
 #endif
 
-    friend constexpr Range::iterator find(const Range& range,
-                                          Range::value_type value);
-
     friend constexpr bool operator==(const Range& lhs,
                                      const Range& rhs) noexcept;
 
-    friend class std::hash<coconext::types::Range>;
-
 private:
+    constexpr Direction reversed_() const noexcept {
+        return direction_ == Direction::TO ? Direction::DOWNTO : Direction::TO;
+    }
+
     value_type left_ = 0;
     value_type right_ = -1;
     Direction direction_ = Direction::TO;
 };
-
-constexpr bool operator==(const Range::iterator& lhs,
-                          const Range::iterator& rhs) noexcept {
-    return *lhs == *rhs;
-}
-
-constexpr bool operator!=(const Range::iterator& lhs,
-                          const Range::iterator& rhs) noexcept {
-    return !(lhs == rhs);
-}
-
-constexpr bool operator<(const Range::iterator& lhs,
-                         const Range::iterator& rhs) noexcept {
-    // We are assuming that the iterators are from the same range, so we don't
-    // need to check if the directions are the same. If they are from different
-    // Ranges, the behavior is undefined.
-    if (lhs.direction_ == Direction::TO) {
-        return *lhs < *rhs;
-    } else {
-        return *lhs > *rhs;
-    }
-}
-
-constexpr bool operator<=(const Range::iterator& lhs,
-                          const Range::iterator& rhs) noexcept {
-    return (lhs < rhs) || (lhs == rhs);
-}
-
-constexpr bool operator>(const Range::iterator& lhs,
-                         const Range::iterator& rhs) noexcept {
-    return !(lhs <= rhs);
-}
-
-constexpr bool operator>=(const Range::iterator& lhs,
-                          const Range::iterator& rhs) noexcept {
-    return !(lhs < rhs);
-}
-
-constexpr Range::iterator operator+(Range::iterator::difference_type n,
-                                    const Range::iterator& it) noexcept {
-    return it + n;
-}
 
 constexpr bool operator==(const Range& lhs, const Range& rhs) noexcept {
     if ((lhs.length() == 0) && (rhs.length() == 0)) {
@@ -252,16 +120,17 @@ constexpr bool operator==(const Range& lhs, const Range& rhs) noexcept {
 
 // more optimal implementation of std::ranges::find for Range
 constexpr Range::iterator find(const Range& range, Range::value_type value) {
-    if (range.direction_ == Direction::TO) {
-        if (value < range.left_ || value > range.right_) {
+    if (range.direction() == Direction::TO) {
+        if (value < range.left() || value > range.right()) {
             return range.end();
         }
+        return range.begin() + (value - range.left());
     } else {
-        if (value > range.left_ || value < range.right_) {
+        if (value > range.left() || value < range.right()) {
             return range.end();
         }
+        return range.begin() + (range.left() - value);
     }
-    return Range::iterator(value, range.direction_);
 }
 
 inline std::string to_string(const Range& range) {
@@ -282,12 +151,10 @@ static_assert(std::ranges::random_access_range<Range>);
 namespace std {
 
 template <>
-class hash<coconext::types::Range> {
-public:
+struct hash<coconext::types::Range> {
     size_t operator()(const coconext::types::Range& range) const noexcept {
-        return std::hash<coconext::types::Range::value_type>()(range.left_) ^
-               std::hash<coconext::types::Range::value_type>()(range.right_) ^
-               std::hash<coconext::types::Direction>()(range.direction_);
+        return coconext::types::detail::hash_combine(
+            range.left(), range.right(), range.direction());
     }
 };
 

--- a/cpp/tests/test_range.cpp
+++ b/cpp/tests/test_range.cpp
@@ -101,6 +101,11 @@ TEST(TestRange, BadGetitemEquivalent) {
     EXPECT_THROW((void)r(8, 4), std::invalid_argument);
 }
 
+TEST(TestRange, SliceStopOutOfRange) {
+    const Range r(1, Direction::TO, 5);
+    EXPECT_THROW((void)r(0, 100), std::out_of_range);
+}
+
 TEST(TestRange, Copy) {
     const Range r(-2, Direction::TO, 1);
     const Range copy_constructed(r);


### PR DESCRIPTION
Extracts Range::iterator into a reusable CountIterator template (parameterized on integer type) and rewrites Range to use it. This is done to support the future static Range object which will use the same runtime iterator. Also adds detail::hash_combine in hash.hpp for Range's std::hash specialization.