### PR TITLE
Add StaticArray<T, Range R>

### DIFF
--- a/cpp/include/coconext/types.hpp
+++ b/cpp/include/coconext/types.hpp
@@ -3,12 +3,14 @@
 
 // NOLINTBEGIN(unused-includes)
 #include "./types/array.hpp"
+#include "./types/array_base.hpp"
 #include "./types/concepts.hpp"
 #include "./types/direction.hpp"
 #include "./types/dynamic_array.hpp"
 #include "./types/logic.hpp"
 #include "./types/logic_array.hpp"
 #include "./types/range.hpp"
+#include "./types/static_array.hpp"
 // NOLINTEND(unused-includes)
 
 #endif  // COCONEXT_TYPES_HPP

--- a/cpp/include/coconext/types/array.hpp
+++ b/cpp/include/coconext/types/array.hpp
@@ -1,23 +1,115 @@
 #ifndef COCONEXT_ARRAY_HPP
 #define COCONEXT_ARRAY_HPP
 
+#include <coconext/types/direction.hpp>
 #include <coconext/types/dynamic_array.hpp>
+#include <coconext/types/range.hpp>
+#include <coconext/types/static_array.hpp>
+#include <concepts>
+#include <cstddef>
+#include <limits>
+#include <tuple>
+#include <type_traits>
 
 namespace coconext::types {
 
 namespace detail {
 
-// Dispatcher customization point selecting the array implementation backing Array<T, ...>.
-template <typename T>
+// Build a static Range from the trailing template arguments of Array<T, ...>.
+//   1 arg, integral N                -> Range(N)              i.e. {0, TO, N-1}
+//   1 arg, Range R                   -> R
+//   2 args, (left, right)            -> Range{left, right}    direction inferred
+//   3 args, (left, Direction, right) -> Range{left, dir, right}
+// Compile-time check that an integral NTTP value fits in
+// Range::value_type without silent narrowing. Used by the 2/3-arg branches
+// of make_static_range below to give a clean diagnostic instead of a
+// silently-truncating static_cast.
+template <auto V>
+constexpr bool fits_range_value_type =
+    static_cast<long long>(V) >= std::numeric_limits<Range::value_type>::min()
+    && static_cast<long long>(V) <= std::numeric_limits<Range::value_type>::max();
+
+template <auto... Args>
+constexpr Range make_static_range() {
+    using std::get;
+    static_assert(
+        sizeof...(Args) >= 1 && sizeof...(Args) <= 3,
+        "Array<T, ...> takes 0 args (dynamic) or 1-3 range args (static)"
+    );
+    constexpr auto t = std::tuple{Args...};
+    if constexpr (sizeof...(Args) == 1) {
+        using First = std::remove_cvref_t<decltype(get<0>(t))>;
+        static_assert(
+            std::is_same_v<First, Range> || std::integral<First>,
+            "single template arg must be a Range value or an integral length"
+        );
+        if constexpr (std::is_same_v<First, Range>) {
+            return get<0>(t);
+        } else {
+            static_assert(get<0>(t) >= 0, "Array<T, N>: N (length) must be non-negative");
+            return Range(static_cast<size_t>(get<0>(t)));
+        }
+    } else if constexpr (sizeof...(Args) == 2) {
+        static_assert(
+            fits_range_value_type<get<0>(t)>,
+            "Array<T, L, H>: L does not fit in Range::value_type (int32_t)"
+        );
+        static_assert(
+            fits_range_value_type<get<1>(t)>,
+            "Array<T, L, H>: H does not fit in Range::value_type (int32_t)"
+        );
+        return Range{
+            static_cast<Range::value_type>(get<0>(t)),
+            static_cast<Range::value_type>(get<1>(t))
+        };
+    } else {  // 3
+        static_assert(
+            std::is_same_v<std::remove_cvref_t<decltype(get<1>(t))>, Direction>,
+            "three-arg form requires (left, Direction, right)"
+        );
+        static_assert(
+            fits_range_value_type<get<0>(t)>,
+            "Array<T, L, D, H>: L does not fit in Range::value_type (int32_t)"
+        );
+        static_assert(
+            fits_range_value_type<get<2>(t)>,
+            "Array<T, L, D, H>: H does not fit in Range::value_type (int32_t)"
+        );
+        return Range{
+            static_cast<Range::value_type>(get<0>(t)),
+            get<1>(t),
+            static_cast<Range::value_type>(get<2>(t))
+        };
+    }
+}
+
+// Dispatcher customization point selecting the array implementation backing
+// Array<T, ...>. The empty-pack primary resolves to DynamicArray<T>; the
+// non-empty pack specialization resolves to StaticArray<T, R> with R built
+// from the trailing args by make_static_range.
+template <typename T, auto... Args>
 struct ArrayImpl {
+    using type = StaticArray<T, make_static_range<Args...>()>;
+};
+
+template <typename T>
+struct ArrayImpl<T> {
     using type = DynamicArray<T>;
 };
 
 }  // namespace detail
 
-// Unified entry point for the array types.
-template <typename T>
-using Array = typename detail::ArrayImpl<T>::type;
+// Unified entry point for the array types. The number and types of the
+// non-type template arguments select the underlying class:
+//   Array<T>                                -> DynamicArray<T>
+//   Array<T, N>           (integral N)      -> StaticArray<T, Range(N)>
+//                                              i.e. {0, TO, N-1}
+//   Array<T, R>           (Range R)         -> StaticArray<T, R>
+//   Array<T, L, H>        (integral L, H)   -> StaticArray<T, Range{L, H}>
+//                                              direction inferred from L vs H
+//   Array<T, L, D, H>     (D = Direction)   -> StaticArray<T, Range{L, D, H}>
+template <typename T, auto... Args>
+using Array = typename detail::ArrayImpl<T, Args...>::type;
 
 }  // namespace coconext::types
 

--- a/cpp/include/coconext/types/array_base.hpp
+++ b/cpp/include/coconext/types/array_base.hpp
@@ -1,0 +1,178 @@
+#ifndef COCONEXT_ARRAY_BASE_HPP
+#define COCONEXT_ARRAY_BASE_HPP
+
+#include <algorithm>
+#include <cassert>
+#include <coconext/types/concepts.hpp>
+#include <coconext/types/range.hpp>
+#include <concepts>
+#include <cstddef>
+#include <format>
+#include <initializer_list>
+#include <iterator>
+#include <ranges>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+
+namespace coconext::types {
+
+namespace detail {
+
+template <typename R>
+concept sized_input_range = std::ranges::sized_range<R> && std::ranges::input_range<R>;
+
+constexpr void subsequence_check(Range parent, Range child) {
+    if (!is_subsequence(parent, child)) {
+        throw std::invalid_argument("Range is not a valid sub-range of the parent");
+    }
+}
+
+}  // namespace detail
+
+// The minimum a type must expose so that index() and slice() can be
+// implemented for it externally.
+template <typename T>
+concept RangedSequence = std::ranges::random_access_range<T> && requires(T& t) {
+    { t.range() } -> std::convertible_to<Range>;
+};
+
+template <typename ArrayT>
+class ArraySlice;
+
+template <typename ArrayT>
+class ArraySlice {
+  public:
+    // ArraySlice is a non-owning view (like std::span). Element mutability is
+    // determined by ArrayT's constness:
+    // - ArraySlice<ArrayT>          -- mutable view, can write elements.
+    // - ArraySlice<const ArrayT>    -- read-only view.
+    // - const ArraySlice<X>         -- pointer/range fixed; element access
+    //                                  follows X's mutability rules.
+    using value_type = std::ranges::range_value_t<ArrayT>;
+    using reference = std::ranges::range_reference_t<ArrayT>;
+    using index_type = Range::value_type;
+    using iterator = std::ranges::iterator_t<ArrayT>;
+    static_assert(!std::is_reference_v<value_type>);
+
+    constexpr ArraySlice() = delete;
+    constexpr ArraySlice(ArraySlice const&) = default;
+    constexpr ArraySlice(ArraySlice&&) = default;
+    constexpr ArraySlice(ArrayT* arr, Range range) noexcept : arr_(arr), range_(range) {}
+
+    constexpr Range const& range() const noexcept { return range_; }
+
+    // Element access bounds-checks against this slice's range_, not the
+    // owner's range. An idx that's valid in the owner but outside the slice
+    // is out-of-range.
+    constexpr reference operator[](index_type idx) const {
+        auto it = find(range_, idx);
+        if (it == range_.end()) {
+            throw std::out_of_range("Index out of bounds");
+        }
+        return *(begin() + std::distance(range_.begin(), it));
+    }
+    // Sub-slicing flattens: returns a new ArraySlice over the same underlying
+    // array with a new range. Validity is checked against the slice's own
+    // range_, not arr_->range().
+    constexpr ArraySlice operator[](Range r) const {
+        detail::subsequence_check(range_, r);
+        return ArraySlice(arr_, r);
+    }
+
+    template <detail::sized_input_range R>
+        requires(!std::is_const_v<ArrayT>)
+             && std::convertible_to<std::ranges::range_value_t<R>, value_type>
+    constexpr ArraySlice const& operator=(R const& obj) const {
+        if (std::ranges::size(obj) != range_.length()) {
+            throw std::invalid_argument(
+                "Value of length " + std::to_string(std::ranges::size(obj))
+                + " cannot be assigned to array slice of length "
+                + std::to_string(range_.length())
+            );
+        }
+        std::ranges::copy(obj, begin());
+        return *this;
+    }
+
+    template <typename T>
+        requires(!std::is_const_v<ArrayT>) && std::convertible_to<T, value_type>
+    constexpr ArraySlice const& operator=(std::initializer_list<T> init) const {
+        if (init.size() != static_cast<size_t>(range_.length())) {
+            throw std::invalid_argument(
+                "Initializer list of size " + std::to_string(init.size())
+                + " cannot be assigned to array slice of length "
+                + std::to_string(range_.length())
+            );
+        }
+        std::ranges::copy(init, begin());
+        return *this;
+    }
+
+    constexpr iterator begin() const noexcept {
+        // Null slices may carry bounds outside the parent's range (the
+        // validity rule allows that). Pin them to the parent's begin so
+        // begin()/end() form a well-formed empty iterator pair.
+        if (range_.length() == 0) {
+            return arr_->begin();
+        }
+        auto start = find(arr_->range(), range_.left);
+        assert(
+            start != arr_->range().end()
+            && "slice range not a sub-range of the owner's range"
+        );
+        return arr_->begin() + std::distance(arr_->range().begin(), start);
+    }
+    constexpr iterator end() const noexcept { return begin() + range_.length(); }
+    constexpr auto rbegin() const noexcept { return std::reverse_iterator(end()); }
+    constexpr auto rend() const noexcept { return std::reverse_iterator(begin()); }
+
+  private:
+    ArrayT* arr_;
+    Range range_;
+};
+
+namespace detail {
+
+// Walks a RangedSequence, emitting "[range]{elem, elem, ...}" via the formatter
+// for each element type. Used by the generic Array/Slice formatters.
+template <RangedSequence ArrayT, typename OutIt>
+    requires Formattable<std::ranges::range_value_t<ArrayT>>
+OutIt format_array(ArrayT const& arr, OutIt out) {
+    out = std::format_to(out, "{}{{", arr.range());
+    bool first = true;
+    for (auto const& elem : arr) {
+        if (!first) {
+            out = std::format_to(out, ", ");
+        }
+        out = std::format_to(out, "{}", elem);
+        first = false;
+    }
+    *out++ = '}';
+    return out;
+}
+
+}  // namespace detail
+
+}  // namespace coconext::types
+
+template <typename ArrayT>
+    requires coconext::types::detail::Formattable<
+        std::ranges::range_value_t<coconext::types::ArraySlice<ArrayT>>>
+struct std::formatter<coconext::types::ArraySlice<ArrayT>> {
+    constexpr auto parse(std::format_parse_context& ctx) {
+        auto it = ctx.begin();
+        if (it != ctx.end() && *it != '}') {
+            throw std::format_error("ArraySlice formatter takes no format spec");
+        }
+        return it;
+    }
+
+    auto format(
+        coconext::types::ArraySlice<ArrayT> const& arr, std::format_context& ctx
+    ) const {
+        return coconext::types::detail::format_array(arr, ctx.out());
+    }
+};
+
+#endif  // COCONEXT_ARRAY_BASE_HPP

--- a/cpp/include/coconext/types/dynamic_array.hpp
+++ b/cpp/include/coconext/types/dynamic_array.hpp
@@ -2,7 +2,9 @@
 #define COCONEXT_DYNAMIC_ARRAY_HPP
 
 #include <algorithm>
+#include <coconext/types/array_base.hpp>
 #include <coconext/types/concepts.hpp>
+#include <coconext/types/hash.hpp>
 #include <coconext/types/range.hpp>
 #include <concepts>
 #include <cstddef>
@@ -25,121 +27,6 @@
 #endif
 
 namespace coconext::types {
-
-namespace detail {
-
-template <typename R>
-concept sized_input_range = std::ranges::sized_range<R> && std::ranges::input_range<R>;
-
-constexpr void subsequence_check(Range parent, Range child) {
-    if (!is_subsequence(parent, child)) {
-        throw std::invalid_argument("Range is not a valid sub-range of the parent");
-    }
-}
-
-}  // namespace detail
-
-// The minimum a type must expose so that index() and slice() can be
-// implemented for it externally.
-template <typename T>
-concept RangedSequence = std::ranges::random_access_range<T> && requires(T& t) {
-    { t.range() } -> std::convertible_to<Range>;
-};
-
-template <typename ArrayT>
-class ArraySlice;
-
-template <typename ArrayT>
-class ArraySlice {
-  public:
-    // ArraySlice is a non-owning view (like std::span). Element mutability is
-    // determined by ArrayT's constness:
-    // - ArraySlice<DynamicArray<T>>          -- mutable view, can write elements.
-    // - ArraySlice<const DynamicArray<T>>    -- read-only view.
-    // - const ArraySlice<X>                  -- pointer/range fixed; element access
-    //                                           follows X's mutability rules.
-    using value_type = std::ranges::range_value_t<ArrayT>;
-    using reference = std::ranges::range_reference_t<ArrayT>;
-    using index_type = Range::value_type;
-    using iterator = std::ranges::iterator_t<ArrayT>;
-    static_assert(!std::is_reference_v<value_type>);
-
-    constexpr ArraySlice() = delete;
-    constexpr ArraySlice(ArraySlice const&) = default;
-    constexpr ArraySlice(ArraySlice&&) = default;
-    constexpr ArraySlice(ArrayT* arr, Range range) noexcept : arr_(arr), range_(range) {}
-
-    constexpr Range const& range() const noexcept { return range_; }
-
-    // Element access bounds-checks against this slice's range_, not the
-    // owner's range. An idx that's valid in the owner but outside the slice
-    // is out-of-range.
-    constexpr reference operator[](index_type idx) const {
-        auto it = find(range_, idx);
-        if (it == range_.end()) {
-            throw std::out_of_range("Index out of bounds");
-        }
-        return *(begin() + std::distance(range_.begin(), it));
-    }
-    // Sub-slicing flattens: returns a new ArraySlice over the same underlying
-    // array with a new range. Validity is checked against the slice's own
-    // range_, not arr_->range().
-    constexpr ArraySlice operator[](Range r) const {
-        detail::subsequence_check(range_, r);
-        return ArraySlice(arr_, r);
-    }
-
-    template <detail::sized_input_range R>
-        requires(!std::is_const_v<ArrayT>)
-             && std::convertible_to<std::ranges::range_value_t<R>, value_type>
-    constexpr ArraySlice const& operator=(R const& obj) const {
-        if (std::ranges::size(obj) != range_.length()) {
-            throw std::invalid_argument(
-                "Value of length " + std::to_string(std::ranges::size(obj))
-                + " cannot be assigned to array slice of length "
-                + std::to_string(range_.length())
-            );
-        }
-        std::ranges::copy(obj, begin());
-        return *this;
-    }
-
-    template <typename T>
-        requires(!std::is_const_v<ArrayT>) && std::convertible_to<T, value_type>
-    constexpr ArraySlice const& operator=(std::initializer_list<T> init) const {
-        if (init.size() != static_cast<size_t>(range_.length())) {
-            throw std::invalid_argument(
-                "Initializer list of size " + std::to_string(init.size())
-                + " cannot be assigned to array slice of length "
-                + std::to_string(range_.length())
-            );
-        }
-        std::ranges::copy(init, begin());
-        return *this;
-    }
-
-    constexpr iterator begin() const noexcept {
-        // Null slices may carry bounds outside the parent's range (the
-        // validity rule allows that). Pin them to the parent's begin so
-        // begin()/end() form a well-formed empty iterator pair.
-        if (range_.length() == 0) {
-            return arr_->begin();
-        }
-        auto start = find(arr_->range(), range_.left);
-        assert(
-            start != arr_->range().end()
-            && "slice range not a sub-range of the owner's range"
-        );
-        return arr_->begin() + std::distance(arr_->range().begin(), start);
-    }
-    constexpr iterator end() const noexcept { return begin() + range_.length(); }
-    constexpr auto rbegin() const noexcept { return std::reverse_iterator(end()); }
-    constexpr auto rend() const noexcept { return std::reverse_iterator(begin()); }
-
-  private:
-    ArrayT* arr_;
-    Range range_;
-};
 
 template <typename ValueT>
 class DynamicArray {
@@ -309,28 +196,6 @@ constexpr bool operator==(
     return true;
 }
 
-namespace detail {
-
-// Walks a RangedSequence, emitting "[range]{elem, elem, ...}" via the formatter
-// for each element type. Used by the generic Array/Slice formatters.
-template <RangedSequence ArrayT, typename OutIt>
-    requires Formattable<std::ranges::range_value_t<ArrayT>>
-OutIt format_array(ArrayT const& arr, OutIt out) {
-    out = std::format_to(out, "{}{{", arr.range());
-    bool first = true;
-    for (auto const& elem : arr) {
-        if (!first) {
-            out = std::format_to(out, ", ");
-        }
-        out = std::format_to(out, "{}", elem);
-        first = false;
-    }
-    *out++ = '}';
-    return out;
-}
-
-}  // namespace detail
-
 static_assert(RangedSequence<DynamicArray<int>>);
 static_assert(RangedSequence<DynamicArray<int> const>);
 static_assert(RangedSequence<ArraySlice<DynamicArray<int>>>);
@@ -362,25 +227,6 @@ struct std::formatter<coconext::types::DynamicArray<T>> {
 
     auto format(
         coconext::types::DynamicArray<T> const& arr, std::format_context& ctx
-    ) const {
-        return coconext::types::detail::format_array(arr, ctx.out());
-    }
-};
-
-template <typename ArrayT>
-    requires coconext::types::detail::Formattable<
-        std::ranges::range_value_t<coconext::types::ArraySlice<ArrayT>>>
-struct std::formatter<coconext::types::ArraySlice<ArrayT>> {
-    constexpr auto parse(std::format_parse_context& ctx) {
-        auto it = ctx.begin();
-        if (it != ctx.end() && *it != '}') {
-            throw std::format_error("ArraySlice formatter takes no format spec");
-        }
-        return it;
-    }
-
-    auto format(
-        coconext::types::ArraySlice<ArrayT> const& arr, std::format_context& ctx
     ) const {
         return coconext::types::detail::format_array(arr, ctx.out());
     }

--- a/cpp/include/coconext/types/logic_array.hpp
+++ b/cpp/include/coconext/types/logic_array.hpp
@@ -3,6 +3,7 @@
 
 #include <coconext/types/dynamic_array.hpp>
 #include <coconext/types/logic.hpp>
+#include <coconext/types/static_array.hpp>
 #include <format>
 
 namespace coconext::types::detail {
@@ -96,6 +97,75 @@ struct std::formatter<coconext::types::ArraySlice<coconext::types::DynamicArray<
 
     auto format(
         coconext::types::ArraySlice<coconext::types::DynamicArray<T> const> const& arr,
+        std::format_context& ctx
+    ) const {
+        return coconext::types::detail::format_typed_array(
+            coconext::types::detail::logic_type_name<T>(), arr, ctx.out()
+        );
+    }
+};
+
+template <coconext::types::LogicType T, coconext::types::Range R>
+    requires coconext::types::detail::Formattable<T>
+struct std::formatter<coconext::types::StaticArray<T, R>> {
+    constexpr auto parse(std::format_parse_context& ctx) {
+        auto it = ctx.begin();
+        if (it != ctx.end() && *it != '}') {
+            throw std::format_error(
+                "StaticArray<Logic/Bit, R> formatter takes no format spec"
+            );
+        }
+        return it;
+    }
+
+    auto format(
+        coconext::types::StaticArray<T, R> const& arr, std::format_context& ctx
+    ) const {
+        return coconext::types::detail::format_typed_array(
+            coconext::types::detail::logic_type_name<T>(), arr, ctx.out()
+        );
+    }
+};
+
+template <coconext::types::LogicType T, coconext::types::Range R>
+    requires coconext::types::detail::Formattable<T>
+struct std::formatter<coconext::types::ArraySlice<coconext::types::StaticArray<T, R>>> {
+    constexpr auto parse(std::format_parse_context& ctx) {
+        auto it = ctx.begin();
+        if (it != ctx.end() && *it != '}') {
+            throw std::format_error(
+                "ArraySlice<StaticArray<Logic/Bit, R>> formatter takes no spec"
+            );
+        }
+        return it;
+    }
+
+    auto format(
+        coconext::types::ArraySlice<coconext::types::StaticArray<T, R>> const& arr,
+        std::format_context& ctx
+    ) const {
+        return coconext::types::detail::format_typed_array(
+            coconext::types::detail::logic_type_name<T>(), arr, ctx.out()
+        );
+    }
+};
+
+template <coconext::types::LogicType T, coconext::types::Range R>
+    requires coconext::types::detail::Formattable<T>
+struct std::formatter<
+    coconext::types::ArraySlice<coconext::types::StaticArray<T, R> const>> {
+    constexpr auto parse(std::format_parse_context& ctx) {
+        auto it = ctx.begin();
+        if (it != ctx.end() && *it != '}') {
+            throw std::format_error(
+                "ArraySlice<StaticArray<Logic/Bit, R>> formatter takes no spec"
+            );
+        }
+        return it;
+    }
+
+    auto format(
+        coconext::types::ArraySlice<coconext::types::StaticArray<T, R> const> const& arr,
         std::format_context& ctx
     ) const {
         return coconext::types::detail::format_typed_array(

--- a/cpp/include/coconext/types/static_array.hpp
+++ b/cpp/include/coconext/types/static_array.hpp
@@ -1,0 +1,169 @@
+#ifndef COCONEXT_STATIC_ARRAY_HPP
+#define COCONEXT_STATIC_ARRAY_HPP
+
+#include <algorithm>
+#include <array>
+#include <coconext/types/array_base.hpp>
+#include <coconext/types/concepts.hpp>
+#include <coconext/types/hash.hpp>
+#include <coconext/types/range.hpp>
+#include <concepts>
+#include <cstddef>
+#include <format>
+#include <initializer_list>
+#include <iterator>
+#include <ranges>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+
+namespace coconext::types {
+
+// Compile-time-bounded array. The range R is part of the type, so length,
+// bounds checks, and indexing fold against R. Storage is std::array, so
+// instances live in automatic / static storage with no heap allocation.
+template <typename T, Range R>
+class StaticArray {
+  public:
+    using value_type = T;
+    using index_type = Range::value_type;
+    static_assert(!std::is_reference_v<value_type>);
+    static_assert(!std::is_const_v<value_type>);
+    using reference = value_type&;
+    using const_reference = value_type const&;
+    using iterator = typename std::array<value_type, R.length()>::iterator;
+    using const_iterator = typename std::array<value_type, R.length()>::const_iterator;
+
+    static constexpr Range static_range = R;
+
+    constexpr StaticArray()
+        requires std::default_initializable<value_type>
+        : data_{} {}
+
+    constexpr StaticArray(StaticArray const&) = default;
+    constexpr StaticArray(StaticArray&&) = default;
+    constexpr StaticArray& operator=(StaticArray const&) = default;
+    constexpr StaticArray& operator=(StaticArray&&) = default;
+
+    template <typename U>
+        requires std::convertible_to<U, value_type>
+    constexpr StaticArray(std::initializer_list<U> init) : data_{} {
+        if (init.size() != R.length()) {
+            throw std::invalid_argument(
+                "Initializer list of size " + std::to_string(init.size())
+                + " does not match StaticArray length " + std::to_string(R.length())
+            );
+        }
+        std::copy(init.begin(), init.end(), data_.begin());
+    }
+
+    template <std::ranges::sized_range Rng>
+        requires std::convertible_to<std::ranges::range_value_t<Rng>, value_type>
+              && (!std::same_as<std::remove_cvref_t<Rng>, StaticArray>)
+    explicit constexpr StaticArray(Rng const& obj) : data_{} {
+        if (std::ranges::size(obj) != R.length()) {
+            throw std::invalid_argument(
+                "Input of size " + std::to_string(std::ranges::size(obj))
+                + " does not match StaticArray length " + std::to_string(R.length())
+            );
+        }
+        std::ranges::copy(obj, data_.begin());
+    }
+
+    constexpr Range range() const noexcept { return R; }
+
+    constexpr reference operator[](index_type idx) {
+        if constexpr (R.direction == Direction::TO) {
+            if (idx < R.left || idx > R.right) {
+                throw std::out_of_range("Index out of bounds");
+            }
+            return *(begin() + (idx - R.left));
+        } else {
+            if (idx > R.left || idx < R.right) {
+                throw std::out_of_range("Index out of bounds");
+            }
+            return *(begin() + (R.left - idx));
+        }
+    }
+    constexpr const_reference operator[](index_type idx) const {
+        if constexpr (R.direction == Direction::TO) {
+            if (idx < R.left || idx > R.right) {
+                throw std::out_of_range("Index out of bounds");
+            }
+            return *(begin() + (idx - R.left));
+        } else {
+            if (idx > R.left || idx < R.right) {
+                throw std::out_of_range("Index out of bounds");
+            }
+            return *(begin() + (R.left - idx));
+        }
+    }
+    constexpr ArraySlice<StaticArray> operator[](Range r) {
+        detail::subsequence_check(static_range, r);
+        return ArraySlice<StaticArray>(this, r);
+    }
+    constexpr ArraySlice<StaticArray const> operator[](Range r) const {
+        detail::subsequence_check(static_range, r);
+        return ArraySlice<StaticArray const>(this, r);
+    }
+
+    constexpr iterator begin() noexcept { return data_.begin(); }
+    constexpr const_iterator begin() const noexcept { return data_.begin(); }
+    constexpr iterator end() noexcept { return data_.end(); }
+    constexpr const_iterator end() const noexcept { return data_.end(); }
+    constexpr auto rbegin() noexcept { return data_.rbegin(); }
+    constexpr auto rbegin() const noexcept { return data_.rbegin(); }
+    constexpr auto rend() noexcept { return data_.rend(); }
+    constexpr auto rend() const noexcept { return data_.rend(); }
+
+  private:
+    std::array<value_type, R.length()> data_;
+};
+
+template <typename T, Range R>
+    requires std::equality_comparable<T>
+constexpr bool operator==(
+    StaticArray<T, R> const& lhs, StaticArray<T, R> const& rhs
+) noexcept {
+    return std::equal(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
+}
+
+static_assert(RangedSequence<StaticArray<int, Range{0, Direction::TO, 7}>>);
+static_assert(RangedSequence<StaticArray<int, Range{0, Direction::TO, 7}> const>);
+static_assert(RangedSequence<ArraySlice<StaticArray<int, Range{0, Direction::TO, 7}>>>);
+static_assert(
+    RangedSequence<ArraySlice<StaticArray<int, Range{0, Direction::TO, 7}> const>>
+);
+
+}  // namespace coconext::types
+
+template <typename T, coconext::types::Range R>
+struct std::hash<coconext::types::StaticArray<T, R>> {
+    size_t operator()(coconext::types::StaticArray<T, R> const& arr) const noexcept {
+        size_t seed = 0;
+        for (auto const& elem : arr) {
+            seed = coconext::types::detail::hash_combine(seed, elem);
+        }
+        return seed;
+    }
+};
+
+template <typename T, coconext::types::Range R>
+    requires coconext::types::detail::Formattable<T>
+struct std::formatter<coconext::types::StaticArray<T, R>> {
+    constexpr auto parse(std::format_parse_context& ctx) {
+        auto it = ctx.begin();
+        if (it != ctx.end() && *it != '}') {
+            throw std::format_error("StaticArray formatter takes no format spec");
+        }
+        return it;
+    }
+
+    auto format(
+        coconext::types::StaticArray<T, R> const& arr, std::format_context& ctx
+    ) const {
+        return coconext::types::detail::format_array(arr, ctx.out());
+    }
+};
+
+#endif  // COCONEXT_STATIC_ARRAY_HPP

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -19,7 +19,8 @@ include(GoogleTest)
 add_executable(coconext_tests
     test_logic.cpp
     test_range.cpp
-    test_array.cpp)
+    test_array.cpp
+    test_static_array.cpp)
 target_link_libraries(coconext_tests PRIVATE coconext::coconext GTest::gtest_main)
 
 gtest_discover_tests(coconext_tests)

--- a/tests/cpp/test_array.cpp
+++ b/tests/cpp/test_array.cpp
@@ -499,4 +499,89 @@ TEST(TestArray, FormatterBitSlice) {
     auto s = a[Range(1, 2)];
     EXPECT_EQ(std::format("{}", s), "Bit[1 to 2]{1, 0}");
 }
+
+// -- Compile-time dispatch -------------------------------------------------
+
+// No NTTPs -> dynamic.
+static_assert(std::is_same_v<Array<int>, DynamicArray<int>>);
+
+// Single integral arg -> length-based static range starting at 0.
+static_assert(Array<int, 8>::static_range == Range{0, Direction::TO, 7});
+static_assert(Array<int, 0>::static_range == Range{0, Direction::TO, -1});
+static_assert(Array<int, 1>::static_range == Range{0, Direction::TO, 0});
+
+// Single Range arg -> direct passthrough.
+static_assert(
+    Array<int, Range{2, Direction::DOWNTO, -5}>::static_range
+    == Range{2, Direction::DOWNTO, -5}
+);
+
+// Two args -> (left, right), direction inferred.
+static_assert(Array<int, 1, 3>::static_range == Range{1, Direction::TO, 3});
+static_assert(Array<int, 4, 0>::static_range == Range{4, Direction::DOWNTO, 0});
+static_assert(Array<int, -3, 4>::static_range == Range{-3, Direction::TO, 4});
+
+// Three args -> (left, Direction, right) verbatim.
+static_assert(Array<int, 1, Direction::TO, 3>::static_range == Range{1, Direction::TO, 3});
+static_assert(
+    Array<int, 4, Direction::DOWNTO, 0>::static_range == Range{4, Direction::DOWNTO, 0}
+);
+
+// Different spellings of the same static range collapse to the same type:
+// length, two-arg, three-arg, and Range forms all unify.
+static_assert(std::is_same_v<Array<int, 8>, Array<int, Range{0, Direction::TO, 7}>>);
+static_assert(std::is_same_v<Array<int, 1, 3>, Array<int, 1, Direction::TO, 3>>);
+static_assert(std::is_same_v<Array<int, 4, 0>, Array<int, 4, Direction::DOWNTO, 0>>);
+
+// Forwarding the static_range of one Array into the alias of another.
+using A_1_to_4 = Array<int, 1, 4>;
+static_assert(std::is_same_v<Array<int, A_1_to_4::static_range>, Array<int, 1, 4>>);
+
+// -- Runtime: verify the dispatched type actually works --------------------
+
+TEST(TestArray, StaticLengthViaAlias) {
+    Array<int, 4> a({1, 2, 3, 4});
+    EXPECT_EQ(a.range(), (Range{0, Direction::TO, 3}));
+    EXPECT_EQ(a[2], 3);
+    a[3] = 99;
+    EXPECT_EQ(a[3], 99);
+}
+
+TEST(TestArray, StaticRangeViaAlias) {
+    constexpr Range R{10, Direction::TO, 13};
+    Array<int, R> a({100, 200, 300, 400});
+    EXPECT_EQ(a.range(), R);
+    EXPECT_EQ(a[10], 100);
+    EXPECT_EQ(a[13], 400);
+}
+
+TEST(TestArray, StaticTwoArgViaAlias) {
+    Array<int, 2, 5> a({10, 20, 30, 40});
+    EXPECT_EQ(a.range(), (Range{2, Direction::TO, 5}));
+    EXPECT_EQ(a[2], 10);
+    EXPECT_EQ(a[5], 40);
+}
+
+TEST(TestArray, StaticTwoArgDOWNTOViaAlias) {
+    Array<int, 4, 1> a({10, 20, 30, 40});
+    EXPECT_EQ(a.range(), (Range{4, Direction::DOWNTO, 1}));
+    EXPECT_EQ(a[4], 10);
+    EXPECT_EQ(a[1], 40);
+}
+
+TEST(TestArray, StaticThreeArgViaAlias) {
+    Array<int, 4, Direction::DOWNTO, 1> a({10, 20, 30, 40});
+    EXPECT_EQ(a.range(), (Range{4, Direction::DOWNTO, 1}));
+    EXPECT_EQ(a[4], 10);
+    EXPECT_EQ(a[1], 40);
+}
+
+TEST(TestArray, StaticFromForeignStaticRange) {
+    using Src = Array<int, 1, 3>;
+    Src src({10, 20, 30});
+    Array<int, Src::static_range> dst({100, 200, 300});
+    EXPECT_EQ(dst.range(), src.range());
+    EXPECT_EQ(dst[1], 100);
+    EXPECT_EQ(dst[3], 300);
+}
 // LCOV_EXCL_BR_STOP

--- a/tests/cpp/test_static_array.cpp
+++ b/tests/cpp/test_static_array.cpp
@@ -1,0 +1,303 @@
+// LCOV_EXCL_BR_START -- gtest macros generate noisy uncovered branches
+#include <gtest/gtest.h>
+
+#include <coconext/types.hpp>
+#include <format>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <unordered_set>
+#include <vector>
+
+using namespace coconext::types;
+
+// -- Construction -----------------------------------------------------------
+
+TEST(TestStaticArray, DefaultConstructZeroInit) {
+    StaticArray<int, Range{0, Direction::TO, 3}> a;
+    EXPECT_EQ(a[0], 0);
+    EXPECT_EQ(a[3], 0);
+}
+
+TEST(TestStaticArray, ConstructFromInitializerList) {
+    StaticArray<int, Range{0, Direction::TO, 3}> a({1, 2, 3, 4});
+    EXPECT_EQ(a[0], 1);
+    EXPECT_EQ(a[3], 4);
+}
+
+TEST(TestStaticArray, ConstructFromInitializerListLengthMismatch) {
+    using A = StaticArray<int, Range{0, Direction::TO, 3}>;
+    EXPECT_THROW(A a({1, 2, 3}), std::invalid_argument);
+    EXPECT_THROW(A a({1, 2, 3, 4, 5}), std::invalid_argument);
+}
+
+TEST(TestStaticArray, ConstructFromSizedRange) {
+    std::vector<int> src = {10, 20, 30, 40};
+    StaticArray<int, Range{-2, Direction::TO, 1}> a(src);
+    EXPECT_EQ(a[-2], 10);
+    EXPECT_EQ(a[1], 40);
+}
+
+TEST(TestStaticArray, ConstructFromSizedRangeLengthMismatch) {
+    std::vector<int> src = {1, 2, 3};
+    using A = StaticArray<int, Range{0, Direction::TO, 3}>;
+    EXPECT_THROW(A a(src), std::invalid_argument);
+}
+
+TEST(TestStaticArray, CopyAndMove) {
+    StaticArray<int, Range{0, Direction::TO, 3}> a({1, 2, 3, 4});
+    StaticArray<int, Range{0, Direction::TO, 3}> b = a;
+    EXPECT_EQ(a, b);
+    StaticArray<int, Range{0, Direction::TO, 3}> c = std::move(a);
+    EXPECT_EQ(b, c);
+}
+
+// -- Range / iteration ------------------------------------------------------
+
+TEST(TestStaticArray, RangeAccessor) {
+    StaticArray<int, Range{2, Direction::TO, 5}> a({1, 2, 3, 4});
+    EXPECT_EQ(a.range(), (Range{2, Direction::TO, 5}));
+    static_assert(decltype(a)::static_range == Range{2, Direction::TO, 5});
+}
+
+TEST(TestStaticArray, ForwardIteration) {
+    StaticArray<int, Range{0, Direction::TO, 4}> a({1, 2, 3, 4, 5});
+    int sum = 0;
+    for (auto v : a) {
+        sum += v;
+    }
+    EXPECT_EQ(sum, 15);
+}
+
+TEST(TestStaticArray, ReverseIteration) {
+    StaticArray<int, Range{0, Direction::TO, 4}> a({1, 2, 3, 4, 5});
+    std::vector<int> rev(a.rbegin(), a.rend());
+    EXPECT_EQ(rev, (std::vector<int>{5, 4, 3, 2, 1}));
+}
+
+TEST(TestStaticArray, IterationConst) {
+    StaticArray<int, Range{0, Direction::TO, 2}> const a({1, 2, 3});
+    int sum = 0;
+    for (auto v : a) {
+        sum += v;
+    }
+    EXPECT_EQ(sum, 6);
+}
+
+// -- Indexing ---------------------------------------------------------------
+
+TEST(TestStaticArray, IndexingTO) {
+    StaticArray<int, Range{8, Direction::TO, 11}> a({10, 20, 30, 40});
+    EXPECT_EQ(a[8], 10);
+    EXPECT_EQ(a[11], 40);
+}
+
+TEST(TestStaticArray, IndexingDOWNTO) {
+    StaticArray<int, Range{10, Direction::DOWNTO, 7}> a({10, 20, 30, 40});
+    EXPECT_EQ(a[10], 10);
+    EXPECT_EQ(a[7], 40);
+}
+
+TEST(TestStaticArray, IndexingMutates) {
+    StaticArray<int, Range{0, Direction::TO, 4}> a({1, 2, 3, 4, 5});
+    a[2] = 99;
+    EXPECT_EQ(a[2], 99);
+}
+
+TEST(TestStaticArray, IndexingOutOfRange) {
+    StaticArray<int, Range{0, Direction::TO, 4}> a({1, 2, 3, 4, 5});
+    EXPECT_THROW((void)a[-1], std::out_of_range);
+    EXPECT_THROW((void)a[5], std::out_of_range);
+}
+
+TEST(TestStaticArray, IndexingDOWNTOOutOfRange) {
+    StaticArray<int, Range{4, Direction::DOWNTO, 0}> a({1, 2, 3, 4, 5});
+    EXPECT_THROW((void)a[-1], std::out_of_range);
+    EXPECT_THROW((void)a[5], std::out_of_range);
+}
+
+TEST(TestStaticArray, IndexingConst) {
+    StaticArray<int, Range{0, Direction::TO, 2}> const a({1, 2, 3});
+    EXPECT_EQ(a[0], 1);
+    EXPECT_EQ(a[2], 3);
+    static_assert(std::is_same_v<decltype(a[0]), int const&>);
+}
+
+// -- Slicing (runtime, returns ArraySlice) ---------------------------------
+
+TEST(TestStaticArray, SliceTO) {
+    StaticArray<int, Range{0, Direction::TO, 4}> a({1, 2, 3, 4, 5});
+    auto s = a[{1, 4}];
+    EXPECT_EQ(s.range(), (Range{1, Direction::TO, 4}));
+    EXPECT_EQ(s[1], 2);
+    EXPECT_EQ(s[4], 5);
+}
+
+TEST(TestStaticArray, SliceDOWNTO) {
+    StaticArray<int, Range{3, Direction::DOWNTO, 0}> a({10, 20, 30, 40});
+    auto s = a[{2, 1}];
+    EXPECT_EQ(s.range(), (Range{2, Direction::DOWNTO, 1}));
+    EXPECT_EQ(s[2], 20);
+    EXPECT_EQ(s[1], 30);
+}
+
+TEST(TestStaticArray, SliceMutatesUnderlying) {
+    StaticArray<int, Range{0, Direction::TO, 4}> a({1, 2, 3, 4, 5});
+    auto s = a[{1, 3}];
+    s[2] = 99;
+    EXPECT_EQ(a[2], 99);
+}
+
+TEST(TestStaticArray, SliceAssignFromRange) {
+    StaticArray<int, Range{0, Direction::TO, 4}> a({1, 2, 3, 4, 5});
+    auto s = a[{1, 3}];
+    s = std::vector<int>{20, 30, 40};
+    EXPECT_EQ(a[1], 20);
+    EXPECT_EQ(a[3], 40);
+}
+
+TEST(TestStaticArray, SliceAssignFromInitializerList) {
+    StaticArray<int, Range{0, Direction::TO, 4}> a({1, 2, 3, 4, 5});
+    auto s = a[{1, 3}];
+    s = {7, 8, 9};
+    EXPECT_EQ(a[1], 7);
+    EXPECT_EQ(a[3], 9);
+}
+
+TEST(TestStaticArray, SliceAssignWrongLength) {
+    StaticArray<int, Range{0, Direction::TO, 2}> a({1, 2, 3});
+    auto s = a[{0, 2}];
+    EXPECT_THROW((s = std::vector<int>{1, 2}), std::invalid_argument);
+    EXPECT_THROW((s = {1, 2}), std::invalid_argument);
+}
+
+TEST(TestStaticArray, SliceStartOutOfRange) {
+    StaticArray<int, Range{0, Direction::TO, 2}> a({1, 2, 3});
+    EXPECT_THROW((void)(a[{99, 1}]), std::invalid_argument);
+}
+
+TEST(TestStaticArray, SliceEndOutOfRange) {
+    StaticArray<int, Range{0, Direction::TO, 2}> a({1, 2, 3});
+    EXPECT_THROW((void)(a[{0, 99}]), std::invalid_argument);
+}
+
+TEST(TestStaticArray, SliceDirectionMismatch) {
+    StaticArray<int, Range{0, Direction::TO, 4}> a({1, 2, 3, 4, 5});
+    EXPECT_THROW((void)(a[{3, Direction::DOWNTO, 1}]), std::invalid_argument);
+}
+
+TEST(TestStaticArray, SliceNullOutOfBoundsOK) {
+    StaticArray<int, Range{0, Direction::TO, 4}> a({1, 2, 3, 4, 5});
+    auto s = a[{99, Direction::TO, 50}];  // length 0
+    EXPECT_EQ(s.range().length(), 0u);
+    EXPECT_EQ(s.begin(), s.end());
+}
+
+TEST(TestStaticArray, SliceLengthOneDirectionAgnostic) {
+    StaticArray<int, Range{0, Direction::TO, 4}> a({1, 2, 3, 4, 5});
+    auto s = a[{2, Direction::DOWNTO, 2}];
+    EXPECT_EQ(s.range().length(), 1u);
+    EXPECT_EQ(s[2], 3);
+}
+
+TEST(TestStaticArray, SliceOfSliceFlattens) {
+    StaticArray<int, Range{0, Direction::TO, 6}> a({1, 2, 3, 4, 5, 6, 7});
+    auto s1 = a[{1, 6}];
+    auto s2 = s1[{2, 4}];
+    EXPECT_EQ(s2.range(), (Range{2, Direction::TO, 4}));
+    EXPECT_EQ(s2[2], 3);
+    EXPECT_EQ(s2[4], 5);
+}
+
+TEST(TestStaticArray, SliceOfSliceErrors) {
+    StaticArray<int, Range{0, Direction::TO, 6}> a({1, 2, 3, 4, 5, 6, 7});
+    auto s1 = a[{1, 4}];
+    EXPECT_THROW((void)(s1[{0, 2}]), std::invalid_argument);
+    EXPECT_THROW((void)(s1[{1, 5}]), std::invalid_argument);
+    EXPECT_THROW((void)(s1[{4, Direction::DOWNTO, 1}]), std::invalid_argument);
+}
+
+TEST(TestStaticArray, ConstSliceOverConstArray) {
+    StaticArray<int, Range{0, Direction::TO, 4}> const a({1, 2, 3, 4, 5});
+    auto s = a[{1, 3}];
+    static_assert(std::is_same_v<decltype(s[1]), int const&>);
+    EXPECT_EQ(s[1], 2);
+    EXPECT_EQ(s[3], 4);
+}
+
+// -- Equality ---------------------------------------------------------------
+
+TEST(TestStaticArray, EqualityValues) {
+    StaticArray<int, Range{0, Direction::TO, 2}> a({1, 2, 3});
+    StaticArray<int, Range{0, Direction::TO, 2}> b({1, 2, 3});
+    EXPECT_EQ(a, b);
+}
+
+TEST(TestStaticArray, InequalityDifferentValues) {
+    StaticArray<int, Range{0, Direction::TO, 2}> a({1, 2, 3});
+    StaticArray<int, Range{0, Direction::TO, 2}> b({1, 2, 9});
+    EXPECT_FALSE(a == b);
+}
+
+// -- Hashing ----------------------------------------------------------------
+
+TEST(TestStaticArray, HashEqualArrays) {
+    StaticArray<int, Range{0, Direction::TO, 2}> a({1, 2, 3});
+    StaticArray<int, Range{0, Direction::TO, 2}> b({1, 2, 3});
+    using H = std::hash<StaticArray<int, Range{0, Direction::TO, 2}>>;
+    EXPECT_EQ(H{}(a), H{}(b));
+}
+
+TEST(TestStaticArray, UnorderedSetByValue) {
+    std::unordered_set<StaticArray<int, Range{0, Direction::TO, 2}>> s;
+    s.insert(StaticArray<int, Range{0, Direction::TO, 2}>({1, 2, 3}));
+    s.insert(StaticArray<int, Range{0, Direction::TO, 2}>({1, 2, 3}));
+    EXPECT_EQ(s.size(), 1u);
+}
+
+// -- Formatter --------------------------------------------------------------
+
+TEST(TestStaticArray, FormatterInt) {
+    StaticArray<int, Range{0, Direction::TO, 2}> a({1, 2, 3});
+    EXPECT_EQ(std::format("{}", a), "[0 to 2]{1, 2, 3}");
+}
+
+TEST(TestStaticArray, FormatterEmpty) {
+    StaticArray<int, Range{0, Direction::TO, -1}> a;
+    EXPECT_EQ(std::format("{}", a), "[0 to -1]{}");
+}
+
+TEST(TestStaticArray, FormatterLogic) {
+    StaticArray<Logic, Range{0, Direction::TO, 2}> a({'0'_l, '1'_l, 'X'_l});
+    EXPECT_EQ(std::format("{}", a), "Logic[0 to 2]{0, 1, X}");
+}
+
+TEST(TestStaticArray, FormatterBit) {
+    StaticArray<Bit, Range{0, Direction::TO, 3}> a({'0'_b, '1'_b, '0'_b, '1'_b});
+    EXPECT_EQ(std::format("{}", a), "Bit[0 to 3]{0, 1, 0, 1}");
+}
+
+TEST(TestStaticArray, FormatterLogicRuntimeSlice) {
+    StaticArray<Logic, Range{0, Direction::TO, 3}> a({'0'_l, '1'_l, 'X'_l, 'Z'_l});
+    auto s = a[Range{1, 2}];
+    EXPECT_EQ(std::format("{}", s), "Logic[1 to 2]{1, X}");
+}
+
+TEST(TestStaticArray, FormatterLogicRuntimeSliceConst) {
+    StaticArray<Logic, Range{0, Direction::TO, 3}> const a({'0'_l, '1'_l, 'X'_l, 'Z'_l});
+    auto s = a[Range{1, 2}];
+    EXPECT_EQ(std::format("{}", s), "Logic[1 to 2]{1, X}");
+}
+
+TEST(TestStaticArray, FormatterBitRuntimeSlice) {
+    StaticArray<Bit, Range{0, Direction::TO, 3}> a({'0'_b, '1'_b, '0'_b, '1'_b});
+    auto s = a[Range{1, 2}];
+    EXPECT_EQ(std::format("{}", s), "Bit[1 to 2]{1, 0}");
+}
+
+TEST(TestStaticArray, FormatterBitRuntimeSliceConst) {
+    StaticArray<Bit, Range{0, Direction::TO, 3}> const a({'0'_b, '1'_b, '0'_b, '1'_b});
+    auto s = a[Range{1, 2}];
+    EXPECT_EQ(std::format("{}", s), "Bit[1 to 2]{1, 0}");
+}
+// LCOV_EXCL_BR_STOP


### PR DESCRIPTION
Closes #172.

The compile-time-bounded sibling of DynamicArray<T>: storage is std::array<T, R.length()> (true fixed-size, stack-allocated), and specialized index() / slice() overloads dispatch on R.direction via if constexpr so the bounds check and offset arithmetic constant-fold against the template parameter.

Generic user code over the existing RangedSequence concept works unchanged for both Array and StaticArray, because StaticArray::range() returns a Range value constructed from R; the concept stays satisfied without a separate StaticRangedSequence.

Tests cover construction (default, init list, sized range, iterator pair), indexing TO/DOWNTO, slicing, iteration, equality, hash, and generic-function compatibility with runtime Array<T>. A block of static_assert calls exercises folding at compile time — if the bounds check or offset arithmetic stops folding, the test won't compile.