### PR TITLE
Add is_subsequence predicate to Range

### DIFF
--- a/cpp/include/coconext/types/range.hpp
+++ b/cpp/include/coconext/types/range.hpp
@@ -126,6 +126,45 @@ struct Range {
     }
 };
 
+// A child range is a valid subsequence of a parent range iff every value in
+// the child appears (in order) in the parent. The rule collapses to:
+//   - length 0:   always a subsequence (any direction, any bounds)
+//   - length 1:   the single value must exist in the parent; the child's
+//                 direction is irrelevant (a one-element ordering is the same
+//                 either way)
+//   - length 2+:  the child's direction must match the parent's (otherwise
+//                 the child's values appear in the parent but in reversed
+//                 order, which isn't a subsequence) and both endpoints must
+//                 exist in the parent
+//
+// constexpr-evaluable, so callers can static_assert it at compile time as
+// well as use it as a runtime predicate.
+constexpr bool is_subsequence(Range parent, Range child) noexcept {
+    auto const in_parent = [&](Range::value_type v) {
+        if (parent.direction == Direction::TO) {
+            return v >= parent.left && v <= parent.right;
+        }
+        return v <= parent.left && v >= parent.right;
+    };
+    // This follows similar logic to operator==, but with in_parent predicate,
+    // and we aren't checking for equality of length, so we have
+    // to check for direction and right endpoint for length >= 2 cases.
+    auto const len = child.length();
+    if (len == 0) {
+        return true;
+    }
+    if (!in_parent(child.left)) {
+        return false;
+    }
+    if (len == 1) {
+        return true;
+    }
+    if (child.direction != parent.direction) {
+        return false;
+    }
+    return in_parent(child.right);
+}
+
 // more optimal implementation of std::ranges::find for Range
 constexpr Range::iterator find(Range const& range, Range::value_type value) {
     if (range.direction == Direction::TO) {

--- a/cpp/tests/test_range.cpp
+++ b/cpp/tests/test_range.cpp
@@ -146,4 +146,51 @@ TEST(TestRange, RangeIsHashable) {
     };
     EXPECT_EQ(different.size(), 2U);
 }
+
+// -- is_subsequence ---------------------------------------------------------
+
+TEST(TestRange, IsSubsequenceLengthZero) {
+    // A length-0 child is a subsequence of any parent, regardless of bounds
+    // or direction.
+    EXPECT_TRUE(is_subsequence(Range{0, Direction::TO, 4}, Range{99, Direction::TO, 50}));
+    EXPECT_TRUE(
+        is_subsequence(Range{0, Direction::TO, 4}, Range{50, Direction::DOWNTO, 99})
+    );
+}
+
+TEST(TestRange, IsSubsequenceLengthOneDirectionAgnostic) {
+    // A length-1 child is valid iff its single value is in the parent;
+    // direction is irrelevant for one element.
+    Range parent{0, Direction::TO, 4};
+    EXPECT_TRUE(is_subsequence(parent, Range{2, Direction::TO, 2}));
+    EXPECT_TRUE(is_subsequence(parent, Range{2, Direction::DOWNTO, 2}));
+    EXPECT_FALSE(is_subsequence(parent, Range{99, Direction::TO, 99}));
+}
+
+TEST(TestRange, IsSubsequenceLengthTwoPlus) {
+    Range parent{0, Direction::TO, 4};
+    EXPECT_TRUE(is_subsequence(parent, Range{1, Direction::TO, 3}));
+    EXPECT_FALSE(is_subsequence(parent, Range{1, Direction::DOWNTO, 0}));  // dir
+    EXPECT_FALSE(is_subsequence(parent, Range{99, Direction::TO, 100}));   // left
+    EXPECT_FALSE(is_subsequence(parent, Range{0, Direction::TO, 99}));     // right
+}
+
+TEST(TestRange, IsSubsequenceDOWNTOParent) {
+    // Exercise the DOWNTO branch of the in_parent helper, mirrored from the
+    // TO test above.
+    Range parent{4, Direction::DOWNTO, 0};
+    EXPECT_TRUE(is_subsequence(parent, Range{3, Direction::DOWNTO, 1}));
+    EXPECT_FALSE(is_subsequence(parent, Range{1, Direction::TO, 3}));  // dir
+    EXPECT_FALSE(is_subsequence(parent, Range{99, Direction::DOWNTO, 1}));
+    EXPECT_FALSE(is_subsequence(parent, Range{3, Direction::DOWNTO, -99}));
+}
+
+TEST(TestRange, IsSubsequenceConstexpr) {
+    // Usable in constant evaluation; downstream slice<R>() forms rely on this
+    // for their static_assert.
+    static_assert(is_subsequence(Range{0, Direction::TO, 4}, Range{1, Direction::TO, 3}));
+    static_assert(
+        !is_subsequence(Range{0, Direction::TO, 4}, Range{1, Direction::DOWNTO, 0})
+    );
+}
 // LCOV_EXCL_BR_STOP


### PR DESCRIPTION
A child Range is a subsequence of a parent Range iff every value in the child appears in order in the parent. This is the Range predicate that slice operations use to check validity.

This was factored out because it will be used in the static array bounds which is done in a static_assert.