### PR TITLE
Prep changes for static ranged Array object

### DIFF
--- a/cpp/include/coconext/types/array.hpp
+++ b/cpp/include/coconext/types/array.hpp
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <initializer_list>
 #include <iterator>
+#include <memory>
 #include <ranges>
 #include <stdexcept>
 #include <string>
@@ -61,7 +62,7 @@ constexpr auto slice(ArrayT& arr, Range::value_type start,
         throw std::invalid_argument(
             "Slice direction does not match array range direction");
     }
-    return ArraySlice(&arr, Range(start, arr.range().direction(), end));
+    return ArraySlice(&arr, Range(start, arr.range().direction, end));
 }
 
 template <typename ArrayT>
@@ -111,7 +112,7 @@ public:  // indexing and slicing
             throw std::invalid_argument(
                 "Slice direction does not match array range direction");
         }
-        return ArraySlice(arr_, Range(start, range_.direction(), end));
+        return ArraySlice(arr_, Range(start, range_.direction, end));
     }
 #if __cplusplus >= 202302L
     constexpr ArraySlice operator[](index_type start, index_type end) const {
@@ -149,7 +150,7 @@ public:  // assignment
 
 public:  // iterators
     constexpr iterator begin() const noexcept {
-        auto start = find(arr_->range(), range_.left());
+        auto start = find(arr_->range(), range_.left);
         assert(start != arr_->range().end() &&
                "slice range not a sub-range of the owner's range");
         return arr_->begin() + std::distance(arr_->range().begin(), start);
@@ -182,11 +183,33 @@ public:
 public:
     constexpr Array() = delete;  // no default constructor
 
-public:  // ensure these are constexpr
+public:
     constexpr Array(Array&& other) = default;
     constexpr Array(const Array& other) = default;
-    constexpr Array& operator=(const Array& other) = default;
-    constexpr Array& operator=(Array&& other) = default;
+
+    // Weird but valid. const on members is semantically different than const on
+    // the whole object. Assignment is not valid on const variables (storage),
+    // but const on members (not storage, semantics) really just describes the
+    // behavioral intent and derived constness when operating on those fields,
+    // so assignment is still sound and the language lets us do this. The
+    // const_cast is required because libc++ insists on a non-const pointer
+    // for std::destroy_at / std::construct_at.
+    constexpr Array& operator=(const Array& other) {
+        if (this != &other) {
+            data_ = other.data_;
+            std::destroy_at(const_cast<Range*>(&range_));
+            std::construct_at(const_cast<Range*>(&range_), other.range_);
+        }
+        return *this;
+    }
+    constexpr Array& operator=(Array&& other) noexcept {
+        if (this != &other) {
+            data_ = std::move(other.data_);
+            std::destroy_at(const_cast<Range*>(&range_));
+            std::construct_at(const_cast<Range*>(&range_), other.range_);
+        }
+        return *this;
+    }
 
 public:  // construct with just range
     explicit constexpr Array(Range range)
@@ -304,7 +327,7 @@ public:  // iterators
 
 private:
     std::vector<value_type> data_;
-    Range range_;
+    const Range range_;
 };
 
 template <typename ValueT>

--- a/cpp/include/coconext/types/array.hpp
+++ b/cpp/include/coconext/types/array.hpp
@@ -269,15 +269,6 @@ public:  // construct from iterator
 
 public:  // attributes
     constexpr const Range& range() const noexcept { return range_; }
-    constexpr void set_range(const Range& range) {
-        if (range.length() != this->range().length()) {
-            throw std::invalid_argument(
-                "New range length " + std::to_string(range.length()) +
-                " does not match current range length " +
-                std::to_string(this->range().length()));
-        }
-        range_ = range;
-    }
 
 public:  // indexing and slicing
     constexpr value_type& operator[](index_type idx) {

--- a/cpp/include/coconext/types/direction.hpp
+++ b/cpp/include/coconext/types/direction.hpp
@@ -1,35 +1,18 @@
 #ifndef COCONEXT_DIRECTION_HPP
 #define COCONEXT_DIRECTION_HPP
 
-#include <cstdint>
 #include <stdexcept>
 #include <string_view>
 
 namespace coconext::types {
 
-class Direction {
-public:
-    enum class value_type : int8_t {
-        TO = 1,
-        DOWNTO = -1,
-    };
-    using enum value_type;
-
-public:
-    constexpr Direction() noexcept = default;
-    constexpr Direction(value_type value) noexcept : value_(value) {}
-    constexpr value_type value() const noexcept { return value_; }
-
-private:
-    value_type value_{TO};
+enum class Direction : bool {
+    TO = 0,
+    DOWNTO = 1,
 };
 
-constexpr bool operator==(const Direction& lhs, const Direction& rhs) noexcept {
-    return lhs.value() == rhs.value();
-}
-
-constexpr std::string_view to_string(const Direction& direction) noexcept {
-    if (direction.value() == Direction::TO) {
+constexpr std::string_view to_string(Direction direction) noexcept {
+    if (direction == Direction::TO) {
         return "to";
     } else {
         return "downto";
@@ -62,18 +45,5 @@ constexpr Direction to_direction(std::string_view value) {
 }
 
 }  // namespace coconext::types
-
-namespace std {
-
-template <>
-struct hash<coconext::types::Direction> {
-    size_t operator()(
-        const coconext::types::Direction& direction) const noexcept {
-        return std::hash<coconext::types::Direction::value_type>()(
-            direction.value());
-    }
-};
-
-}  // namespace std
 
 #endif  // COCONEXT_DIRECTION_HPP

--- a/cpp/include/coconext/types/range.hpp
+++ b/cpp/include/coconext/types/range.hpp
@@ -13,73 +13,71 @@
 
 namespace coconext::types {
 
-class Range {
-public:
+struct Range {
     using value_type = int32_t;
     using iterator = CountIterator<value_type>;
 
-public:
     constexpr Range() noexcept = default;
-    explicit constexpr Range(value_type left, Direction direction,
-                             value_type right) noexcept
-        : left_(left), right_(right), direction_(direction) {}
-    explicit constexpr Range(value_type left, value_type right) noexcept
-        : left_(left),
-          right_(right),
-          direction_(left >= right ? Direction::DOWNTO : Direction::TO) {}
+    explicit constexpr Range(value_type l, Direction d, value_type r) noexcept
+        : left(l), direction(d), right(r) {}
+    explicit constexpr Range(value_type l, value_type r) noexcept
+        : left(l),
+          direction(l >= r ? Direction::DOWNTO : Direction::TO),
+          right(r) {}
     explicit constexpr Range(size_t length)
-        : left_(0),
-          right_(static_cast<value_type>(length) - 1),
-          direction_(Direction::TO) {
+        : left(0),
+          direction(Direction::TO),
+          right(static_cast<value_type>(length) - 1) {
         if (length >
             static_cast<size_t>(std::numeric_limits<value_type>::max())) {
             throw std::length_error("Range length overflows value_type");
         }
     }
 
-public:
-    constexpr value_type left() const noexcept { return left_; }
-    constexpr value_type right() const noexcept { return right_; }
-    constexpr Direction direction() const noexcept { return direction_; }
+    value_type left = 0;
+    Direction direction = Direction::TO;
+    value_type right = -1;
+
     constexpr size_t length() const noexcept {
-        int64_t len = direction_ == Direction::TO
-                          ? static_cast<int64_t>(right_) - left_ + 1
-                          : static_cast<int64_t>(left_) - right_ + 1;
+        int64_t len = direction == Direction::TO
+                          ? static_cast<int64_t>(right) - left + 1
+                          : static_cast<int64_t>(left) - right + 1;
         if (len < 0) {
             return 0;
         }
         return static_cast<size_t>(len);
     }
 
-public:
     constexpr iterator begin() const noexcept {
-        return iterator(left_, direction_);
+        return iterator(left, direction);
     }
     constexpr iterator end() const noexcept {
         const auto len = static_cast<value_type>(length());
         const auto end_value =
-            direction_ == Direction::TO ? left_ + len : left_ - len;
-        return iterator(end_value, direction_);
+            direction == Direction::TO ? left + len : left - len;
+        return iterator(end_value, direction);
     }
     constexpr iterator rbegin() const noexcept {
-        return iterator(right_, reversed_());
+        return iterator(right, direction == Direction::TO ? Direction::DOWNTO
+                                                          : Direction::TO);
     }
     constexpr iterator rend() const noexcept {
         const auto len = static_cast<value_type>(length());
         const auto rend_value =
-            direction_ == Direction::TO ? right_ - len : right_ + len;
-        return iterator(rend_value, reversed_());
+            direction == Direction::TO ? right - len : right + len;
+        return iterator(rend_value, direction == Direction::TO
+                                        ? Direction::DOWNTO
+                                        : Direction::TO);
     }
 
-public:
     constexpr value_type operator[](size_t index) const {
         if (index >= length()) {
             throw std::out_of_range("Index out of range");
         }
-        if (direction_ == Direction::TO) {
-            return left_ + index;
+        if (direction == Direction::TO) {
+            return left + index;
         }
-        return left_ - index;
+        return left - index;
     }
 
     constexpr Range operator()(size_t start, size_t stop) const {
@@ -93,12 +91,10 @@ public:
         const auto from_start = static_cast<int64_t>(start);
         const auto from_last = static_cast<int64_t>(stop) - 1;
         const auto new_left = static_cast<value_type>(
-            direction_ == Direction::TO ? left_ + from_start
-                                        : left_ - from_start);
+            direction == Direction::TO ? left + from_start : left - from_start);
         const auto new_right = static_cast<value_type>(
-            direction_ == Direction::TO ? left_ + from_last
-                                        : left_ - from_last);
-        return Range(new_left, direction_, new_right);
+            direction == Direction::TO ? left + from_last : left - from_last);
+        return Range(new_left, direction, new_right);
     }
 
 #if __cplusplus >= 202302L
@@ -117,7 +113,7 @@ public:
             // lengths are equal and all zero-length ranges are equal
             return true;
         }
-        if (lhs.left_ != rhs.left_) {
+        if (lhs.left != rhs.left) {
             // lengths are equal and >= 1, so if left endpoints differ the
             // ranges cannot be equal
             return false;
@@ -129,39 +125,30 @@ public:
         // we already checked.
         return true;
     }
-
-private:
-    constexpr Direction reversed_() const noexcept {
-        return direction_ == Direction::TO ? Direction::DOWNTO : Direction::TO;
-    }
-
-    value_type left_ = 0;
-    value_type right_ = -1;
-    Direction direction_ = Direction::TO;
 };
 
 // more optimal implementation of std::ranges::find for Range
 constexpr Range::iterator find(const Range& range, Range::value_type value) {
-    if (range.direction() == Direction::TO) {
-        if (value < range.left() || value > range.right()) {
+    if (range.direction == Direction::TO) {
+        if (value < range.left || value > range.right) {
             return range.end();
         }
-        return range.begin() + (value - range.left());
+        return range.begin() + (value - range.left);
     } else {
-        if (value > range.left() || value < range.right()) {
+        if (value > range.left || value < range.right) {
             return range.end();
         }
-        return range.begin() + (range.left() - value);
+        return range.begin() + (range.left - value);
     }
 }
 
 inline std::string to_string(const Range& range) {
     auto res = std::string("Range(");
-    res += std::to_string(range.left());
+    res += std::to_string(range.left);
     res += ", '";
-    res += to_string(range.direction());
+    res += to_string(range.direction);
     res += "', ";
-    res += std::to_string(range.right());
+    res += std::to_string(range.right);
     res += ")";
     return res;
 }
@@ -181,10 +168,10 @@ struct hash<coconext::types::Range> {
         if (len == 0) {
             return hash<size_t>{}(0);
         } else if (len == 1) {
-            return hash<coconext::types::Range::value_type>{}(range.left());
+            return hash<coconext::types::Range::value_type>{}(range.left);
         } else {
             return coconext::types::detail::hash_combine(
-                range.left(), range.right(), range.direction());
+                range.left, range.right, range.direction);
         }
     }
 };

--- a/cpp/tests/test_array.cpp
+++ b/cpp/tests/test_array.cpp
@@ -14,9 +14,9 @@ using namespace coconext::types;
 
 TEST(TestArray, ConstructFromInitializerList) {
     Array<int> a({1, 2, 3, 4});
-    EXPECT_EQ(a.range().left(), 0);
-    EXPECT_EQ(a.range().right(), 3);
-    EXPECT_EQ(a.range().direction(), Direction::TO);
+    EXPECT_EQ(a.range().left, 0);
+    EXPECT_EQ(a.range().right, 3);
+    EXPECT_EQ(a.range().direction, Direction::TO);
 }
 
 TEST(TestArray, ConstructFromInitializerListEmpty) {
@@ -478,6 +478,29 @@ TEST(TestArray, Move) {
     Array<int> b = std::move(a);
     EXPECT_EQ(b.range().length(), 4U);
     EXPECT_EQ(b[0], 1);
+}
+
+TEST(TestArray, CopyAssignReplacesRange) {
+    // range_ is const, so assignment goes through the custom operator= which
+    // reconstructs range_ in place. Verify both data and range get replaced.
+    Array<int> a({1, 2, 3});  // range: 0 TO 2
+    Array<int> b(std::vector<int>{10, 20, 30, 40},
+                 Range(7, Direction::DOWNTO, 4));
+    a = b;
+    EXPECT_EQ(a, b);
+    EXPECT_EQ(a.range(), Range(7, Direction::DOWNTO, 4));
+    EXPECT_EQ(a[7], 10);
+    EXPECT_EQ(a[4], 40);
+}
+
+TEST(TestArray, MoveAssignReplacesRange) {
+    Array<int> a({1, 2, 3});
+    Array<int> b(std::vector<int>{10, 20, 30, 40},
+                 Range(7, Direction::DOWNTO, 4));
+    a = std::move(b);
+    EXPECT_EQ(a.range(), Range(7, Direction::DOWNTO, 4));
+    EXPECT_EQ(a[7], 10);
+    EXPECT_EQ(a[4], 40);
 }
 
 // -- to_string --------------------------------------------------------------

--- a/cpp/tests/test_array.cpp
+++ b/cpp/tests/test_array.cpp
@@ -104,23 +104,11 @@ TEST(TestArray, ConstructFromIteratorPairLengthMismatch) {
                  std::invalid_argument);
 }
 
-// -- range() / set_range() --------------------------------------------------
+// -- range() ----------------------------------------------------------------
 
 TEST(TestArray, RangeAccessor) {
     Array<int> a({1, 2, 3});
     EXPECT_EQ(a.range(), Range(0, Direction::TO, 2));
-}
-
-TEST(TestArray, SetRangeMatchingLength) {
-    Array<int> a({1, 2, 3, 4});
-    a.set_range(Range(3, Direction::DOWNTO, 0));
-    EXPECT_EQ(a.range(), Range(3, Direction::DOWNTO, 0));
-}
-
-TEST(TestArray, SetRangeMismatchedLength) {
-    Array<int> a({1, 2, 3, 4});
-    EXPECT_THROW(a.set_range(Range(0, Direction::TO, 7)),
-                 std::invalid_argument);
 }
 
 // -- Iteration --------------------------------------------------------------
@@ -146,15 +134,14 @@ TEST(TestArray, IterationConst) {
 // -- Indexing ---------------------------------------------------------------
 
 TEST(TestArray, IndexingTO) {
-    Array<int> a({10, 20, 30, 40});
-    a.set_range(Range(8, Direction::TO, 11));
+    Array<int> a(std::vector<int>{10, 20, 30, 40}, Range(8, Direction::TO, 11));
     EXPECT_EQ(a[8], 10);
     EXPECT_EQ(a[11], 40);
 }
 
 TEST(TestArray, IndexingDOWNTO) {
-    Array<int> a({10, 20, 30, 40});
-    a.set_range(Range(10, Direction::DOWNTO, 7));
+    Array<int> a(std::vector<int>{10, 20, 30, 40},
+                 Range(10, Direction::DOWNTO, 7));
     EXPECT_EQ(a[10], 10);
     EXPECT_EQ(a[7], 40);
 }
@@ -166,8 +153,7 @@ TEST(TestArray, IndexingMutates) {
 }
 
 TEST(TestArray, IndexingOutOfRange) {
-    Array<int> a({1, 2, 3});
-    a.set_range(Range(8, Direction::TO, 10));
+    Array<int> a(std::vector<int>{1, 2, 3}, Range(8, Direction::TO, 10));
     EXPECT_THROW((void)a[0], std::out_of_range);
     EXPECT_THROW((void)a[100], std::out_of_range);
 }
@@ -191,8 +177,8 @@ TEST(TestArray, SliceTO) {
 }
 
 TEST(TestArray, SliceDOWNTO) {
-    Array<int> a({10, 20, 30, 40});
-    a.set_range(Range(3, Direction::DOWNTO, 0));
+    Array<int> a(std::vector<int>{10, 20, 30, 40},
+                 Range(3, Direction::DOWNTO, 0));
     auto s = a(2, 1);
     EXPECT_EQ(s.range().length(), 2U);
     EXPECT_EQ(s[2], 20);
@@ -239,8 +225,8 @@ TEST(TestArray, SliceEndOutOfRange) {
 }
 
 TEST(TestArray, SliceDirectionMismatch) {
-    Array<int> a({1, 2, 3, 4, 5});
-    a.set_range(Range(4, Direction::DOWNTO, 0));
+    Array<int> a(std::vector<int>{1, 2, 3, 4, 5},
+                 Range(4, Direction::DOWNTO, 0));
     // start=0, end=4 walks against the array's DOWNTO direction.
     EXPECT_THROW((void)a(0, 4), std::invalid_argument);
 }
@@ -270,8 +256,8 @@ TEST(TestArray, SliceOfSliceEndOutOfRange) {
 }
 
 TEST(TestArray, SliceOfSliceDirectionMismatch) {
-    Array<int> a({1, 2, 3, 4, 5});
-    a.set_range(Range(4, Direction::DOWNTO, 0));
+    Array<int> a(std::vector<int>{1, 2, 3, 4, 5},
+                 Range(4, Direction::DOWNTO, 0));
     auto s1 = a(4, 1);  // DOWNTO slice over coords 4..1
     // Asking for start=1, end=4 walks against s1's DOWNTO direction.
     EXPECT_THROW((void)s1(1, 4), std::invalid_argument);
@@ -296,8 +282,8 @@ TEST(TestArray, SliceConstEndOutOfRange) {
 }
 
 TEST(TestArray, SliceConstDirectionMismatch) {
-    Array<int> mut({1, 2, 3, 4, 5});
-    mut.set_range(Range(4, Direction::DOWNTO, 0));
+    Array<int> mut(std::vector<int>{1, 2, 3, 4, 5},
+                   Range(4, Direction::DOWNTO, 0));
     const Array<int>& a = mut;
     EXPECT_THROW((void)a(0, 4), std::invalid_argument);
 }
@@ -310,8 +296,8 @@ TEST(TestArray, ConstSliceErrors) {
 }
 
 TEST(TestArray, ConstSliceDirectionMismatch) {
-    Array<int> mut({1, 2, 3, 4, 5});
-    mut.set_range(Range(4, Direction::DOWNTO, 0));
+    Array<int> mut(std::vector<int>{1, 2, 3, 4, 5},
+                   Range(4, Direction::DOWNTO, 0));
     const Array<int>& a = mut;
     auto s = a(4, 0);
     EXPECT_THROW((void)s(0, 4), std::invalid_argument);
@@ -397,8 +383,7 @@ TEST(TestArray, InequalityDifferentRange) {
     // Arrays with different ranges have different indexing semantics, so they
     // are not substitutable and must not compare equal.
     Array<int> a({1, 2, 3});
-    Array<int> b({1, 2, 3});
-    b.set_range(Range(10, Direction::DOWNTO, 8));
+    Array<int> b(std::vector<int>{1, 2, 3}, Range(10, Direction::DOWNTO, 8));
     EXPECT_NE(a, b);
 }
 
@@ -436,8 +421,7 @@ TEST(TestArray, HashEmptyArraysWithDifferentBounds) {
     // arrays with any range bounds compare equal and must hash equal.
     std::hash<Array<int>> h;
     Array<int> a({});
-    Array<int> b({});
-    b.set_range(Range(5, Direction::DOWNTO, 8));  // length 0, different bounds
+    Array<int> b(std::vector<int>{}, Range(5, Direction::DOWNTO, 8));
     EXPECT_EQ(a, b);
     EXPECT_EQ(h(a), h(b));
 }
@@ -448,8 +432,7 @@ TEST(TestArray, HashSingleElementSameLeftDifferentDirection) {
     // and must hash equal.
     std::hash<Array<int>> h;
     Array<int> a({42});  // range: 0 TO 0
-    Array<int> b({42});
-    b.set_range(Range(0, Direction::DOWNTO, 0));
+    Array<int> b(std::vector<int>{42}, Range(0, Direction::DOWNTO, 0));
     EXPECT_EQ(a, b);
     EXPECT_EQ(h(a), h(b));
 }
@@ -457,15 +440,13 @@ TEST(TestArray, HashSingleElementSameLeftDifferentDirection) {
 TEST(TestArray, MultiElementDifferentRangeNotEqual) {
     // For length >= 2, range direction and bounds matter for indexing.
     Array<int> a({1, 2, 3});
-    Array<int> b({1, 2, 3});
-    b.set_range(Range(10, Direction::DOWNTO, 8));
+    Array<int> b(std::vector<int>{1, 2, 3}, Range(10, Direction::DOWNTO, 8));
     EXPECT_NE(a, b);
 }
 
 TEST(TestArray, UnorderedSetDistinguishesByRange) {
     Array<int> a({1, 2, 3});
-    Array<int> b({1, 2, 3});
-    b.set_range(Range(10, Direction::DOWNTO, 8));
+    Array<int> b(std::vector<int>{1, 2, 3}, Range(10, Direction::DOWNTO, 8));
     std::unordered_set<Array<int>> s;
     s.insert(a);
     s.insert(b);
@@ -474,8 +455,7 @@ TEST(TestArray, UnorderedSetDistinguishesByRange) {
 
 TEST(TestArray, UnorderedSetDeduplicatesEmptyArrays) {
     Array<int> a({});
-    Array<int> b({});
-    b.set_range(Range(5, Direction::DOWNTO, 8));
+    Array<int> b(std::vector<int>{}, Range(5, Direction::DOWNTO, 8));
     std::unordered_set<Array<int>> s;
     s.insert(a);
     s.insert(b);
@@ -485,8 +465,7 @@ TEST(TestArray, UnorderedSetDeduplicatesEmptyArrays) {
 // -- Copy semantics ---------------------------------------------------------
 
 TEST(TestArray, Copy) {
-    Array<int> a({1, 2, 3, 4});
-    a.set_range(Range(-2, Direction::TO, 1));
+    Array<int> a(std::vector<int>{1, 2, 3, 4}, Range(-2, Direction::TO, 1));
     Array<int> b = a;
     EXPECT_EQ(a, b);
     EXPECT_EQ(a.range(), b.range());

--- a/cpp/tests/test_range.cpp
+++ b/cpp/tests/test_range.cpp
@@ -9,9 +9,9 @@ using namespace coconext::types;
 
 TEST(TestRange, ToRange) {
     const Range r(1, Direction::TO, 8);
-    EXPECT_EQ(r.left(), 1);
-    EXPECT_EQ(r.direction(), Direction::TO);
-    EXPECT_EQ(r.right(), 8);
+    EXPECT_EQ(r.left, 1);
+    EXPECT_EQ(r.direction, Direction::TO);
+    EXPECT_EQ(r.right, 8);
     EXPECT_EQ(r.length(), 8U);
 
     const std::vector<int32_t> forward(r.begin(), r.end());
@@ -31,9 +31,9 @@ TEST(TestRange, ToRange) {
 
 TEST(TestRange, DowntoRange) {
     const Range r(4, Direction::DOWNTO, -3);
-    EXPECT_EQ(r.left(), 4);
-    EXPECT_EQ(r.direction(), Direction::DOWNTO);
-    EXPECT_EQ(r.right(), -3);
+    EXPECT_EQ(r.left, 4);
+    EXPECT_EQ(r.direction, Direction::DOWNTO);
+    EXPECT_EQ(r.right, -3);
     EXPECT_EQ(r.length(), 8U);
 
     const std::vector<int32_t> forward(r.begin(), r.end());
@@ -53,9 +53,9 @@ TEST(TestRange, DowntoRange) {
 
 TEST(TestRange, NullRange) {
     const Range r(1, Direction::DOWNTO, 4);
-    EXPECT_EQ(r.left(), 1);
-    EXPECT_EQ(r.direction(), Direction::DOWNTO);
-    EXPECT_EQ(r.right(), 4);
+    EXPECT_EQ(r.left, 1);
+    EXPECT_EQ(r.direction, Direction::DOWNTO);
+    EXPECT_EQ(r.right, 4);
     EXPECT_EQ(r.length(), 0U);
 
     const std::vector<int32_t> forward(r.begin(), r.end());
@@ -106,7 +106,7 @@ TEST(TestRange, ReprEquivalent) {
 
 TEST(TestRange, UppercaseDirection) {
     const Range r(1, to_direction("TO"), 8);
-    EXPECT_EQ(r.direction(), Direction::TO);
+    EXPECT_EQ(r.direction, Direction::TO);
 }
 
 TEST(TestRange, BadGetitemEquivalent) {

--- a/nanobind/src/types/bind_range.cpp
+++ b/nanobind/src/types/bind_range.cpp
@@ -16,13 +16,13 @@ using namespace coconext::types;
 void register_range(nb::module_& m) {
     nb::object range_func = nb::module_::import_("builtins").attr("range");
 
-    nb::enum_<Direction::value_type>(m, "Direction")
+    nb::enum_<Direction>(m, "Direction")
         .value("TO", Direction::TO)
         .value("DOWNTO", Direction::DOWNTO);
 
     nb::class_<Range>(m, "Range")
-        .def(nb::init<int32_t, Direction::value_type, int32_t>(),
-             "left"_a.noconvert(), "direction"_a, "right"_a.noconvert())
+        .def(nb::init<int32_t, Direction, int32_t>(), "left"_a.noconvert(),
+             "direction"_a, "right"_a.noconvert())
         .def(
             "__init__",
             [](Range* self, int32_t left, std::string_view direction,

--- a/nanobind/src/types/bind_range.cpp
+++ b/nanobind/src/types/bind_range.cpp
@@ -35,9 +35,9 @@ void register_range(nb::module_& m) {
              "right"_a.noconvert())
         .def("to_range",
              [](const Range& self) {
-                 auto step_c = (self.direction() == Direction::TO) ? 1 : -1;
-                 auto start = nb::cast(self.left());
-                 auto stop = nb::cast(self.right() + step_c);
+                 auto step_c = (self.direction == Direction::TO) ? 1 : -1;
+                 auto start = nb::cast(self.left);
+                 auto stop = nb::cast(self.right + step_c);
                  auto step = nb::cast(step_c);
                  auto range_type =
                      nb::module_::import_("builtins").attr("range");
@@ -61,35 +61,33 @@ void register_range(nb::module_& m) {
                 return Range(start, direction, right);
             },
             "range"_a)
-        .def_prop_ro("left", &Range::left)
-        .def_prop_ro("right", &Range::right)
+        .def_ro("left", &Range::left)
+        .def_ro("right", &Range::right)
         .def_prop_ro(
             "direction",
-            [](const Range& self) { return to_string(self.direction()); })
+            [](const Range& self) { return to_string(self.direction); })
         .def("__len__", [](const Range& self) { return self.length(); })
         .def(
             "__contains__",
             [](const Range& self, int32_t index) {
-                return (self.direction() == Direction::TO)
-                           ? (index >= self.left() && index <= self.right())
-                           : (index <= self.left() && index >= self.right());
+                return (self.direction == Direction::TO)
+                           ? (index >= self.left && index <= self.right)
+                           : (index <= self.left && index >= self.right);
             },
             nb::arg().noconvert())
         .def("__iter__",
              [range_func](const Range& self) {
                  return nb::iter(range_func(
-                     self.left(),
-                     self.right() +
-                         ((self.direction() == Direction::TO) ? 1 : -1),
-                     (self.direction() == Direction::TO) ? 1 : -1));
+                     self.left,
+                     self.right + ((self.direction == Direction::TO) ? 1 : -1),
+                     (self.direction == Direction::TO) ? 1 : -1));
              })
         .def("__reversed__",
              [range_func](const Range& self) {
                  return nb::iter(range_func(
-                     self.right(),
-                     self.left() -
-                         ((self.direction() == Direction::TO) ? 1 : -1),
-                     (self.direction() == Direction::TO) ? -1 : 1));
+                     self.right,
+                     self.left - ((self.direction == Direction::TO) ? 1 : -1),
+                     (self.direction == Direction::TO) ? -1 : 1));
              })
         .def("__getitem__", &Range::operator[], nb::arg().noconvert())
         .def(
@@ -122,12 +120,10 @@ void register_range(nb::module_& m) {
             [](const Range& self, int32_t value) noexcept {
                 // TODO Handle the fact that non-integer values should return 0
                 // rather than throwing
-                return (self.direction() == Direction::TO)
-                           ? (value >= self.left() && value <= self.right() ? 1
-                                                                            : 0)
-                           : (value <= self.left() && value >= self.right()
-                                  ? 1
-                                  : 0);
+                return (self.direction == Direction::TO)
+                           ? (value >= self.left && value <= self.right ? 1 : 0)
+                           : (value <= self.left && value >= self.right ? 1
+                                                                        : 0);
             },
             nb::arg().noconvert())
         .def("__copy__", [](const Range& self) { return Range(self); })


### PR DESCRIPTION
xref #172. The overall intent here is to make Range a structural type so we can use it as a non-type template parameter in a static-Ranged Array type:

```c++
template <typename T, Range R>
class StaticArray;
```

To accomplish that we needed to make Direction a structural type, which we did by simply removing the wrapper class. Since the left, right, and direction fields of Ranges are now publicly exposed, we have to worry about users changing those fields on an Array's Range breaking the invariant between the data and range, so we made Array's Range const, which required us to remove the `Array.set_range` method, which we don't care about since we aren't intending this to be a type that sits in place of the Python Array object.