### PR TITLE
Exclude branches from coverage in test files

### DIFF
--- a/cpp/tests/test_array.cpp
+++ b/cpp/tests/test_array.cpp
@@ -1,3 +1,4 @@
+// LCOV_EXCL_BR_START -- gtest macros generate noisy uncovered branches
 #include <gtest/gtest.h>
 
 #include <coconext/types.hpp>
@@ -478,3 +479,4 @@ TEST(TestArray, ToStringLogic) {
     EXPECT_NE(s.find("0"), std::string::npos);
     EXPECT_NE(s.find("X"), std::string::npos);
 }
+// LCOV_EXCL_BR_STOP

--- a/cpp/tests/test_logic.cpp
+++ b/cpp/tests/test_logic.cpp
@@ -1,3 +1,4 @@
+// LCOV_EXCL_BR_START -- gtest macros generate noisy uncovered branches
 #include <gtest/gtest.h>
 
 #include <coconext/types.hpp>
@@ -365,3 +366,4 @@ TEST(TestBit, BitIsHashable) {
     std::unordered_set<Bit> const different{'0'_b, '1'_b};
     EXPECT_EQ(different.size(), 2U);
 }
+// LCOV_EXCL_BR_STOP

--- a/cpp/tests/test_range.cpp
+++ b/cpp/tests/test_range.cpp
@@ -1,3 +1,4 @@
+// LCOV_EXCL_BR_START -- gtest macros generate noisy uncovered branches
 #include <gtest/gtest.h>
 
 #include <coconext/types.hpp>
@@ -145,3 +146,4 @@ TEST(TestRange, RangeIsHashable) {
     };
     EXPECT_EQ(different.size(), 2U);
 }
+// LCOV_EXCL_BR_STOP


### PR DESCRIPTION
GoogleTest macros have branches in them for instrumenting the testing functionality. This trips up coverage with missing branches on code that should never branch. I just excluded branch coverage for all test files. We still want line coverage to pick up dead testing lines.