### PR TITLE
Clean up Array constructors

### DIFF
--- a/cpp/include/coconext/types/array.hpp
+++ b/cpp/include/coconext/types/array.hpp
@@ -204,72 +204,33 @@ class Array {
         data_.resize(range.length());
     }
 
-    explicit constexpr Array(size_t length)
-        requires std::default_initializable<value_type>
-        : Array(Range(length)) {}
-
-    template <typename T>
-        requires std::convertible_to<T, value_type>
-    explicit constexpr Array(std::initializer_list<T> init)
+    constexpr Array(std::initializer_list<value_type> init)
         : data_(init), range_(data_.size()) {}
 
-    template <typename T>
-        requires std::convertible_to<T, value_type>
-    explicit constexpr Array(std::vector<T>&& vec)
-        : data_(std::move(vec)), range_(data_.size()) {}
-
-    template <std::ranges::input_range T>
-        requires std::convertible_to<std::ranges::range_value_t<T>, value_type>
-    explicit constexpr Array(T const& obj, Range range) : data_(), range_(range) {
-        data_.reserve(range.length());
-        data_.assign(std::ranges::begin(obj), std::ranges::end(obj));
+    constexpr Array(std::initializer_list<value_type> init, Range range)
+        : data_(init), range_(range) {
         if (data_.size() != range.length()) {
             throw std::invalid_argument(
-                "Input of size " + std::to_string(data_.size())
+                "Initializer list of size " + std::to_string(data_.size())
                 + " does not match range length " + std::to_string(range.length())
             );
         }
     }
 
-    template <std::ranges::input_range T>
-        requires std::convertible_to<std::ranges::range_value_t<T>, value_type>
-    explicit constexpr Array(T const& obj, size_t length) : data_(), range_(length) {
-        data_.reserve(length);
-        data_.assign(std::ranges::begin(obj), std::ranges::end(obj));
-        if (data_.size() != length) {
-            throw std::invalid_argument(
-                "Input of size " + std::to_string(data_.size())
-                + " does not match range length " + std::to_string(length)
-            );
-        }
-    }
+    template <std::ranges::sized_range R>
+        requires std::convertible_to<std::ranges::range_value_t<R>, value_type>
+                  && (!std::same_as<std::remove_cvref_t<R>, Array>)
+    explicit constexpr Array(R const& obj)
+        : data_(std::ranges::begin(obj), std::ranges::end(obj)), range_(data_.size()) {}
 
-    template <std::input_iterator It>
-        requires std::convertible_to<
-                     typename std::iterator_traits<It>::value_type,
-                     value_type>
-    explicit constexpr Array(It begin, It end, Range range) : data_(), range_(range) {
-        data_.reserve(range.length());
-        data_.assign(begin, end);
+    template <std::ranges::sized_range R>
+        requires std::convertible_to<std::ranges::range_value_t<R>, value_type>
+    constexpr Array(R const& obj, Range range)
+        : data_(std::ranges::begin(obj), std::ranges::end(obj)), range_(range) {
         if (data_.size() != range.length()) {
             throw std::invalid_argument(
-                "Iterator of size " + std::to_string(data_.size())
+                "Input of size " + std::to_string(data_.size())
                 + " does not match range length " + std::to_string(range.length())
-            );
-        }
-    }
-
-    template <std::input_iterator It>
-        requires std::convertible_to<
-                     typename std::iterator_traits<It>::value_type,
-                     value_type>
-    explicit constexpr Array(It begin, It end, size_t length) : data_(), range_(length) {
-        data_.reserve(length);
-        data_.assign(begin, end);
-        if (data_.size() != length) {
-            throw std::invalid_argument(
-                "Iterator of size " + std::to_string(data_.size())
-                + " does not match range length " + std::to_string(length)
             );
         }
     }

--- a/cpp/tests/test_array.cpp
+++ b/cpp/tests/test_array.cpp
@@ -24,35 +24,17 @@ TEST(TestArray, ConstructFromInitializerListEmpty) {
     EXPECT_EQ(a.range().length(), 0U);
 }
 
-TEST(TestArray, ConstructFromVectorMove) {
-    std::vector<int> v{1, 2, 3, 4};
-    Array<int> a(std::move(v));
-    EXPECT_EQ(a.range().length(), 4U);
-    EXPECT_EQ(a[0], 1);
-    EXPECT_EQ(a[3], 4);
-    EXPECT_TRUE(v.empty());  // moved-from
+TEST(TestArray, ConstructFromInitializerListWithRange) {
+    Array<int> a({10, 20, 30, 40}, Range(-2, Direction::TO, 1));
+    EXPECT_EQ(a.range(), Range(-2, Direction::TO, 1));
+    EXPECT_EQ(a[-2], 10);
+    EXPECT_EQ(a[1], 40);
 }
 
-TEST(TestArray, ConstructFromVectorMoveEmpty) {
-    std::vector<int> v;
-    Array<int> a(std::move(v));
-    EXPECT_EQ(a.range().length(), 0U);
-}
-
-TEST(TestArray, ConstructFromLength) {
-    Array<int> a(static_cast<size_t>(5));
-    EXPECT_EQ(a.range().length(), 5U);
-    EXPECT_EQ(a.range(), Range(0, Direction::TO, 4));
-}
-
-TEST(TestArray, ConstructFromLengthZero) {
-    Array<int> a(static_cast<size_t>(0));
-    EXPECT_EQ(a.range().length(), 0U);
-}
-
-TEST(TestArray, ConstructFromLengthOverflow) {
-    constexpr size_t too_big = static_cast<size_t>(std::numeric_limits<int32_t>::max()) + 1;
-    EXPECT_THROW(Array<int> a(too_big), std::length_error);
+TEST(TestArray, ConstructFromInitializerListWithRangeLengthMismatch) {
+    EXPECT_THROW(
+        Array<int> a({1, 2, 3}, Range(0, Direction::TO, 7)), std::invalid_argument
+    );
 }
 
 TEST(TestArray, ConstructFromRange) {
@@ -61,46 +43,24 @@ TEST(TestArray, ConstructFromRange) {
     EXPECT_EQ(a.range().length(), 4U);
 }
 
-TEST(TestArray, ConstructFromInputRangeWithRange) {
+TEST(TestArray, ConstructFromSizedRange) {
+    std::vector<int> src{1, 2, 3};
+    Array<int> a(src);
+    EXPECT_EQ(a.range(), Range(0, Direction::TO, 2));
+    EXPECT_EQ(a[0], 1);
+    EXPECT_EQ(a[2], 3);
+}
+
+TEST(TestArray, ConstructFromSizedRangeWithRange) {
     std::vector<int> src{10, 20, 30, 40};
     Array<int> a(src, Range(-2, Direction::TO, 1));
     EXPECT_EQ(a[-2], 10);
     EXPECT_EQ(a[1], 40);
 }
 
-TEST(TestArray, ConstructFromInputRangeWithLength) {
-    std::vector<int> src{1, 2, 3};
-    Array<int> a(src, static_cast<size_t>(3));
-    EXPECT_EQ(a.range(), Range(0, Direction::TO, 2));
-}
-
-TEST(TestArray, ConstructFromInputRangeLengthMismatch) {
+TEST(TestArray, ConstructFromSizedRangeLengthMismatch) {
     std::vector<int> src{1, 2, 3};
     EXPECT_THROW(Array<int> a(src, Range(0, Direction::TO, 7)), std::invalid_argument);
-    EXPECT_THROW(Array<int> a(src, static_cast<size_t>(7)), std::invalid_argument);
-}
-
-TEST(TestArray, ConstructFromIteratorPairWithRange) {
-    std::vector<int> src{1, 2, 3, 4};
-    Array<int> a(src.begin(), src.end(), Range(0, Direction::TO, 3));
-    EXPECT_EQ(a[2], 3);
-}
-
-TEST(TestArray, ConstructFromIteratorPairWithLength) {
-    std::vector<int> src{1, 2, 3, 4};
-    Array<int> a(src.begin(), src.end(), static_cast<size_t>(4));
-    EXPECT_EQ(a.range().length(), 4U);
-}
-
-TEST(TestArray, ConstructFromIteratorPairLengthMismatch) {
-    std::vector<int> src{1, 2, 3};
-    EXPECT_THROW(
-        Array<int> a(src.begin(), src.end(), Range(0, Direction::TO, 7)),
-        std::invalid_argument
-    );
-    EXPECT_THROW(
-        Array<int> a(src.begin(), src.end(), static_cast<size_t>(7)), std::invalid_argument
-    );
 }
 
 // -- range() ----------------------------------------------------------------
@@ -308,32 +268,9 @@ TEST(TestArray, ConstSliceOfConstSlice) {
     EXPECT_EQ(inner[3], 4);
 }
 
-TEST(TestArray, ConstructLogicLengthOverflow) {
-    // length_to_right_ is a static member of each Array<T> instantiation;
-    // Array<Logic>'s copy needs its own overflow exercise.
-    constexpr size_t too_big = static_cast<size_t>(std::numeric_limits<int32_t>::max()) + 1;
-    EXPECT_THROW(Array<Logic> a(too_big), std::length_error);
-}
-
-TEST(TestArray, ConstructLogicFromLength) {
-    // Successful Array<Logic>(size_t) — covers the data_.resize(length) line
-    // inside the size_t constructor's Array<Logic> instantiation.
-    Array<Logic> a(static_cast<size_t>(3));
+TEST(TestArray, ConstructLogicFromRange) {
+    Array<Logic> a(Range(3));
     EXPECT_EQ(a.range().length(), 3U);
-}
-
-// Cover length_to_right_'s overflow throw via the other constructor paths
-// that route through it.
-TEST(TestArray, ConstructFromInputRangeWithLengthOverflow) {
-    constexpr size_t too_big = static_cast<size_t>(std::numeric_limits<int32_t>::max()) + 1;
-    std::vector<int> empty;
-    EXPECT_THROW(Array<int> a(empty, too_big), std::length_error);
-}
-
-TEST(TestArray, ConstructFromIteratorPairWithLengthOverflow) {
-    constexpr size_t too_big = static_cast<size_t>(std::numeric_limits<int32_t>::max()) + 1;
-    std::vector<int> empty;
-    EXPECT_THROW(Array<int> a(empty.begin(), empty.end(), too_big), std::length_error);
 }
 
 TEST(TestArray, ConstSliceOverConstArray) {


### PR DESCRIPTION
A lot of the constructors existed to provide functionality for the Python binding which we are no longer doing.

We now only support default initialization providing just a Range, initializer list with optional Range, and sized ranges (e.g. vectors, arrays, spans, and more) with an optional Range.