### PR TITLE
Static Range improvements

### DIFF
--- a/cpp/include/coconext/types/array.hpp
+++ b/cpp/include/coconext/types/array.hpp
@@ -188,6 +188,12 @@ static_assert(RangedSequence<Array<int, Range{0, Direction::TO, 7}> const>);
 static_assert(RangedSequence<ArraySlice<Array<int, Range{0, Direction::TO, 7}>>>);
 static_assert(RangedSequence<ArraySlice<Array<int, Range{0, Direction::TO, 7}> const>>);
 
+// Array's range is part of its type, so it matches; a runtime slice (even
+// over a static Array) does not.
+static_assert(StaticRangedSequence<Array<int, Range{0, Direction::TO, 7}>>);
+static_assert(StaticRangedSequence<Array<int, Range{0, Direction::TO, 7}> const>);
+static_assert(!StaticRangedSequence<ArraySlice<Array<int, Range{0, Direction::TO, 7}>>>);
+
 }  // namespace detail
 
 // Static-bounded array. Range is built from the trailing NTTPs:

--- a/cpp/include/coconext/types/array.hpp
+++ b/cpp/include/coconext/types/array.hpp
@@ -183,6 +183,15 @@ constexpr bool operator==(Array<T, R> const& lhs, Array<T, R> const& rhs) noexce
 template <typename T, Range R>
 struct is_array<Array<T, R>> : std::true_type {};
 
+}  // namespace detail
+
+template <typename T, Range R>
+struct static_range_of<detail::Array<T, R>> {
+    static constexpr Range value = R;
+};
+
+namespace detail {
+
 static_assert(RangedSequence<Array<int, Range{0, Direction::TO, 7}>>);
 static_assert(RangedSequence<Array<int, Range{0, Direction::TO, 7}> const>);
 static_assert(RangedSequence<ArraySlice<Array<int, Range{0, Direction::TO, 7}>>>);

--- a/cpp/include/coconext/types/array_base.hpp
+++ b/cpp/include/coconext/types/array_base.hpp
@@ -37,12 +37,19 @@ concept RangedSequence = std::ranges::random_access_range<T> && requires(T& t) {
     { t.range() } -> std::convertible_to<Range>;
 };
 
-// A RangedSequence whose range is known at compile time, exposed as a static
-// member. Lets generic code fold offsets into the owner against a constexpr
-// range instead of recomputing them at runtime via find()/distance().
+// Customization point. A type opts into StaticRangedSequence by specializing
+// this trait so that ::value is a Range constant expression. Specialize this
+// instead of requiring an intrusive member, so external/wrapper types can
+// participate without modification.
+template <typename T>
+struct static_range_of;
+
+// A RangedSequence whose range is known at compile time, exposed via the
+// static_range_of trait. Lets generic code fold offsets into the owner against
+// a constexpr range instead of recomputing them at runtime via find()/distance().
 template <typename T>
 concept StaticRangedSequence = RangedSequence<T> && requires {
-    { std::remove_cvref_t<T>::static_range } -> std::convertible_to<Range>;
+    { static_range_of<std::remove_cvref_t<T>>::value } -> std::convertible_to<Range>;
 };
 
 // Any type that opts into the array machinery via is_array. Element-type

--- a/cpp/include/coconext/types/array_base.hpp
+++ b/cpp/include/coconext/types/array_base.hpp
@@ -37,6 +37,14 @@ concept RangedSequence = std::ranges::random_access_range<T> && requires(T& t) {
     { t.range() } -> std::convertible_to<Range>;
 };
 
+// A RangedSequence whose range is known at compile time, exposed as a static
+// member. Lets generic code fold offsets into the owner against a constexpr
+// range instead of recomputing them at runtime via find()/distance().
+template <typename T>
+concept StaticRangedSequence = RangedSequence<T> && requires {
+    { std::remove_cvref_t<T>::static_range } -> std::convertible_to<Range>;
+};
+
 // Any type that opts into the array machinery via is_array. Element-type
 // constraints (formattability, etc.) live on the consumers that need them,
 // not on this concept.

--- a/cpp/include/coconext/types/dyn_array.hpp
+++ b/cpp/include/coconext/types/dyn_array.hpp
@@ -208,6 +208,10 @@ static_assert(RangedSequence<DynArray<int> const>);
 static_assert(RangedSequence<ArraySlice<DynArray<int>>>);
 static_assert(RangedSequence<ArraySlice<DynArray<int> const>>);
 
+// Neither DynArray nor a runtime-ranged slice exposes static_range.
+static_assert(!StaticRangedSequence<DynArray<int>>);
+static_assert(!StaticRangedSequence<ArraySlice<DynArray<int>>>);
+
 }  // namespace coconext::types
 
 template <typename T>


### PR DESCRIPTION
Depends on #233. Adds a `StaticRangedSequence` to mirror the dynamic version and a `static_range_of` customization point for pulling off static ranges of things (I see packed objects really screwing with our ability to assume `static_range` is sufficient.