### PR TITLE
Add release build and testing

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -85,7 +85,7 @@ jobs:
         CXX: ${{ matrix.cxx || 'g++' }}
         GCOV_EXECUTABLE: ${{ matrix.gcov || 'gcov' }}
       run: |
-        make tests
+        make dev_tests
 
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v6

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -4,6 +4,13 @@ Build Issues?
 Since we set `build-dir` to a non-temp directory there can be issues with the build reusing existing outputs.
 If you run into issues just `rm -rf build/`.
 
+Release Builds
+==============
+
+Release builds are staged under `release/{version}-{wheel-tag}/`.
+There are the `dist/`, `build/`, and `.venv/` directories used during the build.
+Use `python tools/release_paths.py` to inspect the exact paths for the current metadata and interpreter.
+
 Generating Compilation DB
 =========================
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-
 .PHONY: dev_build
 dev_build:
 	uv sync --no-default-groups --group=tests --no-install-project
@@ -12,25 +11,67 @@ dev_build:
 
 GCOV_EXECUTABLE ?= gcov
 
-.PHONY: tests
-tests: dev_build
-	# Clean up old coverage data
-	find . -name ".coverage" -delete
-
-	# Run Python tests
-	COCOTB_USER_COVERAGE=1 pytest --cov=coconext --cov-report=
-
-	# Run C++ tests
-	WHEEL_TAG=$$(python -c "from scikit_build_core.builder.wheel_tag import WheelTag; print(WheelTag.compute_best([], ''))"); \
-    ctest --output-on-failure --test-dir build/$$WHEEL_TAG
-
-	# Combine coverage data and generate reports
-	find . -name ".coverage" | xargs coverage combine
-	coverage xml -o .python-coverage.xml
-	WHEEL_TAG=$$(python -c "from scikit_build_core.builder.wheel_tag import WheelTag; print(WheelTag.compute_best([], ''))"); \
-	gcovr build/$$WHEEL_TAG/ --gcov-executable='$(GCOV_EXECUTABLE)' --cobertura -o .cpp-coverage.xml
-	coverage report
+.PHONY: dev_tests
+dev_tests: dev_build
+	@wheel_tag="$$(python tools/release_paths.py wheel-tag)"; \
+	find . -name ".coverage" -delete; \
+	COCOTB_USER_COVERAGE=1 pytest --cov=coconext --cov-report=; \
+	ctest --output-on-failure --test-dir "build/$$wheel_tag"; \
+	find . -name ".coverage" | xargs coverage combine; \
+	coverage xml -o .python-coverage.xml; \
+	gcovr "build/$$wheel_tag/" --gcov-executable='$(GCOV_EXECUTABLE)' --cobertura -o .cpp-coverage.xml; \
+	coverage report; \
 	gcovr --gcov-executable='$(GCOV_EXECUTABLE)' --print-summary
+
+
+.PHONY: clean
+clean:
+	# build/ hardcoded in pyproject.toml
+	rm -rf build/
+
+
+.PHONY: release_build_wheel
+release_build_wheel:
+	@eval "$$(python tools/release_paths.py shell)" && \
+	SKBUILD_CMAKE_BUILD_TYPE=Release SKBUILD_BUILD_DIR="$$RELEASE_BUILD_DIR" uv build --wheel --out-dir "$$RELEASE_DIST_DIR"
+
+
+.PHONY: release_test_wheel
+release_test_wheel: release_build_wheel
+	@eval "$$(python tools/release_paths.py shell)" && \
+	if [ -d "$$RELEASE_VENV" ]; then rm -rf "$$RELEASE_VENV"; fi && \
+	uv venv "$$RELEASE_VENV" && \
+	. "$$RELEASE_VENV/bin/activate" && \
+	uv sync --active --no-default-groups --group=tests --no-install-project && \
+	SKBUILD_BUILD_DIR="$$RELEASE_BUILD_DIR" uv pip install --force-reinstall "$$RELEASE_WHEEL" && \
+	pytest && \
+	ctest --output-on-failure --test-dir "$$RELEASE_BUILD_DIR"
+
+
+.PHONY: release_build_sdist
+release_build_sdist:
+	@eval "$$(python tools/release_paths.py shell)" && \
+	SKBUILD_CMAKE_BUILD_TYPE=Release SKBUILD_BUILD_DIR="$$RELEASE_BUILD_DIR" uv build --sdist --out-dir "$$RELEASE_DIST_DIR"
+
+
+.PHONY: release_test_sdist
+release_test_sdist: release_build_sdist
+	@eval "$$(python tools/release_paths.py shell)" && \
+	if [ -d "$$RELEASE_VENV" ]; then rm -rf "$$RELEASE_VENV"; fi && \
+	uv venv "$$RELEASE_VENV" && \
+	. "$$RELEASE_VENV/bin/activate" && \
+	uv sync --active --no-default-groups --group=tests --no-install-project && \
+	SKBUILD_BUILD_DIR="$$RELEASE_BUILD_DIR" uv pip install "$$RELEASE_SDIST" && \
+	pytest && \
+	ctest --output-on-failure --test-dir "$$RELEASE_BUILD_DIR"
+
+
+.PHONY: release_build
+release_build: release_build_wheel release_build_sdist
+
+
+.PHONY: release_test
+release_test: release_test_wheel release_test_sdist
 
 
 DOCS_OUTDIR ?= .docs_out

--- a/tests/test_release_paths.py
+++ b/tests/test_release_paths.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from packaging.utils import canonicalize_name
+from scikit_build_core._compat import tomllib
+from scikit_build_core.build.metadata import get_standard_metadata
+from scikit_build_core.builder.builder import archs_to_tags, get_archs
+from scikit_build_core.builder.wheel_tag import WheelTag
+from scikit_build_core.settings.skbuild_read_settings import SettingsReader
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "tools" / "release_paths.py"
+
+
+def _load_release_paths_module() -> Any:
+    spec = importlib.util.spec_from_file_location("release_paths", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _expected_artifacts() -> tuple[str, str, str, str]:
+    with (REPO_ROOT / "pyproject.toml").open("rb") as f:
+        pyproject = tomllib.load(f)
+
+    settings = SettingsReader(pyproject, {}, state="wheel").settings
+    metadata = get_standard_metadata(pyproject, settings)
+    assert metadata.version is not None
+
+    if settings.wheel.platlib is None:
+        root_is_purelib = not settings.wheel.cmake
+    else:
+        root_is_purelib = not settings.wheel.platlib
+
+    wheel_tag = str(
+        WheelTag.compute_best(
+            archs_to_tags(get_archs(os.environ)),
+            settings.wheel.py_api,
+            expand_macos=settings.wheel.expand_macos_universal_tags,
+            root_is_purelib=root_is_purelib,
+            build_tag=settings.wheel.build_tag,
+        )
+    )
+    version = str(metadata.version)
+    wheel = (
+        f"{metadata.canonical_name.replace('-', '_')}-"
+        f"{str(metadata.version).replace('-', '_')}-{wheel_tag}.whl"
+    )
+    sdist = (
+        f"{canonicalize_name(metadata.name).replace('-', '_')}-"
+        f"{metadata.version}.tar.gz"
+    )
+    return version, wheel_tag, wheel, sdist
+
+
+def test_compute_release_paths_matches_backend() -> None:
+    release_paths = _load_release_paths_module()
+    paths = release_paths.compute_release_paths(project_dir=REPO_ROOT)
+    version, wheel_tag, wheel, sdist = _expected_artifacts()
+
+    assert paths.version == version
+    assert paths.wheel_tag == wheel_tag
+    assert paths.root == Path("release") / f"{version}-{wheel_tag}"
+    assert paths.dist == paths.root / "dist"
+    assert paths.build == paths.root / "build"
+    assert paths.venv == paths.root / ".venv"
+    assert paths.wheel == paths.dist / wheel
+    assert paths.sdist == paths.dist / sdist
+
+
+def test_cli_returns_requested_path() -> None:
+    expected = str(
+        _load_release_paths_module().compute_release_paths(project_dir=REPO_ROOT).dist
+    )
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "dist"],
+        check=True,
+        capture_output=True,
+        cwd=REPO_ROOT,
+        text=True,
+    )
+
+    assert result.stdout.strip() == expected
+
+
+def test_cli_shell_output_contains_release_vars() -> None:
+    paths = _load_release_paths_module().compute_release_paths(project_dir=REPO_ROOT)
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "shell"],
+        check=True,
+        capture_output=True,
+        cwd=REPO_ROOT,
+        text=True,
+    )
+
+    exports = result.stdout.strip()
+    assert f"VERSION={paths.version}" in exports
+    assert f"WHEEL_TAG={paths.wheel_tag}" in exports
+    assert f"RELEASE_ROOT={paths.root}" in exports
+    assert f"RELEASE_DIST_DIR={paths.dist}" in exports

--- a/tools/release_paths.py
+++ b/tools/release_paths.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from packaging.utils import canonicalize_name
+from scikit_build_core._compat import tomllib
+from scikit_build_core.build.metadata import get_standard_metadata
+from scikit_build_core.builder.builder import archs_to_tags, get_archs
+from scikit_build_core.builder.wheel_tag import WheelTag
+from scikit_build_core.settings.skbuild_read_settings import SettingsReader
+
+
+@dataclass(frozen=True)
+class ReleasePaths:
+    version: str
+    wheel_tag: str
+    root: Path
+    dist: Path
+    build: Path
+    venv: Path
+    wheel: Path
+    sdist: Path
+
+    def get(self, key: str) -> str:
+        value = getattr(self, key.replace("-", "_"))
+        return str(value)
+
+    def shell_exports(self) -> str:
+        return " ".join(
+            f"{key}={shlex.quote(value)}"
+            for key, value in {
+                "VERSION": self.version,
+                "WHEEL_TAG": self.wheel_tag,
+                "RELEASE_ROOT": str(self.root),
+                "RELEASE_DIST_DIR": str(self.dist),
+                "RELEASE_BUILD_DIR": str(self.build),
+                "RELEASE_VENV": str(self.venv),
+                "RELEASE_WHEEL": str(self.wheel),
+                "RELEASE_SDIST": str(self.sdist),
+            }.items()
+        )
+
+
+def _load_metadata(project_dir: Path) -> tuple[Any, Any]:
+    with (project_dir / "pyproject.toml").open("rb") as f:
+        pyproject = tomllib.load(f)
+
+    settings = SettingsReader(pyproject, {}, state="wheel").settings
+    metadata = get_standard_metadata(pyproject, settings)
+    return metadata, settings
+
+
+def _root_is_purelib(settings: Any) -> bool:
+    wheel_settings = settings.wheel
+    if wheel_settings.platlib is None:
+        return not wheel_settings.cmake
+    return not wheel_settings.platlib
+
+
+def compute_release_paths(
+    *,
+    project_dir: Path | None = None,
+    release_dir: Path = Path("release"),
+) -> ReleasePaths:
+    project_dir = (project_dir or Path.cwd()).resolve()
+    metadata, settings = _load_metadata(project_dir)
+
+    if metadata.version is None:
+        msg = "project.version could not be resolved"
+        raise RuntimeError(msg)
+
+    wheel_tag = str(
+        WheelTag.compute_best(
+            archs_to_tags(get_archs(os.environ)),
+            settings.wheel.py_api,
+            expand_macos=settings.wheel.expand_macos_universal_tags,
+            root_is_purelib=_root_is_purelib(settings),
+            build_tag=settings.wheel.build_tag,
+        )
+    )
+    version = str(metadata.version)
+    root = release_dir / f"{version}-{wheel_tag}"
+    dist = root / "dist"
+    build = root / "build"
+    venv = root / ".venv"
+
+    wheel_name = (
+        f"{metadata.canonical_name.replace('-', '_')}-"
+        f"{str(metadata.version).replace('-', '_')}-{wheel_tag}.whl"
+    )
+    sdist_name = (
+        f"{canonicalize_name(metadata.name).replace('-', '_')}-"
+        f"{metadata.version}.tar.gz"
+    )
+
+    return ReleasePaths(
+        version=version,
+        wheel_tag=wheel_tag,
+        root=root,
+        dist=dist,
+        build=build,
+        venv=venv,
+        wheel=dist / wheel_name,
+        sdist=dist / sdist_name,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Compute release build paths from the current project metadata."
+    )
+    parser.add_argument(
+        "value",
+        choices=[
+            "version",
+            "wheel-tag",
+            "root",
+            "dist",
+            "build",
+            "venv",
+            "wheel",
+            "sdist",
+            "shell",
+        ],
+        help="The value to print.",
+    )
+    parser.add_argument(
+        "--project-dir",
+        type=Path,
+        default=Path.cwd(),
+        help="Project directory containing pyproject.toml.",
+    )
+    parser.add_argument(
+        "--release-dir",
+        type=Path,
+        default=Path("release"),
+        help="Base directory for release artifacts.",
+    )
+    args = parser.parse_args()
+
+    paths = compute_release_paths(
+        project_dir=args.project_dir,
+        release_dir=args.release_dir,
+    )
+    if args.value == "shell":
+        print(paths.shell_exports())
+    else:
+        print(paths.get(args.value))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Added new tool to assist with release build env and testing.

I really hate how we have to shell out to Python for real functionality and the whole pipe chaining because Make runs each line of a rule in a separate shell is annoying. We need to get off of Make.