### PR TITLE
Add `range_of` customization point

### DIFF
--- a/cpp/include/coconext/types/array_base.hpp
+++ b/cpp/include/coconext/types/array_base.hpp
@@ -6,7 +6,6 @@
 #include <coconext/types/concepts.hpp>
 #include <coconext/types/range.hpp>
 #include <concepts>
-#include <cstddef>
 #include <format>
 #include <initializer_list>
 #include <iterator>
@@ -28,21 +27,50 @@ concept sized_input_range = std::ranges::sized_range<R> && std::ranges::input_ra
 template <typename T>
 struct is_array : std::false_type {};
 
-}  // namespace detail
-
-// The minimum a type must expose so that index() and slice() can be
-// implemented for it externally.
 template <typename T>
-concept RangedSequence = std::ranges::random_access_range<T> && requires(T& t) {
+concept has_range_member = requires(T const& t) {
     { t.range() } -> std::convertible_to<Range>;
 };
 
-// Customization point. A type opts into StaticRangedSequence by specializing
-// this trait so that ::value is a Range constant expression. Specialize this
-// instead of requiring an intrusive member, so external/wrapper types can
+}  // namespace detail
+
+// Customization point for the runtime range of a sequence. Specialize this
+// for external/wrapper types that can't or don't expose t.range() directly
+// (e.g. std::vector, std::span, std::string). A default partial specialization
+// below picks up types that already provide t.range(), so our own array types
+// participate without writing one.
+template <typename T>
+struct range_of;
+
+template <detail::has_range_member T>
+struct range_of<T> {
+    static constexpr Range get(T const& t) { return t.range(); }
+};
+
+// Customization point for the compile-time range. Specialize so that ::value
+// is a Range constant expression. Non-intrusive: external/wrapper types can
 // participate without modification.
 template <typename T>
 struct static_range_of;
+
+// Fallback range_of for types that opt into static_range_of but lack a
+// .range() member (e.g. std::array<T, N>). Picks up the compile-time range
+// so a single static_range_of specialization is enough.
+template <typename T>
+    requires(!detail::has_range_member<T>) && requires {
+        { static_range_of<T>::value } -> std::convertible_to<Range>;
+    }
+struct range_of<T> {
+    static constexpr Range get(T const&) { return static_range_of<T>::value; }
+};
+
+// The minimum a type must expose so that index() and slice() can be
+// implemented for it externally. Satisfied either via an intrusive .range()
+// member or via a range_of specialization.
+template <typename T>
+concept RangedSequence = std::ranges::random_access_range<T> && requires(T const& t) {
+    { range_of<std::remove_cvref_t<T>>::get(t) } -> std::convertible_to<Range>;
+};
 
 // A RangedSequence whose range is known at compile time, exposed via the
 // static_range_of trait. Lets generic code fold offsets into the owner against
@@ -308,7 +336,7 @@ struct is_array<ArraySlice<ArrayT, R>> : std::true_type {};
 template <RangedSequence ArrayT, typename OutIt>
     requires Formattable<std::ranges::range_value_t<ArrayT>>
 OutIt format_array(ArrayT const& arr, OutIt out) {
-    out = std::format_to(out, "{}{{", arr.range());
+    out = std::format_to(out, "{}{{", range_of<std::remove_cvref_t<ArrayT>>::get(arr));
     bool first = true;
     for (auto const& elem : arr) {
         if (!first) {

--- a/cpp/include/coconext/types/array_base.hpp
+++ b/cpp/include/coconext/types/array_base.hpp
@@ -32,6 +32,11 @@ concept has_range_member = requires(T const& t) {
     { t.range() } -> std::convertible_to<Range>;
 };
 
+template <typename T>
+concept has_static_range_member = requires {
+    { T::static_range } -> std::convertible_to<Range>;
+};
+
 }  // namespace detail
 
 // Customization point for the runtime range of a sequence. Specialize this
@@ -49,9 +54,16 @@ struct range_of<T> {
 
 // Customization point for the compile-time range. Specialize so that ::value
 // is a Range constant expression. Non-intrusive: external/wrapper types can
-// participate without modification.
+// participate without modification. A default partial specialization below
+// picks up types that expose a `static constexpr Range static_range` member,
+// so our own array types participate without writing one.
 template <typename T>
 struct static_range_of;
+
+template <detail::has_static_range_member T>
+struct static_range_of<T> {
+    static constexpr Range value = T::static_range;
+};
 
 // Fallback range_of for types that opt into static_range_of but lack a
 // .range() member (e.g. std::array<T, N>). Picks up the compile-time range
@@ -314,11 +326,6 @@ class ArraySlice {
 
   private:
     ArrayT* arr_;
-};
-
-template <typename ArrayT, Range R>
-struct static_range_of<ArraySlice<ArrayT, R>> {
-    static constexpr Range value = R;
 };
 
 namespace detail {

--- a/cpp/include/coconext/types/logic_array.hpp
+++ b/cpp/include/coconext/types/logic_array.hpp
@@ -23,7 +23,9 @@ constexpr std::string_view logic_type_name() {
 // tag.
 template <RangedSequence ArrayT, typename OutIt>
 OutIt format_typed_array(std::string_view type_name, ArrayT const& arr, OutIt out) {
-    out = std::format_to(out, "{}{}{{", type_name, arr.range());
+    out = std::format_to(
+        out, "{}{}{{", type_name, range_of<std::remove_cvref_t<ArrayT>>::get(arr)
+    );
     bool first = true;
     for (auto const& elem : arr) {
         if (!first) {

--- a/tests/cpp/test_array.cpp
+++ b/tests/cpp/test_array.cpp
@@ -1,14 +1,50 @@
 // LCOV_EXCL_BR_START -- gtest macros generate noisy uncovered branches
 #include <gtest/gtest.h>
 
+#include <array>
 #include <coconext/types.hpp>
 #include <format>
 #include <functional>
 #include <numeric>
+#include <span>
 #include <stdexcept>
 #include <string>
 #include <unordered_set>
 #include <vector>
+
+// -- Post-hoc adaptation of foreign types via range_of / static_range_of ---
+//
+// Demonstrates the customization points: any type can participate in
+// RangedSequence / StaticRangedSequence without modifying its definition.
+// For static-range adapters (std::array, fixed-extent std::span), only
+// static_range_of is specialized; the default range_of partial specialization
+// picks it up automatically.
+
+namespace coconext::types {
+
+template <typename T, size_t N>
+struct static_range_of<std::array<T, N>> {
+    static constexpr Range value = Range(N);
+};
+
+template <typename T, size_t N>
+struct static_range_of<std::span<T, N>> {
+    static constexpr Range value = Range(N);
+};
+
+template <typename T, typename A>
+struct range_of<std::vector<T, A>> {
+    static constexpr Range get(std::vector<T, A> const& v) { return Range(v.size()); }
+};
+
+template <typename C, typename Tr, typename A>
+struct range_of<std::basic_string<C, Tr, A>> {
+    static constexpr Range get(std::basic_string<C, Tr, A> const& s) {
+        return Range(s.size());
+    }
+};
+
+}  // namespace coconext::types
 
 using namespace coconext::types;
 
@@ -696,5 +732,51 @@ TEST(TestDynArraySlice, StaticSliceConstReturnsConstSlice) {
     static_assert(std::is_same_v<decltype(s[2]), int const&>);
     EXPECT_EQ(s[2], 30);
     EXPECT_EQ(s[3], 40);
+}
+
+// -- range_of / static_range_of customization-point adaptation -------------
+
+// std::array<T, N>: size is part of the type, so only static_range_of is
+// specialized; range_of falls through to it.
+static_assert(RangedSequence<std::array<int, 8>>);
+static_assert(StaticRangedSequence<std::array<int, 8>>);
+static_assert(static_range_of<std::array<int, 8>>::value == Range(8));
+
+TEST(TestRangeOf, AdaptStdArray) {
+    std::array<int, 4> a{10, 20, 30, 40};
+    EXPECT_EQ((range_of<std::array<int, 4>>::get(a)), Range(4));
+}
+
+// std::span<T, Extent>: the fixed-extent form carries Extent in its type, so
+// it also models StaticRangedSequence via static_range_of alone.
+static_assert(RangedSequence<std::span<int, 5>>);
+static_assert(StaticRangedSequence<std::span<int, 5>>);
+static_assert(static_range_of<std::span<int, 5>>::value == Range(5));
+
+TEST(TestRangeOf, AdaptStdSpanFixedExtent) {
+    int data[6] = {1, 2, 3, 4, 5, 6};
+    std::span<int, 6> s{data};
+    EXPECT_EQ((range_of<std::span<int, 6>>::get(s)), Range(6));
+}
+
+// std::vector<T>: size is runtime; specialize range_of only. The type must
+// NOT satisfy StaticRangedSequence.
+static_assert(RangedSequence<std::vector<int>>);
+static_assert(!StaticRangedSequence<std::vector<int>>);
+
+TEST(TestRangeOf, AdaptStdVector) {
+    std::vector<int> v{10, 20, 30};
+    EXPECT_EQ((range_of<std::vector<int>>::get(v)), Range(3));
+    v.push_back(40);
+    EXPECT_EQ((range_of<std::vector<int>>::get(v)), Range(4));
+}
+
+// std::string: same shape as std::vector -- runtime size, range_of only.
+static_assert(RangedSequence<std::string>);
+static_assert(!StaticRangedSequence<std::string>);
+
+TEST(TestRangeOf, AdaptStdString) {
+    std::string s = "hello";
+    EXPECT_EQ((range_of<std::string>::get(s)), Range(5));
 }
 // LCOV_EXCL_BR_STOP


### PR DESCRIPTION
Mirrors static_range_of for the runtime range. Specialize range_of<T> to adapt foreign types (std::vector, std::span, std::string, ...) into RangedSequence without modifying them. A default partial specialization picks up types with a t.range() member, so our own array types keep working without explicit opt-in. A second fallback uses static_range_of when present, so adapters for compile-time-sized types (std::array, fixed-extent std::span) only need to specialize one trait.

RangedSequence is updated to go through range_of so foreign-type adapters actually participate. Two generic .range() call sites (format_array, format_typed_array) are updated to match; concrete-type call sites in dyn_array.hpp keep calling .range() directly.

Tests adapt std::array, std::span<T, N>, std::vector, and std::string as worked examples.