### PR TITLE
Static ArraySlice equivalent

### DIFF
--- a/cpp/include/coconext/types/array.hpp
+++ b/cpp/include/coconext/types/array.hpp
@@ -137,13 +137,32 @@ class Array {
     constexpr const_reference operator[](index_type idx) const {
         return access_(*this, idx);
     }
-    constexpr ArraySlice<Array> operator[](Range r) {
+    constexpr DynArraySlice<Array> operator[](Range r) {
         detail::subsequence_check(static_range, r);
-        return ArraySlice<Array>(this, r);
+        return DynArraySlice<Array>(this, r);
     }
-    constexpr ArraySlice<Array const> operator[](Range r) const {
+    constexpr DynArraySlice<Array const> operator[](Range r) const {
         detail::subsequence_check(static_range, r);
-        return ArraySlice<Array const>(this, r);
+        return DynArraySlice<Array const>(this, r);
+    }
+
+    // Compile-time-checked sub-slice. R2 is validated against R at compile time;
+    // the result keeps the static range so its bounds checks fold to constants.
+    template <Range R2>
+    constexpr ArraySlice<Array, R2> slice() {
+        static_assert(
+            is_subsequence(R, R2),
+            "static sub-slice range is not a sub-range of the parent Array"
+        );
+        return ArraySlice<Array, R2>(this);
+    }
+    template <Range R2>
+    constexpr ArraySlice<Array const, R2> slice() const {
+        static_assert(
+            is_subsequence(R, R2),
+            "static sub-slice range is not a sub-range of the parent Array"
+        );
+        return ArraySlice<Array const, R2>(this);
     }
 
     constexpr iterator begin() noexcept { return data_.begin(); }
@@ -194,14 +213,25 @@ namespace detail {
 
 static_assert(RangedSequence<Array<int, Range{0, Direction::TO, 7}>>);
 static_assert(RangedSequence<Array<int, Range{0, Direction::TO, 7}> const>);
-static_assert(RangedSequence<ArraySlice<Array<int, Range{0, Direction::TO, 7}>>>);
-static_assert(RangedSequence<ArraySlice<Array<int, Range{0, Direction::TO, 7}> const>>);
+static_assert(RangedSequence<DynArraySlice<Array<int, Range{0, Direction::TO, 7}>>>);
+static_assert(RangedSequence<DynArraySlice<Array<int, Range{0, Direction::TO, 7}> const>>);
+static_assert(
+    RangedSequence<
+        ArraySlice<Array<int, Range{0, Direction::TO, 7}>, Range{1, Direction::TO, 3}>>
+);
+static_assert(RangedSequence<ArraySlice<
+                  Array<int, Range{0, Direction::TO, 7}> const,
+                  Range{1, Direction::TO, 3}>>);
 
-// Array's range is part of its type, so it matches; a runtime slice (even
-// over a static Array) does not.
+// Array's range is part of its type, so it matches; a runtime view (even of
+// a static Array) does not.
 static_assert(StaticRangedSequence<Array<int, Range{0, Direction::TO, 7}>>);
 static_assert(StaticRangedSequence<Array<int, Range{0, Direction::TO, 7}> const>);
-static_assert(!StaticRangedSequence<ArraySlice<Array<int, Range{0, Direction::TO, 7}>>>);
+static_assert(!StaticRangedSequence<DynArraySlice<Array<int, Range{0, Direction::TO, 7}>>>);
+static_assert(
+    StaticRangedSequence<
+        ArraySlice<Array<int, Range{0, Direction::TO, 7}>, Range{1, Direction::TO, 3}>>
+);
 
 }  // namespace detail
 

--- a/cpp/include/coconext/types/array_base.hpp
+++ b/cpp/include/coconext/types/array_base.hpp
@@ -70,28 +70,28 @@ constexpr void subsequence_check(Range parent, Range child) {
 
 }  // namespace detail
 
-template <typename ArrayT>
+template <typename ArrayT, Range R>
 class ArraySlice;
 
 template <typename ArrayT>
-class ArraySlice {
+class DynArraySlice {
   public:
-    // ArraySlice is a non-owning view (like std::span). Element mutability is
-    // determined by ArrayT's constness:
-    // - ArraySlice<ArrayT>          -- mutable view, can write elements.
-    // - ArraySlice<const ArrayT>    -- read-only view.
-    // - const ArraySlice<X>         -- pointer/range fixed; element access
-    //                                  follows X's mutability rules.
+    // DynArraySlice is a non-owning view (like std::span) with a runtime
+    // range. Element mutability is determined by ArrayT's constness:
+    // - DynArraySlice<ArrayT>          -- mutable view, can write elements.
+    // - DynArraySlice<const ArrayT>    -- read-only view.
+    // - const DynArraySlice<X>         -- pointer/range fixed; element access
+    //                                     follows X's mutability rules.
     using value_type = std::ranges::range_value_t<ArrayT>;
     using reference = std::ranges::range_reference_t<ArrayT>;
     using index_type = Range::value_type;
     using iterator = std::ranges::iterator_t<ArrayT>;
     static_assert(!std::is_reference_v<value_type>);
 
-    constexpr ArraySlice() = delete;
-    constexpr ArraySlice(ArraySlice const&) = default;
-    constexpr ArraySlice(ArraySlice&&) = default;
-    constexpr ArraySlice(ArrayT* arr, Range range) noexcept : arr_(arr), range_(range) {}
+    constexpr DynArraySlice() = delete;
+    constexpr DynArraySlice(DynArraySlice const&) = default;
+    constexpr DynArraySlice(DynArraySlice&&) = default;
+    constexpr DynArraySlice(ArrayT* arr, Range range) noexcept : arr_(arr), range_(range) {}
 
     constexpr Range const& range() const noexcept { return range_; }
 
@@ -105,18 +105,27 @@ class ArraySlice {
         }
         return *(begin() + std::distance(range_.begin(), it));
     }
-    // Sub-slicing flattens: returns a new ArraySlice over the same underlying
-    // array with a new range. Validity is checked against the slice's own
-    // range_, not arr_->range().
-    constexpr ArraySlice operator[](Range r) const {
+    // Sub-slicing flattens: returns a new DynArraySlice over the same
+    // underlying array with a new range. Validity is checked against the
+    // slice's own range_, not arr_->range().
+    constexpr DynArraySlice operator[](Range r) const {
         detail::subsequence_check(range_, r);
-        return ArraySlice(arr_, r);
+        return DynArraySlice(arr_, r);
+    }
+
+    // Static sub-slicing flattens to ArraySlice<ArrayT, R> over the same
+    // underlying array. The subsequence check is runtime here (this slice's
+    // own bound is dynamic).
+    template <Range R>
+    constexpr ArraySlice<ArrayT, R> slice() const {
+        detail::subsequence_check(range_, R);
+        return ArraySlice<ArrayT, R>(arr_);
     }
 
     template <detail::sized_input_range R>
         requires(!std::is_const_v<ArrayT>)
              && std::convertible_to<std::ranges::range_value_t<R>, value_type>
-    constexpr ArraySlice const& operator=(R const& obj) const {
+    constexpr DynArraySlice const& operator=(R const& obj) const {
         if (std::ranges::size(obj) != range_.length()) {
             throw std::invalid_argument(
                 "Value of length " + std::to_string(std::ranges::size(obj))
@@ -130,7 +139,7 @@ class ArraySlice {
 
     template <typename T>
         requires(!std::is_const_v<ArrayT>) && std::convertible_to<T, value_type>
-    constexpr ArraySlice const& operator=(std::initializer_list<T> init) const {
+    constexpr DynArraySlice const& operator=(std::initializer_list<T> init) const {
         if (init.size() != static_cast<size_t>(range_.length())) {
             throw std::invalid_argument(
                 "Initializer list of size " + std::to_string(init.size())
@@ -165,10 +174,132 @@ class ArraySlice {
     Range range_;
 };
 
+// Compile-time-bounded counterpart to DynArraySlice. R is part of the type,
+// so length, bounds checks, and indexing fold against R. When the parent's
+// range is also a compile-time constant (a static Array, or another static
+// ArraySlice), begin()/end() collapse to a single pointer offset.
+template <typename ArrayT, Range R>
+class ArraySlice {
+  public:
+    using value_type = std::ranges::range_value_t<ArrayT>;
+    using reference = std::ranges::range_reference_t<ArrayT>;
+    using index_type = Range::value_type;
+    using iterator = std::ranges::iterator_t<ArrayT>;
+    static_assert(!std::is_reference_v<value_type>);
+
+    static constexpr Range static_range = R;
+
+    constexpr ArraySlice() = delete;
+    constexpr ArraySlice(ArraySlice const&) = default;
+    constexpr ArraySlice(ArraySlice&&) = default;
+    constexpr explicit ArraySlice(ArrayT* arr) noexcept : arr_(arr) {}
+
+    constexpr Range const& range() const noexcept { return static_range; }
+
+    constexpr reference operator[](index_type idx) const {
+        if constexpr (R.direction == Direction::TO) {
+            if (idx < R.left || idx > R.right) {
+                throw std::out_of_range("Index out of bounds");
+            }
+            return *(begin() + (idx - R.left));
+        } else {
+            if (idx > R.left || idx < R.right) {
+                throw std::out_of_range("Index out of bounds");
+            }
+            return *(begin() + (R.left - idx));
+        }
+    }
+
+    // Static sub-slicing flattens to ArraySlice<ArrayT, R2> over the same
+    // underlying array. R2's validity against R is checked at compile time.
+    template <Range R2>
+    constexpr ArraySlice<ArrayT, R2> slice() const {
+        static_assert(
+            is_subsequence(R, R2),
+            "static sub-slice range is not a sub-range of the parent slice"
+        );
+        return ArraySlice<ArrayT, R2>(arr_);
+    }
+
+    // Runtime sub-slicing flattens to DynArraySlice<ArrayT> -- the result is
+    // no longer compile-time-bounded, since r is a runtime value.
+    constexpr DynArraySlice<ArrayT> operator[](Range r) const {
+        detail::subsequence_check(R, r);
+        return DynArraySlice<ArrayT>(arr_, r);
+    }
+
+    template <detail::sized_input_range Rng>
+        requires(!std::is_const_v<ArrayT>)
+             && std::convertible_to<std::ranges::range_value_t<Rng>, value_type>
+    constexpr ArraySlice const& operator=(Rng const& obj) const {
+        if (std::ranges::size(obj) != R.length()) {
+            throw std::invalid_argument(
+                "Value of length " + std::to_string(std::ranges::size(obj))
+                + " cannot be assigned to array slice of length "
+                + std::to_string(R.length())
+            );
+        }
+        std::ranges::copy(obj, begin());
+        return *this;
+    }
+
+    template <typename T>
+        requires(!std::is_const_v<ArrayT>) && std::convertible_to<T, value_type>
+    constexpr ArraySlice const& operator=(std::initializer_list<T> init) const {
+        if (init.size() != R.length()) {
+            throw std::invalid_argument(
+                "Initializer list of size " + std::to_string(init.size())
+                + " cannot be assigned to array slice of length "
+                + std::to_string(R.length())
+            );
+        }
+        std::ranges::copy(init, begin());
+        return *this;
+    }
+
+    constexpr iterator begin() const noexcept {
+        // Null slices may carry bounds outside the parent's range (the
+        // validity rule allows that). Pin them to the parent's begin so
+        // begin()/end() form a well-formed empty iterator pair.
+        if constexpr (R.length() == 0) {
+            return arr_->begin();
+        } else if constexpr (StaticRangedSequence<ArrayT>) {
+            // Parent's range is a compile-time constant; fold the offset to
+            // a constant instead of recomputing it via find()/distance().
+            constexpr auto parent = static_range_of<std::remove_cvref_t<ArrayT>>::value;
+            constexpr auto offset = parent.direction == Direction::TO
+                                      ? R.left - parent.left
+                                      : parent.left - R.left;
+            return arr_->begin() + offset;
+        } else {
+            auto start = find(arr_->range(), R.left);
+            assert(
+                start != arr_->range().end()
+                && "slice range not a sub-range of the owner's range"
+            );
+            return arr_->begin() + std::distance(arr_->range().begin(), start);
+        }
+    }
+    constexpr iterator end() const noexcept { return begin() + R.length(); }
+    constexpr auto rbegin() const noexcept { return std::reverse_iterator(end()); }
+    constexpr auto rend() const noexcept { return std::reverse_iterator(begin()); }
+
+  private:
+    ArrayT* arr_;
+};
+
+template <typename ArrayT, Range R>
+struct static_range_of<ArraySlice<ArrayT, R>> {
+    static constexpr Range value = R;
+};
+
 namespace detail {
 
 template <typename ArrayT>
-struct is_array<ArraySlice<ArrayT>> : std::true_type {};
+struct is_array<DynArraySlice<ArrayT>> : std::true_type {};
+
+template <typename ArrayT, Range R>
+struct is_array<ArraySlice<ArrayT, R>> : std::true_type {};
 
 // -- Formatter ----------------------------------------------------------------
 

--- a/cpp/include/coconext/types/dyn_array.hpp
+++ b/cpp/include/coconext/types/dyn_array.hpp
@@ -130,13 +130,27 @@ class DynArray {
     COCONEXT_DYN_ARRAY_CONSTEXPR const_reference operator[](index_type idx) const {
         return access_(*this, idx);
     }
-    COCONEXT_DYN_ARRAY_CONSTEXPR ArraySlice<DynArray> operator[](Range r) {
+    COCONEXT_DYN_ARRAY_CONSTEXPR DynArraySlice<DynArray> operator[](Range r) {
         detail::subsequence_check(range_, r);
-        return ArraySlice<DynArray>(this, r);
+        return DynArraySlice<DynArray>(this, r);
     }
-    COCONEXT_DYN_ARRAY_CONSTEXPR ArraySlice<DynArray const> operator[](Range r) const {
+    COCONEXT_DYN_ARRAY_CONSTEXPR DynArraySlice<DynArray const> operator[](Range r) const {
         detail::subsequence_check(range_, r);
-        return ArraySlice<DynArray const>(this, r);
+        return DynArraySlice<DynArray const>(this, r);
+    }
+
+    // Statically-typed sub-slice. R lives in the result type, so the slice's
+    // own bounds checks fold to constants; the subsequence check against this
+    // DynArray's runtime range happens once, here.
+    template <Range R>
+    COCONEXT_DYN_ARRAY_CONSTEXPR ArraySlice<DynArray, R> slice() {
+        detail::subsequence_check(range_, R);
+        return ArraySlice<DynArray, R>(this);
+    }
+    template <Range R>
+    COCONEXT_DYN_ARRAY_CONSTEXPR ArraySlice<DynArray const, R> slice() const {
+        detail::subsequence_check(range_, R);
+        return ArraySlice<DynArray const, R>(this);
     }
 
     COCONEXT_DYN_ARRAY_CONSTEXPR iterator begin() noexcept { return data_.get(); }
@@ -205,12 +219,17 @@ struct is_array<DynArray<T>> : std::true_type {};
 
 static_assert(RangedSequence<DynArray<int>>);
 static_assert(RangedSequence<DynArray<int> const>);
-static_assert(RangedSequence<ArraySlice<DynArray<int>>>);
-static_assert(RangedSequence<ArraySlice<DynArray<int> const>>);
+static_assert(RangedSequence<DynArraySlice<DynArray<int>>>);
+static_assert(RangedSequence<DynArraySlice<DynArray<int> const>>);
+static_assert(RangedSequence<ArraySlice<DynArray<int>, Range{0, Direction::TO, 3}>>);
+static_assert(RangedSequence<ArraySlice<DynArray<int> const, Range{0, Direction::TO, 3}>>);
 
-// Neither DynArray nor a runtime-ranged slice exposes static_range.
+// Runtime-ranged types have no static_range, so they must not match.
 static_assert(!StaticRangedSequence<DynArray<int>>);
-static_assert(!StaticRangedSequence<ArraySlice<DynArray<int>>>);
+static_assert(!StaticRangedSequence<DynArraySlice<DynArray<int>>>);
+// ArraySlice carries the range in its type, so it does match -- even when the
+// underlying owner's range is runtime-only.
+static_assert(StaticRangedSequence<ArraySlice<DynArray<int>, Range{0, Direction::TO, 3}>>);
 
 }  // namespace coconext::types
 

--- a/cpp/include/coconext/types/logic_array.hpp
+++ b/cpp/include/coconext/types/logic_array.hpp
@@ -45,13 +45,12 @@ using DynLogicArray = DynArray<Logic>;
 }  // namespace coconext::types
 
 // One LogicType-constrained formatter for every array type that opts into
-// is_array (DynArray, Array, ArraySlice). The
-// constraint is a conjunction of the generic ArrayType constraint plus a
-// LogicType check on the element type, so it subsumes the generic
-// std::formatter<ArrayType T> in array_base.hpp via C++20 partial
-// specialization ordering with constraints. Result: arrays of Logic/Bit
-// print as "Logic[range]{0, 1, X}" instead of "[range]{Logic{0}, Logic{1},
-// Logic{X}}".
+// is_array (DynArray, Array, DynArraySlice, ArraySlice). The constraint is a
+// conjunction of the generic ArrayType constraint plus a LogicType check on
+// the element type, so it subsumes the generic std::formatter<ArrayType T> in
+// array_base.hpp via C++20 partial specialization ordering with constraints.
+// Result: arrays of Logic/Bit print as "Logic[range]{0, 1, X}" instead of
+// "[range]{Logic{0}, Logic{1}, Logic{X}}".
 template <typename T>
     requires coconext::types::ArrayType<T>
           && coconext::types::detail::Formattable<std::ranges::range_value_t<T>>

--- a/tests/cpp/test_array.cpp
+++ b/tests/cpp/test_array.cpp
@@ -224,7 +224,7 @@ TEST(TestDynArray, SliceOfSliceFlattens) {
     auto s1 = a[{1, 6}];
     auto s2 = s1[{2, 4}];
     static_assert(
-        std::is_same_v<decltype(s2), ArraySlice<DynArray<int>>>,
+        std::is_same_v<decltype(s2), DynArraySlice<DynArray<int>>>,
         "slice-of-slice must flatten"
     );
     EXPECT_EQ(s2[2], 3);
@@ -252,7 +252,7 @@ TEST(TestDynArray, SliceOfSliceDirectionMismatch) {
     EXPECT_THROW((void)(s1[{1, 4}]), std::invalid_argument);
 }
 
-// Same error paths but on const DynArray / const ArraySlice; index() and
+// Same error paths but on const DynArray / const DynArraySlice; index() and
 // slice() are templates, so const and non-const callers instantiate separate
 // specializations and each throw needs to be exercised independently.
 TEST(TestDynArray, IndexingConstOutOfRange) {
@@ -307,7 +307,7 @@ TEST(TestDynArray, ConstructLogicFromRange) {
 TEST(TestDynArray, ConstSliceOverConstArray) {
     DynArray<int> const a({10, 20, 30, 40});
     auto s = a[{1, 2}];
-    static_assert(std::is_same_v<decltype(s), ArraySlice<DynArray<int> const>>);
+    static_assert(std::is_same_v<decltype(s), DynArraySlice<DynArray<int> const>>);
     EXPECT_EQ(s[1], 20);
     static_assert(std::is_same_v<decltype(s[1]), int const&>);
 }
@@ -324,7 +324,7 @@ TEST(TestDynArray, ConstSliceOverMutableArrayMutates) {
     // not restrict element access. The slice's own const-ness only fixes the
     // pointer/range; the underlying ArrayT determines element mutability.
     DynArray<int> a({1, 2, 3, 4});
-    auto const cs = a[{0, 3}];  // const ArraySlice<DynArray<int>>
+    auto const cs = a[{0, 3}];  // const DynArraySlice<DynArray<int>>
     cs[0] = 99;                 // mutation through const slice
     cs = std::vector<int>{10, 20, 30, 40};
     EXPECT_EQ(a[0], 10);
@@ -485,6 +485,96 @@ TEST(TestDynArray, FormatterBitSlice) {
     EXPECT_EQ(std::format("{}", s), "Bit[1 to 2]{1, 0}");
 }
 
+// -- Static slice of DynArray (compile-time-bounded view) -----------------
+
+TEST(TestDynArrayStaticSlice, SliceHappyPath) {
+    DynArray<int> a({10, 20, 30, 40, 50});
+    auto s = a.slice<Range{1, 3}>();
+    static_assert(
+        std::is_same_v<decltype(s), ArraySlice<DynArray<int>, Range{1, 3}>>,
+        "DynArray::slice<R>() must return a static ArraySlice"
+    );
+    static_assert(decltype(s)::static_range == Range{1, Direction::TO, 3});
+    EXPECT_EQ(s.range().length(), 3U);
+    EXPECT_EQ(s[1], 20);
+    EXPECT_EQ(s[3], 40);
+}
+
+TEST(TestDynArrayStaticSlice, SliceMutatesUnderlying) {
+    DynArray<int> a({1, 2, 3, 4, 5});
+    auto s = a.slice<Range{1, 3}>();
+    s[2] = 99;
+    EXPECT_EQ(a[2], 99);
+}
+
+TEST(TestDynArrayStaticSlice, SliceAssignFromRange) {
+    DynArray<int> a({1, 2, 3, 4, 5});
+    auto s = a.slice<Range{1, 3}>();
+    s = std::vector<int>{20, 30, 40};
+    EXPECT_EQ(a[1], 20);
+    EXPECT_EQ(a[3], 40);
+}
+
+TEST(TestDynArrayStaticSlice, SliceAssignFromInitializerList) {
+    DynArray<int> a({1, 2, 3, 4, 5});
+    auto s = a.slice<Range{1, 3}>();
+    s = {7, 8, 9};
+    EXPECT_EQ(a[2], 8);
+}
+
+TEST(TestDynArrayStaticSlice, SliceAssignWrongLength) {
+    DynArray<int> a({1, 2, 3, 4, 5});
+    auto s = a.slice<Range{1, 3}>();
+    EXPECT_THROW((s = std::vector<int>{1, 2, 3, 4}), std::invalid_argument);
+}
+
+TEST(TestDynArrayStaticSlice, SliceOutOfRangeRuntime) {
+    DynArray<int> a({1, 2, 3});
+    EXPECT_THROW((void)(a.slice<Range{99, 100}>()), std::invalid_argument);
+}
+
+TEST(TestDynArrayStaticSlice, SliceConstReturnsConstSlice) {
+    DynArray<int> const a({10, 20, 30, 40});
+    auto s = a.slice<Range{1, 2}>();
+    static_assert(
+        std::is_same_v<decltype(s), ArraySlice<DynArray<int> const, Range{1, 2}>>
+    );
+    static_assert(std::is_same_v<decltype(s[1]), int const&>);
+    EXPECT_EQ(s[1], 20);
+    EXPECT_EQ(s[2], 30);
+}
+
+TEST(TestDynArrayStaticSlice, RuntimeSubSliceFlattensToDyn) {
+    DynArray<int> a({1, 2, 3, 4, 5, 6});
+    auto s = a.slice<Range{1, 4}>();
+    auto sub = s[Range{2, 3}];
+    static_assert(
+        std::is_same_v<decltype(sub), DynArraySlice<DynArray<int>>>,
+        "runtime sub-slice of a static slice must flatten to DynArraySlice"
+    );
+    EXPECT_EQ(sub[2], 3);
+    EXPECT_EQ(sub[3], 4);
+}
+
+TEST(TestDynArrayStaticSlice, StaticSubSliceFlattensToSameOwner) {
+    DynArray<int> a({1, 2, 3, 4, 5, 6, 7, 8});
+    auto s = a.slice<Range{1, 6}>();
+    auto sub = s.slice<Range{2, 4}>();
+    static_assert(
+        std::is_same_v<decltype(sub), ArraySlice<DynArray<int>, Range{2, 4}>>,
+        "static sub-slice flattens to ArraySlice<owner, R>, not nested slices"
+    );
+    EXPECT_EQ(sub[2], 3);
+    EXPECT_EQ(sub[4], 5);
+}
+
+TEST(TestDynArrayStaticSlice, NullSliceBoundsOutsideParentOK) {
+    DynArray<int> a({1, 2, 3, 4, 5});
+    auto s = a.slice<Range{99, Direction::TO, 50}>();
+    EXPECT_EQ(s.range().length(), 0U);
+    EXPECT_EQ(s.begin(), s.end());
+}
+
 // -- Compile-time dispatch -------------------------------------------------
 
 // Single integral arg -> length-based static range starting at 0.
@@ -565,5 +655,46 @@ TEST(TestArray, StaticFromForeignStaticRange) {
     EXPECT_EQ(dst.range(), src.range());
     EXPECT_EQ(dst[1], 100);
     EXPECT_EQ(dst[3], 300);
+}
+
+// -- DynArraySlice::slice<R> (runtime parent, static sub-slice) ------------
+
+TEST(TestDynArraySlice, StaticSliceFlattensToOwner) {
+    DynArray<int> a({10, 20, 30, 40, 50, 60});
+    auto dyn = a[{1, 4}];
+    auto s = dyn.slice<Range{2, 3}>();
+    static_assert(
+        std::is_same_v<decltype(s), ArraySlice<DynArray<int>, Range{2, 3}>>,
+        "static sub-slice of DynArraySlice flattens to ArraySlice<owner, R>"
+    );
+    EXPECT_EQ(s.range().length(), 2U);
+    EXPECT_EQ(s[2], 30);
+    EXPECT_EQ(s[3], 40);
+}
+
+TEST(TestDynArraySlice, StaticSliceMutatesUnderlying) {
+    DynArray<int> a({1, 2, 3, 4, 5});
+    auto dyn = a[{1, 4}];
+    auto s = dyn.slice<Range{2, 3}>();
+    s[2] = 99;
+    EXPECT_EQ(a[2], 99);
+}
+
+TEST(TestDynArraySlice, StaticSliceOutOfRangeRuntime) {
+    DynArray<int> a({1, 2, 3, 4, 5});
+    auto dyn = a[{1, 3}];
+    EXPECT_THROW((void)(dyn.slice<Range{99, 100}>()), std::invalid_argument);
+}
+
+TEST(TestDynArraySlice, StaticSliceConstReturnsConstSlice) {
+    DynArray<int> const a({10, 20, 30, 40, 50});
+    auto dyn = a[{1, 4}];
+    auto s = dyn.slice<Range{2, 3}>();
+    static_assert(
+        std::is_same_v<decltype(s), ArraySlice<DynArray<int> const, Range{2, 3}>>
+    );
+    static_assert(std::is_same_v<decltype(s[2]), int const&>);
+    EXPECT_EQ(s[2], 30);
+    EXPECT_EQ(s[3], 40);
 }
 // LCOV_EXCL_BR_STOP

--- a/tests/cpp/test_static_array.cpp
+++ b/tests/cpp/test_static_array.cpp
@@ -123,7 +123,7 @@ TEST(TestStaticArray, IndexingConst) {
     static_assert(std::is_same_v<decltype(a[0]), int const&>);
 }
 
-// -- Slicing (runtime, returns ArraySlice) ---------------------------------
+// -- Slicing (runtime, returns DynArraySlice) ------------------------------
 
 TEST(TestStaticArray, SliceTO) {
     Array<int, Range{0, Direction::TO, 4}> a({1, 2, 3, 4, 5});
@@ -299,5 +299,126 @@ TEST(TestStaticArray, FormatterBitRuntimeSliceConst) {
     Array<Bit, Range{0, Direction::TO, 3}> const a({'0'_b, '1'_b, '0'_b, '1'_b});
     auto s = a[Range{1, 2}];
     EXPECT_EQ(std::format("{}", s), "Bit[1 to 2]{1, 0}");
+}
+
+// -- Static sub-slice (compile-time-bounded) -------------------------------
+
+TEST(TestStaticArrayStaticSlice, SliceHappyPath) {
+    Array<int, Range{0, Direction::TO, 4}> a({10, 20, 30, 40, 50});
+    auto s = a.slice<Range{1, 3}>();
+    using AT = Array<int, Range{0, Direction::TO, 4}>;
+    static_assert(
+        std::is_same_v<decltype(s), ArraySlice<AT, Range{1, 3}>>,
+        "Array::slice<R>() must return ArraySlice<Array, R>"
+    );
+    static_assert(decltype(s)::static_range == Range{1, Direction::TO, 3});
+    EXPECT_EQ(s.range().length(), 3U);
+    EXPECT_EQ(s[1], 20);
+    EXPECT_EQ(s[3], 40);
+}
+
+TEST(TestStaticArrayStaticSlice, SliceMutatesUnderlying) {
+    Array<int, Range{0, Direction::TO, 4}> a({1, 2, 3, 4, 5});
+    auto s = a.slice<Range{1, 3}>();
+    s[2] = 99;
+    EXPECT_EQ(a[2], 99);
+}
+
+TEST(TestStaticArrayStaticSlice, SliceAssignFromRange) {
+    Array<int, Range{0, Direction::TO, 4}> a({1, 2, 3, 4, 5});
+    auto s = a.slice<Range{1, 3}>();
+    s = std::vector<int>{20, 30, 40};
+    EXPECT_EQ(a[1], 20);
+    EXPECT_EQ(a[3], 40);
+}
+
+TEST(TestStaticArrayStaticSlice, SliceAssignFromInitializerList) {
+    Array<int, Range{0, Direction::TO, 4}> a({1, 2, 3, 4, 5});
+    auto s = a.slice<Range{1, 3}>();
+    s = {7, 8, 9};
+    EXPECT_EQ(a[2], 8);
+}
+
+TEST(TestStaticArrayStaticSlice, SliceConstReturnsConstSlice) {
+    Array<int, Range{0, Direction::TO, 3}> const a({10, 20, 30, 40});
+    auto s = a.slice<Range{1, 2}>();
+    using AT = Array<int, Range{0, Direction::TO, 3}>;
+    static_assert(std::is_same_v<decltype(s), ArraySlice<AT const, Range{1, 2}>>);
+    static_assert(std::is_same_v<decltype(s[1]), int const&>);
+    EXPECT_EQ(s[1], 20);
+    EXPECT_EQ(s[2], 30);
+}
+
+TEST(TestStaticArrayStaticSlice, IndexingOutOfRange) {
+    Array<int, Range{0, Direction::TO, 4}> a({1, 2, 3, 4, 5});
+    auto s = a.slice<Range{1, 3}>();
+    EXPECT_THROW((void)s[0], std::out_of_range);
+    EXPECT_THROW((void)s[4], std::out_of_range);
+}
+
+TEST(TestStaticArrayStaticSlice, RuntimeSubSliceFlattensToDyn) {
+    Array<int, Range{0, Direction::TO, 5}> a({1, 2, 3, 4, 5, 6});
+    auto s = a.slice<Range{1, 4}>();
+    auto sub = s[Range{2, 3}];
+    using AT = Array<int, Range{0, Direction::TO, 5}>;
+    static_assert(
+        std::is_same_v<decltype(sub), DynArraySlice<AT>>,
+        "runtime sub-slice of a static slice must flatten to DynArraySlice"
+    );
+    EXPECT_EQ(sub[2], 3);
+    EXPECT_EQ(sub[3], 4);
+}
+
+TEST(TestStaticArrayStaticSlice, StaticSubSliceFlattensToSameOwner) {
+    Array<int, Range{0, Direction::TO, 7}> a({1, 2, 3, 4, 5, 6, 7, 8});
+    auto s = a.slice<Range{1, 6}>();
+    auto sub = s.slice<Range{2, 4}>();
+    using AT = Array<int, Range{0, Direction::TO, 7}>;
+    static_assert(
+        std::is_same_v<decltype(sub), ArraySlice<AT, Range{2, 4}>>,
+        "static sub-slice flattens to ArraySlice<owner, R2>, not nested"
+    );
+    EXPECT_EQ(sub[2], 3);
+    EXPECT_EQ(sub[4], 5);
+}
+
+TEST(TestStaticArrayStaticSlice, NullSliceBoundsOutsideParentOK) {
+    Array<int, Range{0, Direction::TO, 4}> a({1, 2, 3, 4, 5});
+    // Length 0; static_assert(is_subsequence(...)) accepts null ranges with
+    // any bounds.
+    auto s = a.slice<Range{99, Direction::TO, 50}>();
+    EXPECT_EQ(s.range().length(), 0U);
+    EXPECT_EQ(s.begin(), s.end());
+}
+
+// Exercises the DOWNTO branch of ArraySlice::begin()'s static-parent fast
+// path. The TO branch is covered by the other tests in this suite.
+TEST(TestStaticArrayStaticSlice, SliceDOWNTOParent) {
+    Array<int, Range{10, Direction::DOWNTO, 6}> a({1, 2, 3, 4, 5});
+    auto s = a.slice<Range{9, Direction::DOWNTO, 7}>();
+    EXPECT_EQ(s.range().length(), 3U);
+    EXPECT_EQ(s[9], 2);
+    EXPECT_EQ(s[8], 3);
+    EXPECT_EQ(s[7], 4);
+    s[8] = 99;
+    EXPECT_EQ(a[8], 99);
+}
+
+// -- DynArraySlice::slice<R> over a static Array ---------------------------
+
+TEST(TestStaticArray, DynSliceStaticSubSliceFlattens) {
+    Array<int, Range{0, Direction::TO, 5}> a({10, 20, 30, 40, 50, 60});
+    auto dyn = a[Range{1, 4}];
+    auto s = dyn.slice<Range{2, 3}>();
+    using AT = Array<int, Range{0, Direction::TO, 5}>;
+    static_assert(
+        std::is_same_v<decltype(s), ArraySlice<AT, Range{2, 3}>>,
+        "static sub-slice of a DynArraySlice over a static Array flattens to "
+        "ArraySlice<owner, R>"
+    );
+    EXPECT_EQ(s[2], 30);
+    EXPECT_EQ(s[3], 40);
+    s[2] = 99;
+    EXPECT_EQ(a[2], 99);
 }
 // LCOV_EXCL_BR_STOP


### PR DESCRIPTION
Depends on #234.

This renames `ArraySlice` to `DynArraySlice` and adds a compile-time bounded version as `ArraySlice`. It also adds a `slice<Range>()` method to each of `DynArray`, `Array`, `DynArraySlice` and `ArraySlice` to create these static array slices.

Care is taken to ensure that all paths that can leverage compile-time evalution is done. 