### PR TITLE
Replace `to_string`s with `std::formatter`

### DIFF
--- a/cpp/include/coconext/types.hpp
+++ b/cpp/include/coconext/types.hpp
@@ -7,6 +7,7 @@
 #include "./types/direction.hpp"
 #include "./types/dynamic_array.hpp"
 #include "./types/logic.hpp"
+#include "./types/logic_array.hpp"
 #include "./types/range.hpp"
 // NOLINTEND(unused-includes)
 

--- a/cpp/include/coconext/types/concepts.hpp
+++ b/cpp/include/coconext/types/concepts.hpp
@@ -1,7 +1,10 @@
 #ifndef COCONEXT_TYPES_UTIL_HPP
 #define COCONEXT_TYPES_UTIL_HPP
 
-#include <string>
+#include <concepts>
+#include <cstddef>
+#include <format>
+#include <functional>
 #include <type_traits>
 
 namespace coconext::types {
@@ -52,18 +55,16 @@ struct is_int<unsigned long long> : public std::true_type {};
 
 namespace detail {
 
-// For use in other to_string methods. We can't overload std::to_string for
-// custom types, so we have to use ADL. This checks for both std and ADL
-// lookups. It also widens the result type requirements to anything that can be
-// used to build a string.
-template <typename T>
-concept Stringifiable = requires(T val, std::string s) { s += std::to_string(val); }
-                     || requires(T val, std::string s) { s += to_string(val); };
-
 template <typename T>
 concept Hashable = requires(T a) {
     { std::hash<T>{}(a) } -> std::convertible_to<std::size_t>;
 };
+
+// C++20 substitute for std::formattable (C++23). Strong enough to discriminate
+// types with a usable std::formatter specialization from those that fall back
+// to the disabled primary template.
+template <typename T>
+concept Formattable = std::semiregular<std::formatter<std::remove_cvref_t<T>, char>>;
 
 }  // namespace detail
 

--- a/cpp/include/coconext/types/direction.hpp
+++ b/cpp/include/coconext/types/direction.hpp
@@ -1,6 +1,7 @@
 #ifndef COCONEXT_DIRECTION_HPP
 #define COCONEXT_DIRECTION_HPP
 
+#include <format>
 #include <stdexcept>
 #include <string_view>
 
@@ -45,5 +46,20 @@ constexpr Direction to_direction(std::string_view value) {
 }
 
 }  // namespace coconext::types
+
+template <>
+struct std::formatter<coconext::types::Direction> {
+    constexpr auto parse(std::format_parse_context& ctx) {
+        auto it = ctx.begin();
+        if (it != ctx.end() && *it != '}') {
+            throw std::format_error("Direction formatter takes no format spec");
+        }
+        return it;
+    }
+
+    auto format(coconext::types::Direction d, std::format_context& ctx) const {
+        return std::format_to(ctx.out(), "Direction{{{}}}", coconext::types::to_string(d));
+    }
+};
 
 #endif  // COCONEXT_DIRECTION_HPP

--- a/cpp/include/coconext/types/dynamic_array.hpp
+++ b/cpp/include/coconext/types/dynamic_array.hpp
@@ -6,6 +6,7 @@
 #include <coconext/types/range.hpp>
 #include <concepts>
 #include <cstddef>
+#include <format>
 #include <initializer_list>
 #include <iterator>
 #include <memory>
@@ -308,22 +309,27 @@ constexpr bool operator==(
     return true;
 }
 
-template <RangedSequence ArrayT>
-    requires detail::Stringifiable<std::ranges::range_value_t<ArrayT>>
-std::string to_string(ArrayT const& arr) {
-    using std::to_string;  // make std::to_string and ADL candidates co-visible
-    std::string result = "Array([";
-    for (auto it = arr.begin(); it != arr.end(); ++it) {
-        result += to_string(*it);
-        if (std::next(it) != arr.end()) {
-            result += ", ";
+namespace detail {
+
+// Walks a RangedSequence, emitting "[range]{elem, elem, ...}" via the formatter
+// for each element type. Used by the generic Array/Slice formatters.
+template <RangedSequence ArrayT, typename OutIt>
+    requires Formattable<std::ranges::range_value_t<ArrayT>>
+OutIt format_array(ArrayT const& arr, OutIt out) {
+    out = std::format_to(out, "{}{{", arr.range());
+    bool first = true;
+    for (auto const& elem : arr) {
+        if (!first) {
+            out = std::format_to(out, ", ");
         }
+        out = std::format_to(out, "{}", elem);
+        first = false;
     }
-    result += "], ";
-    result += to_string(arr.range());
-    result += ")";
-    return result;
+    *out++ = '}';
+    return out;
 }
+
+}  // namespace detail
 
 static_assert(RangedSequence<DynamicArray<int>>);
 static_assert(RangedSequence<DynamicArray<int> const>);
@@ -340,6 +346,43 @@ struct std::hash<coconext::types::DynamicArray<T>> {
             seed = coconext::types::detail::hash_combine(seed, elem);
         }
         return seed;
+    }
+};
+
+template <typename T>
+    requires coconext::types::detail::Formattable<T>
+struct std::formatter<coconext::types::DynamicArray<T>> {
+    constexpr auto parse(std::format_parse_context& ctx) {
+        auto it = ctx.begin();
+        if (it != ctx.end() && *it != '}') {
+            throw std::format_error("DynamicArray formatter takes no format spec");
+        }
+        return it;
+    }
+
+    auto format(
+        coconext::types::DynamicArray<T> const& arr, std::format_context& ctx
+    ) const {
+        return coconext::types::detail::format_array(arr, ctx.out());
+    }
+};
+
+template <typename ArrayT>
+    requires coconext::types::detail::Formattable<
+        std::ranges::range_value_t<coconext::types::ArraySlice<ArrayT>>>
+struct std::formatter<coconext::types::ArraySlice<ArrayT>> {
+    constexpr auto parse(std::format_parse_context& ctx) {
+        auto it = ctx.begin();
+        if (it != ctx.end() && *it != '}') {
+            throw std::format_error("ArraySlice formatter takes no format spec");
+        }
+        return it;
+    }
+
+    auto format(
+        coconext::types::ArraySlice<ArrayT> const& arr, std::format_context& ctx
+    ) const {
+        return coconext::types::detail::format_array(arr, ctx.out());
     }
 };
 

--- a/cpp/include/coconext/types/logic.hpp
+++ b/cpp/include/coconext/types/logic.hpp
@@ -3,6 +3,7 @@
 
 #include <coconext/types/concepts.hpp>
 #include <cstdint>
+#include <format>
 #include <stdexcept>
 #include <string_view>
 #include <type_traits>
@@ -179,6 +180,10 @@ constexpr std::string_view to_string(Logic const& value) noexcept {
     return str_map[static_cast<size_t>(value.value())];
 }
 
+constexpr std::string_view to_string(Bit const& value) noexcept {
+    return value.value() == Bit::_0 ? "0" : "1";
+}
+
 constexpr char to_char(Logic const& value) noexcept {
     constexpr char char_map[] = {'0', '1', 'X', 'Z', 'U', 'W', 'L', 'H', '-'};
     return char_map[static_cast<size_t>(value.value())];
@@ -335,6 +340,36 @@ template <>
 struct std::hash<coconext::types::Bit> {
     size_t operator()(coconext::types::Bit const& bit) const noexcept {
         return std::hash<coconext::types::Bit::value_type>()(bit.value());
+    }
+};
+
+template <>
+struct std::formatter<coconext::types::Logic> {
+    constexpr auto parse(std::format_parse_context& ctx) {
+        auto it = ctx.begin();
+        if (it != ctx.end() && *it != '}') {
+            throw std::format_error("Logic formatter takes no format spec");
+        }
+        return it;
+    }
+
+    auto format(coconext::types::Logic const& v, std::format_context& ctx) const {
+        return std::format_to(ctx.out(), "Logic{{{}}}", coconext::types::to_string(v));
+    }
+};
+
+template <>
+struct std::formatter<coconext::types::Bit> {
+    constexpr auto parse(std::format_parse_context& ctx) {
+        auto it = ctx.begin();
+        if (it != ctx.end() && *it != '}') {
+            throw std::format_error("Bit formatter takes no format spec");
+        }
+        return it;
+    }
+
+    auto format(coconext::types::Bit v, std::format_context& ctx) const {
+        return std::format_to(ctx.out(), "Bit{{{}}}", coconext::types::to_string(v));
     }
 };
 

--- a/cpp/include/coconext/types/logic_array.hpp
+++ b/cpp/include/coconext/types/logic_array.hpp
@@ -1,0 +1,107 @@
+#ifndef COCONEXT_LOGIC_ARRAY_HPP
+#define COCONEXT_LOGIC_ARRAY_HPP
+
+#include <coconext/types/dynamic_array.hpp>
+#include <coconext/types/logic.hpp>
+#include <format>
+
+namespace coconext::types::detail {
+
+template <LogicType T>
+constexpr std::string_view logic_type_name() {
+    if constexpr (std::same_as<T, Logic>) {
+        return "Logic";
+    } else {
+        return "Bit";
+    }
+}
+
+// Variant for arrays of types with a bare to_string form (Logic, Bit). Prints
+// "TypeName[range]{e1, e2, ...}" with elements rendered via to_string instead
+// of std::formatter, suppressing the per-element type tag.
+template <RangedSequence ArrayT, typename OutIt>
+OutIt format_typed_array(std::string_view type_name, ArrayT const& arr, OutIt out) {
+    out = std::format_to(out, "{}{}{{", type_name, arr.range());
+    bool first = true;
+    for (auto const& elem : arr) {
+        if (!first) {
+            out = std::format_to(out, ", ");
+        }
+        out = std::format_to(out, "{}", to_string(elem));
+        first = false;
+    }
+    *out++ = '}';
+    return out;
+}
+
+}  // namespace coconext::types::detail
+
+template <coconext::types::LogicType T>
+    requires coconext::types::detail::Formattable<T>
+struct std::formatter<coconext::types::DynamicArray<T>> {
+    constexpr auto parse(std::format_parse_context& ctx) {
+        auto it = ctx.begin();
+        if (it != ctx.end() && *it != '}') {
+            throw std::format_error(
+                "DynamicArray<Logic/Bit> formatter takes no format spec"
+            );
+        }
+        return it;
+    }
+
+    auto format(
+        coconext::types::DynamicArray<T> const& arr, std::format_context& ctx
+    ) const {
+        return coconext::types::detail::format_typed_array(
+            coconext::types::detail::logic_type_name<T>(), arr, ctx.out()
+        );
+    }
+};
+
+template <coconext::types::LogicType T>
+    requires coconext::types::detail::Formattable<T>
+struct std::formatter<coconext::types::ArraySlice<coconext::types::DynamicArray<T>>> {
+    constexpr auto parse(std::format_parse_context& ctx) {
+        auto it = ctx.begin();
+        if (it != ctx.end() && *it != '}') {
+            throw std::format_error(
+                "ArraySlice<DynamicArray<Logic/Bit>> formatter takes no spec"
+            );
+        }
+        return it;
+    }
+
+    auto format(
+        coconext::types::ArraySlice<coconext::types::DynamicArray<T>> const& arr,
+        std::format_context& ctx
+    ) const {
+        return coconext::types::detail::format_typed_array(
+            coconext::types::detail::logic_type_name<T>(), arr, ctx.out()
+        );
+    }
+};
+
+template <coconext::types::LogicType T>
+    requires coconext::types::detail::Formattable<T>
+struct std::formatter<coconext::types::ArraySlice<coconext::types::DynamicArray<T> const>> {
+    constexpr auto parse(std::format_parse_context& ctx) {
+        auto it = ctx.begin();
+        if (it != ctx.end() && *it != '}') {
+            throw std::format_error(
+                "ArraySlice<DynamicArray<Logic/Bit>> formatter takes no spec"
+            );
+        }
+        return it;
+    }
+
+    auto format(
+        coconext::types::ArraySlice<coconext::types::DynamicArray<T> const> const& arr,
+        std::format_context& ctx
+    ) const {
+        return coconext::types::detail::format_typed_array(
+            coconext::types::detail::logic_type_name<T>(), arr, ctx.out()
+        );
+    }
+};
+
+#endif  // COCONEXT_LOGIC_ARRAY_HPP

--- a/cpp/include/coconext/types/range.hpp
+++ b/cpp/include/coconext/types/range.hpp
@@ -7,6 +7,7 @@
 #include <coconext/types/direction.hpp>
 #include <coconext/types/hash.hpp>
 #include <cstdint>
+#include <format>
 #include <limits>
 #include <ranges>
 #include <stdexcept>
@@ -180,20 +181,30 @@ constexpr Range::iterator find(Range const& range, Range::value_type value) {
     }
 }
 
-inline std::string to_string(Range const& range) {
-    auto res = std::string("Range(");
-    res += std::to_string(range.left);
-    res += ", '";
-    res += to_string(range.direction);
-    res += "', ";
-    res += std::to_string(range.right);
-    res += ")";
-    return res;
-}
-
 static_assert(std::ranges::random_access_range<Range>);
 
 }  // namespace coconext::types
+
+template <>
+struct std::formatter<coconext::types::Range> {
+    constexpr auto parse(std::format_parse_context& ctx) {
+        auto it = ctx.begin();
+        if (it != ctx.end() && *it != '}') {
+            throw std::format_error("Range formatter takes no format spec");
+        }
+        return it;
+    }
+
+    auto format(coconext::types::Range const& r, std::format_context& ctx) const {
+        return std::format_to(
+            ctx.out(),
+            "[{} {} {}]",
+            r.left,
+            coconext::types::to_string(r.direction),
+            r.right
+        );
+    }
+};
 
 template <>
 struct std::hash<coconext::types::Range> {

--- a/nanobind/src/types/bind_logic.cpp
+++ b/nanobind/src/types/bind_logic.cpp
@@ -54,7 +54,7 @@ void register_logic(nb::module_& m) {
             "__init__",
             [](Logic* self, long long value) { new (self) Logic(to_logic(value)); }
         )
-        .def("__str__", &to_string)
+        .def("__str__", [](Logic const& self) { return to_string(self); })
         .def("__index__", &to_int)
         .def("__bool__", [](Logic const& self) { return to_int(self) != 0; })
         .def(
@@ -150,7 +150,7 @@ void register_logic(nb::module_& m) {
             [](Bit* self, std::string_view value) { new (self) Bit(to_bit(value)); }
         )
         .def("__init__", [](Bit* self, long long value) { new (self) Bit(to_bit(value)); })
-        .def("__str__", &to_string)
+        .def("__str__", [](Bit const& self) { return to_string(self); })
         .def("__index__", &to_int)
         .def("__bool__", [](Bit const& self) { return to_int(self) != 0; })
         .def(

--- a/nanobind/src/types/bind_range.cpp
+++ b/nanobind/src/types/bind_range.cpp
@@ -7,6 +7,7 @@
 #include <coconext/types/concepts.hpp>
 #include <coconext/types/range.hpp>
 #include <cstdint>
+#include <format>
 
 namespace nb = nanobind;
 using namespace nb::literals;
@@ -117,7 +118,14 @@ void register_range(nb::module_& m) {
         )
         .def(nb::self == nb::self, nb::arg().noconvert())
         .def("__hash__", [](Range const& self) { return std::hash<Range>()(self); })
-        .def("__repr__", [](Range const& self) { return to_string(self); })
+        .def(
+            "__repr__",
+            [](Range const& self) {
+                return std::format(
+                    "Range({}, '{}', {})", self.left, to_string(self.direction), self.right
+                );
+            }
+        )
         .def(
             "index",
             [](Range const& self, int32_t value) {

--- a/tests/cpp/test_array.cpp
+++ b/tests/cpp/test_array.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 
 #include <coconext/types.hpp>
+#include <format>
 #include <functional>
 #include <numeric>
 #include <stdexcept>
@@ -459,24 +460,43 @@ TEST(TestArray, MoveAssignReplacesRange) {
     EXPECT_EQ(a[4], 40);
 }
 
-// -- to_string --------------------------------------------------------------
+// -- Formatter --------------------------------------------------------------
 
-TEST(TestArray, ToStringInt) {
+TEST(TestArray, FormatterInt) {
     Array<int> a({1, 2, 3});
-    EXPECT_EQ(to_string(a), "Array([1, 2, 3], Range(0, 'to', 2))");
+    EXPECT_EQ(std::format("{}", a), "[0 to 2]{1, 2, 3}");
 }
 
-TEST(TestArray, ToStringEmpty) {
+TEST(TestArray, FormatterEmpty) {
     Array<int> a({});
-    EXPECT_EQ(to_string(a), "Array([], Range(0, 'to', -1))");
+    EXPECT_EQ(std::format("{}", a), "[0 to -1]{}");
 }
 
-TEST(TestArray, ToStringLogic) {
-    // Exercises the ADL path in to_string (Logic's to_string is in
-    // coconext::types, not std).
+TEST(TestArray, FormatterLogic) {
     Array<Logic> a({'0'_l, '1'_l, 'X'_l});
-    auto s = to_string(a);
-    EXPECT_NE(s.find("0"), std::string::npos);
-    EXPECT_NE(s.find("X"), std::string::npos);
+    EXPECT_EQ(std::format("{}", a), "Logic[0 to 2]{0, 1, X}");
+}
+
+TEST(TestArray, FormatterBit) {
+    Array<Bit> a({'0'_b, '1'_b, '0'_b, '1'_b});
+    EXPECT_EQ(std::format("{}", a), "Bit[0 to 3]{0, 1, 0, 1}");
+}
+
+TEST(TestArray, FormatterLogicSlice) {
+    Array<Logic> a({'0'_l, '1'_l, 'X'_l, 'Z'_l});
+    auto s = a[Range(1, 2)];
+    EXPECT_EQ(std::format("{}", s), "Logic[1 to 2]{1, X}");
+}
+
+TEST(TestArray, FormatterLogicConstSlice) {
+    Array<Logic> const a({'0'_l, '1'_l, 'X'_l, 'Z'_l});
+    auto s = a[Range(1, 2)];
+    EXPECT_EQ(std::format("{}", s), "Logic[1 to 2]{1, X}");
+}
+
+TEST(TestArray, FormatterBitSlice) {
+    Array<Bit> a({'0'_b, '1'_b, '0'_b, '1'_b});
+    auto s = a[Range(1, 2)];
+    EXPECT_EQ(std::format("{}", s), "Bit[1 to 2]{1, 0}");
 }
 // LCOV_EXCL_BR_STOP

--- a/tests/cpp/test_logic.cpp
+++ b/tests/cpp/test_logic.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 
 #include <coconext/types.hpp>
+#include <format>
 #include <stdexcept>
 #include <unordered_set>
 #include <vector>
@@ -125,6 +126,18 @@ TEST(TestLogic, LogicStringConversions) {
 TEST(TestBit, BitStringConversions) {
     EXPECT_EQ(to_string('0'_b), "0");
     EXPECT_EQ(to_string('1'_b), "1");
+}
+
+TEST(TestLogic, LogicFormatter) {
+    EXPECT_EQ(std::format("{}", '0'_l), "Logic{0}");
+    EXPECT_EQ(std::format("{}", '1'_l), "Logic{1}");
+    EXPECT_EQ(std::format("{}", 'X'_l), "Logic{X}");
+    EXPECT_EQ(std::format("{}", 'Z'_l), "Logic{Z}");
+}
+
+TEST(TestBit, BitFormatter) {
+    EXPECT_EQ(std::format("{}", '0'_b), "Bit{0}");
+    EXPECT_EQ(std::format("{}", '1'_b), "Bit{1}");
 }
 
 TEST(TestLogic, LogicCharConversions) {

--- a/tests/cpp/test_range.cpp
+++ b/tests/cpp/test_range.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 
 #include <coconext/types.hpp>
+#include <format>
 #include <stdexcept>
 #include <unordered_set>
 #include <vector>
@@ -101,9 +102,14 @@ TEST(TestRange, OtherConstructors) {
     EXPECT_EQ(Range(3, -4), Range(3, Direction::DOWNTO, -4));
 }
 
-TEST(TestRange, ReprEquivalent) {
-    Range const r(5, Direction::TO, 9);
-    EXPECT_EQ(to_string(r), "Range(5, 'to', 9)");
+TEST(TestRange, Formatter) {
+    EXPECT_EQ(std::format("{}", Range(5, Direction::TO, 9)), "[5 to 9]");
+    EXPECT_EQ(std::format("{}", Range(9, Direction::DOWNTO, 5)), "[9 downto 5]");
+}
+
+TEST(TestDirection, Formatter) {
+    EXPECT_EQ(std::format("{}", Direction::TO), "Direction{to}");
+    EXPECT_EQ(std::format("{}", Direction::DOWNTO), "Direction{downto}");
 }
 
 TEST(TestRange, UppercaseDirection) {

--- a/tests/python/test_logic.py
+++ b/tests/python/test_logic.py
@@ -218,6 +218,16 @@ def test_bit_constructor() -> None:
         Bit(a)
 
 
+def test_bit_str_conversions() -> None:
+    assert str(Bit(0)) == "0"
+    assert str(Bit(1)) == "1"
+
+
+def test_bit_repr() -> None:
+    assert eval(repr(Bit(0))) == Bit(0)
+    assert eval(repr(Bit(1))) == Bit(1)
+
+
 def test_bit_ops() -> None:
     assert Bit(1) | Bit(0) == Bit(1)
     assert Bit(1) & Bit(0) == Bit(0)


### PR DESCRIPTION
Closes #203.

We previously used to_string for "printable" string conversions, but this isn't ideal. We should have a function for converting to "printable" formats and another that is simply value as string conversion ("to_string"). For example, Logic and LogicArray have "string" conversions which are the binstr that is the stringly-typed version of those types that used by the simulator.

The simplest, but certainly not perfect, solution to printability is std::formatter. It separates the interface from to_string and also adds in some useful features for free as well as some customization points for everything short of pretty-printing.

Finally we left to_string for Logic, Bit, and Direction as they have string value equivalences.