### PR TITLE
Add LogicArray operations and array utilities

### DIFF
--- a/cpp/include/coconext/types/array.hpp
+++ b/cpp/include/coconext/types/array.hpp
@@ -22,6 +22,179 @@ namespace coconext::types {
 
 namespace detail {
 
+template <typename T, Range R>
+class Array;
+
+template <typename T, Range R>
+
+// The actual Array implementation. Separated out so it can be reused for the LogicArray
+// specialization.
+class ArrayImpl {
+  public:
+    using value_type = T;
+    using index_type = Range::value_type;
+    static_assert(!std::is_reference_v<value_type>);
+    static_assert(!std::is_const_v<value_type>);
+    using reference = value_type&;
+    using const_reference = value_type const&;
+    using iterator = typename std::array<value_type, R.length()>::iterator;
+    using const_iterator = typename std::array<value_type, R.length()>::const_iterator;
+
+    constexpr ArrayImpl()
+        requires std::default_initializable<value_type>
+        : data_{} {}
+
+    constexpr ArrayImpl(ArrayImpl const&) = default;
+    constexpr ArrayImpl(ArrayImpl&&) = default;
+    constexpr ArrayImpl& operator=(ArrayImpl const&) = default;
+    constexpr ArrayImpl& operator=(ArrayImpl&&) = default;
+
+    template <typename U>
+        requires std::convertible_to<U, value_type>
+    constexpr ArrayImpl(std::initializer_list<U> init) : data_{} {
+        if (init.size() != R.length()) {
+            throw std::invalid_argument(
+                "Initializer list of size " + std::to_string(init.size())
+                + " does not match Array length " + std::to_string(R.length())
+            );
+        }
+        std::copy(init.begin(), init.end(), data_.begin());
+    }
+
+    template <std::ranges::sized_range Rng>
+        requires std::convertible_to<std::ranges::range_value_t<Rng>, value_type>
+              && (!std::derived_from<std::remove_cvref_t<Rng>, ArrayImpl>)
+    explicit constexpr ArrayImpl(Rng const& obj) : data_{} {
+        if (std::ranges::size(obj) != R.length()) {
+            throw std::invalid_argument(
+                "Input of size " + std::to_string(std::ranges::size(obj))
+                + " does not match Array length " + std::to_string(R.length())
+            );
+        }
+        std::ranges::copy(obj, data_.begin());
+    }
+
+    // Deliberately similar to DynArray's instance range() so that generic code can query
+    // the range with instance access pattern: `obj.range()`.
+    static constexpr Range range() noexcept { return R; }
+
+    constexpr reference operator[](index_type idx) { return access_(*this, idx); }
+    constexpr const_reference operator[](index_type idx) const {
+        return access_(*this, idx);
+    }
+
+    // Slices are constructed with the outer `Array<T, R>` (or const variant)
+    // as the owner. `this` is an ArrayImpl*, but the outer Array derives from
+    // it, so static_cast safely lands on the most-derived type at every
+    // instantiation -- and routes through the Logic/Bit slice partial spec
+    // when applicable.
+    constexpr DynArraySlice<Array<T, R>> operator[](Range r) {
+        detail::subsequence_check(R, r);
+        return DynArraySlice<Array<T, R>>(static_cast<Array<T, R>*>(this), r);
+    }
+    constexpr DynArraySlice<Array<T, R> const> operator[](Range r) const {
+        detail::subsequence_check(R, r);
+        return DynArraySlice<Array<T, R> const>(static_cast<Array<T, R> const*>(this), r);
+    }
+#if __cplusplus >= 202302L
+    constexpr DynArraySlice<Array<T, R>> operator[](
+        Range::value_type left, Range::value_type right
+    ) const {
+        return (*this)[Range{left, R.direction, right}];
+    }
+    constexpr DynArraySlice<Array<T, R>> operator[](
+        Range::value_type left, Direction dir, Range::value_type right
+    ) const {
+        return (*this)[Range{left, dir, right}];
+    }
+#endif
+
+    template <Range R2>
+    constexpr ArraySlice<Array<T, R>, R2> slice() {
+        static_assert(
+            R2.is_subsequence_of(R),
+            "static sub-slice range is not a sub-range of the parent Array"
+        );
+        return ArraySlice<Array<T, R>, R2>(static_cast<Array<T, R>*>(this));
+    }
+    template <Range R2>
+    constexpr ArraySlice<Array<T, R> const, R2> slice() const {
+        static_assert(
+            R2.is_subsequence_of(R),
+            "static sub-slice range is not a sub-range of the parent Array"
+        );
+        return ArraySlice<Array<T, R> const, R2>(static_cast<Array<T, R> const*>(this));
+    }
+
+    constexpr iterator begin() noexcept { return data_.begin(); }
+    constexpr const_iterator begin() const noexcept { return data_.begin(); }
+    constexpr iterator end() noexcept { return data_.end(); }
+    constexpr const_iterator end() const noexcept { return data_.end(); }
+    constexpr auto rbegin() noexcept { return data_.rbegin(); }
+    constexpr auto rbegin() const noexcept { return data_.rbegin(); }
+    constexpr auto rend() noexcept { return data_.rend(); }
+    constexpr auto rend() const noexcept { return data_.rend(); }
+
+  private:
+    template <typename Self>
+    static constexpr auto& access_(Self& self, index_type idx) {
+        if constexpr (R.direction == Direction::TO) {
+            if (idx < R.left || idx > R.right) {
+                throw std::out_of_range("Index out of bounds");
+            }
+            return *(self.begin() + (idx - R.left));
+        } else {
+            if (idx > R.left || idx < R.right) {
+                throw std::out_of_range("Index out of bounds");
+            }
+            return *(self.begin() + (R.left - idx));
+        }
+    }
+
+    std::array<value_type, R.length()> data_;
+};
+
+// Local-allocated, compile-time-bounded array indexed according to its Range.
+// This is the canonical "Array" implementation. It's stuck in detail since `Array`
+template <typename T, Range R>
+class Array : public ArrayImpl<T, R> {
+  public:
+    using ArrayImpl<T, R>::ArrayImpl;
+    using ArrayImpl<T, R>::operator=;
+};
+
+template <typename T, Range R1, Range R2>
+    requires std::equality_comparable<T>
+constexpr bool operator==(Array<T, R1> const& lhs, Array<T, R2> const& rhs) noexcept {
+    if constexpr (R1 != R2) {
+        return false;
+    }
+    return std::equal(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
+}
+
+template <typename T, Range R>
+struct is_array<Array<T, R>> : std::true_type {};
+
+static_assert(RangedSequence<Array<int, Range{0, Direction::TO, 7}>>);
+static_assert(RangedSequence<Array<int, Range{0, Direction::TO, 7}> const>);
+static_assert(RangedSequence<DynArraySlice<Array<int, Range{0, Direction::TO, 7}>>>);
+static_assert(RangedSequence<DynArraySlice<Array<int, Range{0, Direction::TO, 7}> const>>);
+static_assert(
+    RangedSequence<
+        ArraySlice<Array<int, Range{0, Direction::TO, 7}>, Range{1, Direction::TO, 3}>>
+);
+static_assert(RangedSequence<ArraySlice<
+                  Array<int, Range{0, Direction::TO, 7}> const,
+                  Range{1, Direction::TO, 3}>>);
+
+static_assert(StaticRangedSequence<Array<int, Range{0, Direction::TO, 7}>>);
+static_assert(StaticRangedSequence<Array<int, Range{0, Direction::TO, 7}> const>);
+static_assert(!StaticRangedSequence<DynArraySlice<Array<int, Range{0, Direction::TO, 7}>>>);
+static_assert(
+    StaticRangedSequence<
+        ArraySlice<Array<int, Range{0, Direction::TO, 7}>, Range{1, Direction::TO, 3}>>
+);
+
 template <auto V>
 constexpr bool fits_range_value_type =
     static_cast<long long>(V) >= std::numeric_limits<Range::value_type>::min()
@@ -80,151 +253,10 @@ constexpr Range make_static_range() {
     }
 }
 
-// Compile-time-bounded array. The range R is part of the type, so length,
-// bounds checks, and indexing fold against R. Storage is std::array, so
-// instances live in automatic / static storage with no heap allocation.
-template <typename T, Range R>
-class Array {
-  public:
-    using value_type = T;
-    using index_type = Range::value_type;
-    static_assert(!std::is_reference_v<value_type>);
-    static_assert(!std::is_const_v<value_type>);
-    using reference = value_type&;
-    using const_reference = value_type const&;
-    using iterator = typename std::array<value_type, R.length()>::iterator;
-    using const_iterator = typename std::array<value_type, R.length()>::const_iterator;
-
-    constexpr Array()
-        requires std::default_initializable<value_type>
-        : data_{} {}
-
-    constexpr Array(Array const&) = default;
-    constexpr Array(Array&&) = default;
-    constexpr Array& operator=(Array const&) = default;
-    constexpr Array& operator=(Array&&) = default;
-
-    template <typename U>
-        requires std::convertible_to<U, value_type>
-    constexpr Array(std::initializer_list<U> init) : data_{} {
-        if (init.size() != R.length()) {
-            throw std::invalid_argument(
-                "Initializer list of size " + std::to_string(init.size())
-                + " does not match Array length " + std::to_string(R.length())
-            );
-        }
-        std::copy(init.begin(), init.end(), data_.begin());
-    }
-
-    template <std::ranges::sized_range Rng>
-        requires std::convertible_to<std::ranges::range_value_t<Rng>, value_type>
-              && (!std::same_as<std::remove_cvref_t<Rng>, Array>)
-    explicit constexpr Array(Rng const& obj) : data_{} {
-        if (std::ranges::size(obj) != R.length()) {
-            throw std::invalid_argument(
-                "Input of size " + std::to_string(std::ranges::size(obj))
-                + " does not match Array length " + std::to_string(R.length())
-            );
-        }
-        std::ranges::copy(obj, data_.begin());
-    }
-
-    static constexpr Range range() noexcept { return R; }
-
-    constexpr reference operator[](index_type idx) { return access_(*this, idx); }
-    constexpr const_reference operator[](index_type idx) const {
-        return access_(*this, idx);
-    }
-    constexpr DynArraySlice<Array> operator[](Range r) {
-        detail::subsequence_check(R, r);
-        return DynArraySlice<Array>(this, r);
-    }
-    constexpr DynArraySlice<Array const> operator[](Range r) const {
-        detail::subsequence_check(R, r);
-        return DynArraySlice<Array const>(this, r);
-    }
-
-    // Compile-time-checked sub-slice. R2 is validated against R at compile time;
-    // the result keeps the static range so its bounds checks fold to constants.
-    template <Range R2>
-    constexpr ArraySlice<Array, R2> slice() {
-        static_assert(
-            R2.is_subsequence_of(R),
-            "static sub-slice range is not a sub-range of the parent Array"
-        );
-        return ArraySlice<Array, R2>(this);
-    }
-    template <Range R2>
-    constexpr ArraySlice<Array const, R2> slice() const {
-        static_assert(
-            R2.is_subsequence_of(R),
-            "static sub-slice range is not a sub-range of the parent Array"
-        );
-        return ArraySlice<Array const, R2>(this);
-    }
-
-    constexpr iterator begin() noexcept { return data_.begin(); }
-    constexpr const_iterator begin() const noexcept { return data_.begin(); }
-    constexpr iterator end() noexcept { return data_.end(); }
-    constexpr const_iterator end() const noexcept { return data_.end(); }
-    constexpr auto rbegin() noexcept { return data_.rbegin(); }
-    constexpr auto rbegin() const noexcept { return data_.rbegin(); }
-    constexpr auto rend() noexcept { return data_.rend(); }
-    constexpr auto rend() const noexcept { return data_.rend(); }
-
-  private:
-    template <typename Self>
-    static constexpr auto& access_(Self& self, index_type idx) {
-        if constexpr (R.direction == Direction::TO) {
-            if (idx < R.left || idx > R.right) {
-                throw std::out_of_range("Index out of bounds");
-            }
-            return *(self.begin() + (idx - R.left));
-        } else {
-            if (idx > R.left || idx < R.right) {
-                throw std::out_of_range("Index out of bounds");
-            }
-            return *(self.begin() + (R.left - idx));
-        }
-    }
-
-    std::array<value_type, R.length()> data_;
-};
-
-template <typename T, Range R>
-    requires std::equality_comparable<T>
-constexpr bool operator==(Array<T, R> const& lhs, Array<T, R> const& rhs) noexcept {
-    return std::equal(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
-}
-
-template <typename T, Range R>
-struct is_array<Array<T, R>> : std::true_type {};
-
-static_assert(RangedSequence<Array<int, Range{0, Direction::TO, 7}>>);
-static_assert(RangedSequence<Array<int, Range{0, Direction::TO, 7}> const>);
-static_assert(RangedSequence<DynArraySlice<Array<int, Range{0, Direction::TO, 7}>>>);
-static_assert(RangedSequence<DynArraySlice<Array<int, Range{0, Direction::TO, 7}> const>>);
-static_assert(
-    RangedSequence<
-        ArraySlice<Array<int, Range{0, Direction::TO, 7}>, Range{1, Direction::TO, 3}>>
-);
-static_assert(RangedSequence<ArraySlice<
-                  Array<int, Range{0, Direction::TO, 7}> const,
-                  Range{1, Direction::TO, 3}>>);
-
-// Array's range is part of its type, so it matches; a runtime view (even of
-// a static Array) does not.
-static_assert(StaticRangedSequence<Array<int, Range{0, Direction::TO, 7}>>);
-static_assert(StaticRangedSequence<Array<int, Range{0, Direction::TO, 7}> const>);
-static_assert(!StaticRangedSequence<DynArraySlice<Array<int, Range{0, Direction::TO, 7}>>>);
-static_assert(
-    StaticRangedSequence<
-        ArraySlice<Array<int, Range{0, Direction::TO, 7}>, Range{1, Direction::TO, 3}>>
-);
-
 }  // namespace detail
 
-// Static-bounded array. Range is built from the trailing NTTPs:
+// Static-bounded array. Storage is local, not on the heap, similar to std::array. Range is
+// built from the trailing NTTPs:
 //   Array<T, N>           (integral N)      -> detail::Array<T, Range(N)>
 //   Array<T, R>           (Range R)         -> detail::Array<T, R>
 //   Array<T, L, H>        (integral L, H)   -> detail::Array<T, Range{L, H}>

--- a/cpp/include/coconext/types/array_base.hpp
+++ b/cpp/include/coconext/types/array_base.hpp
@@ -23,7 +23,7 @@ namespace detail {
 template <typename R>
 concept sized_input_range = std::ranges::sized_range<R> && std::ranges::input_range<R>;
 
-// Opt-in trait that array types.
+// Opt-in trait for array types.
 template <typename T>
 struct is_array : std::false_type {};
 
@@ -65,41 +65,35 @@ constexpr void subsequence_check(Range parent, Range child) {
 
 }  // namespace detail
 
+template <typename ArrayT>
+class DynArraySlice;
 template <typename ArrayT, Range R>
 class ArraySlice;
 
+// We split out the implementations into a base class so that we can reuse then in the
+// Logic/Bit-aware specializations in logic_array.hpp. LogicArray is just an Array with
+// extra members. BitArray is too, for now...
+
+namespace detail {
+
 template <typename ArrayT>
-class DynArraySlice {
+class DynArraySliceImpl {
   public:
-    // DynArraySlice is a non-owning view (like std::span) with a runtime
-    // range. Element mutability is determined by ArrayT's constness:
-    // - DynArraySlice<ArrayT>          -- mutable view, can write elements.
-    // - DynArraySlice<const ArrayT>    -- read-only view.
-    // - const DynArraySlice<X>         -- pointer/range fixed; element access
-    //                                     follows X's mutability rules.
     using value_type = std::ranges::range_value_t<ArrayT>;
     using reference = std::ranges::range_reference_t<ArrayT>;
     using index_type = Range::value_type;
     using iterator = std::ranges::iterator_t<ArrayT>;
     static_assert(!std::is_reference_v<value_type>);
 
-    constexpr DynArraySlice() = delete;
-    constexpr DynArraySlice(DynArraySlice const&) = default;
-    constexpr DynArraySlice(DynArraySlice&&) = default;
-    // begin_ is computed once at construction by walking the owner's range to
-    // locate range.left. Subsequent begin() / end() / operator[] calls are
-    // O(1) and avoid re-projecting on every access. Slice constructors are
-    // expected to have already validated `range` against the owner (via
-    // detail::subsequence_check or operator[](Range r)); we don't re-check.
-    constexpr DynArraySlice(ArrayT* arr, Range range) noexcept
+    constexpr DynArraySliceImpl() = delete;
+    constexpr DynArraySliceImpl(DynArraySliceImpl const&) = default;
+    constexpr DynArraySliceImpl(DynArraySliceImpl&&) = default;
+    constexpr DynArraySliceImpl(ArrayT* arr, Range range) noexcept
         : arr_(arr), range_(range), begin_(compute_begin(arr, range)) {}
 
     constexpr Range const& range() const noexcept { return range_; }
 
-    // Element access bounds-checks against this slice's range_, not the
-    // owner's range. An idx that's valid in the owner but outside the slice
-    // is out-of-range. Uses the cached begin_ + direct arithmetic instead of
-    // re-projecting through find()/distance() on every call.
+    // Element access bounds-checks against this slice's range_, not the owner's range.
     constexpr reference operator[](index_type idx) const {
         if (range_.direction == Direction::TO) {
             if (idx < range_.left || idx > range_.right) {
@@ -113,26 +107,37 @@ class DynArraySlice {
             return *(begin_ + (range_.left - idx));
         }
     }
-    // Sub-slicing flattens: returns a new DynArraySlice over the same
-    // underlying array with a new range. Validity is checked against the
-    // slice's own range_, not arr_->range().
-    constexpr DynArraySlice operator[](Range r) const {
-        detail::subsequence_check(range_, r);
-        return DynArraySlice(arr_, r);
-    }
 
-    // Static sub-slicing flattens to ArraySlice<ArrayT, R> over the same
-    // underlying array. The subsequence check is runtime here (this slice's
-    // own bound is dynamic).
+    // Slicing a slice flattens to a new DynArraySlice of the same underlying array.
+    // Validity is checked against the slice's range, not the underlying owner's range. This
+    // returns the outer DynArraySlice type so that we pick up the Logic and Bit
+    // specializations.
+    constexpr DynArraySlice<ArrayT> operator[](Range r) const {
+        detail::subsequence_check(range_, r);
+        return DynArraySlice<ArrayT>(arr_, r);
+    }
+#if __cplusplus >= 202302L
+    constexpr DynArraySlice<ArrayT> operator[](
+        Range::value_type left, Range::value_type right
+    ) const {
+        return (*this)[Range{left, range_.direction, right}];
+    }
+    constexpr DynArraySlice<ArrayT> operator[](
+        Range::value_type left, Direction dir, Range::value_type right
+    ) const {
+        return (*this)[Range{left, dir, right}];
+    }
+#endif
+
     template <Range R>
     constexpr ArraySlice<ArrayT, R> slice() const {
         detail::subsequence_check(range_, R);
         return ArraySlice<ArrayT, R>(arr_);
     }
 
-    // Explicitly define a DynArraySlice assignment since the implicitly created one is a
-    // variable assignment and not an element-wise assignment to the underlying storage.
-    constexpr DynArraySlice const& operator=(DynArraySlice const& other) const
+    // Have to override this since the implicitly generated copy assignment acts as a
+    // variable assignment rather than writing through to the underlying storage.
+    constexpr DynArraySliceImpl const& operator=(DynArraySliceImpl const& other) const
         requires(!std::is_const_v<ArrayT>)
     {
         if (other.range_.length() != range_.length()) {
@@ -149,7 +154,7 @@ class DynArraySlice {
     template <detail::sized_input_range R>
         requires(!std::is_const_v<ArrayT>)
              && std::convertible_to<std::ranges::range_value_t<R>, value_type>
-    constexpr DynArraySlice const& operator=(R const& obj) const {
+    constexpr DynArraySliceImpl const& operator=(R const& obj) const {
         if (std::ranges::size(obj) != range_.length()) {
             throw std::invalid_argument(
                 "Value of length " + std::to_string(std::ranges::size(obj))
@@ -163,7 +168,7 @@ class DynArraySlice {
 
     template <typename T>
         requires(!std::is_const_v<ArrayT>) && std::convertible_to<T, value_type>
-    constexpr DynArraySlice const& operator=(std::initializer_list<T> init) const {
+    constexpr DynArraySliceImpl const& operator=(std::initializer_list<T> init) const {
         if (init.size() != range_.length()) {
             throw std::invalid_argument(
                 "Initializer list of size " + std::to_string(init.size())
@@ -181,6 +186,8 @@ class DynArraySlice {
     constexpr auto rend() const noexcept { return std::reverse_iterator(begin()); }
 
   private:
+    // Cache the begin pointer. This is just one stack pointer for a temporary object, and
+    // it saves recomputing the offset on every element access.
     static constexpr iterator compute_begin(ArrayT* arr, Range range) noexcept {
         // Null slices may carry bounds outside the parent's range (the
         // validity rule allows that). Pin them to the parent's begin so
@@ -201,12 +208,8 @@ class DynArraySlice {
     iterator begin_;
 };
 
-// Compile-time-bounded counterpart to DynArraySlice. R is part of the type,
-// so length, bounds checks, and indexing fold against R. When the parent's
-// range is also a compile-time constant (a static Array, or another static
-// ArraySlice), begin()/end() collapse to a single pointer offset.
 template <typename ArrayT, Range R>
-class ArraySlice {
+class ArraySliceImpl {
   public:
     using value_type = std::ranges::range_value_t<ArrayT>;
     using reference = std::ranges::range_reference_t<ArrayT>;
@@ -214,11 +217,13 @@ class ArraySlice {
     using iterator = std::ranges::iterator_t<ArrayT>;
     static_assert(!std::is_reference_v<value_type>);
 
-    constexpr ArraySlice() = delete;
-    constexpr ArraySlice(ArraySlice const&) = default;
-    constexpr ArraySlice(ArraySlice&&) = default;
-    constexpr explicit ArraySlice(ArrayT* arr) noexcept : arr_(arr) {}
+    constexpr ArraySliceImpl() = delete;
+    constexpr ArraySliceImpl(ArraySliceImpl const&) = default;
+    constexpr ArraySliceImpl(ArraySliceImpl&&) = default;
+    constexpr explicit ArraySliceImpl(ArrayT* arr) noexcept : arr_(arr) {}
 
+    // Deliberately similar to DynArraySlice's instance range() so that generic code can
+    // query the range with instance access pattern: `obj.range()`.
     static constexpr Range range() noexcept { return R; }
 
     constexpr reference operator[](index_type idx) const {
@@ -235,8 +240,6 @@ class ArraySlice {
         }
     }
 
-    // Static sub-slicing flattens to ArraySlice<ArrayT, R2> over the same
-    // underlying array. R2's validity against R is checked at compile time.
     template <Range R2>
     constexpr ArraySlice<ArrayT, R2> slice() const {
         static_assert(
@@ -246,16 +249,26 @@ class ArraySlice {
         return ArraySlice<ArrayT, R2>(arr_);
     }
 
-    // Runtime sub-slicing flattens to DynArraySlice<ArrayT> -- the result is
-    // no longer compile-time-bounded, since r is a runtime value.
     constexpr DynArraySlice<ArrayT> operator[](Range r) const {
         detail::subsequence_check(R, r);
         return DynArraySlice<ArrayT>(arr_, r);
     }
+#if __cplusplus >= 202302L
+    constexpr DynArraySlice<ArrayT> operator[](
+        Range::value_type left, Range::value_type right
+    ) const {
+        return (*this)[Range{left, range_.direction, right}];
+    }
+    constexpr DynArraySlice<ArrayT> operator[](
+        Range::value_type left, Direction dir, Range::value_type right
+    ) const {
+        return (*this)[Range{left, dir, right}];
+    }
+#endif
 
-    // Explicitly define a ArraySlice assignment since the implicitly created one is a
-    // variable assignment and not an element-wise assignment to the underlying storage.
-    constexpr ArraySlice const& operator=(ArraySlice const& other) const
+    // Have to override this since the implicitly generated copy assignment acts as a
+    // variable assignment rather than writing through to the underlying storage.
+    constexpr ArraySliceImpl const& operator=(ArraySliceImpl const& other) const
         requires(!std::is_const_v<ArrayT>)
     {
         std::ranges::copy(other, begin());
@@ -265,7 +278,7 @@ class ArraySlice {
     template <detail::sized_input_range Rng>
         requires(!std::is_const_v<ArrayT>)
              && std::convertible_to<std::ranges::range_value_t<Rng>, value_type>
-    constexpr ArraySlice const& operator=(Rng const& obj) const {
+    constexpr ArraySliceImpl const& operator=(Rng const& obj) const {
         if constexpr (StaticRangedSequence<Rng>) {
             static_assert(
                 std::remove_cvref_t<Rng>::range().length() == R.length(),
@@ -284,7 +297,7 @@ class ArraySlice {
 
     template <typename T>
         requires(!std::is_const_v<ArrayT>) && std::convertible_to<T, value_type>
-    constexpr ArraySlice const& operator=(std::initializer_list<T> init) const {
+    constexpr ArraySliceImpl const& operator=(std::initializer_list<T> init) const {
         if (init.size() != R.length()) {
             throw std::invalid_argument(
                 "Initializer list of size " + std::to_string(init.size())
@@ -297,6 +310,9 @@ class ArraySlice {
     }
 
     constexpr iterator begin() const noexcept {
+        // We don't cache the begin pointer here since we can conditionally leverage the
+        // compile-time range to fold the offset to a constant.
+
         // Null slices may carry bounds outside the parent's range (the
         // validity rule allows that). Pin them to the parent's begin so
         // begin()/end() form a well-formed empty iterator pair.
@@ -325,6 +341,34 @@ class ArraySlice {
 
   private:
     ArrayT* arr_;
+};
+
+}  // namespace detail
+
+// A non-owning view (like std::span with dynamic extent) with a runtime range. Element
+// mutability is determined by ArrayT's constness:
+// - DynArraySlice<ArrayT>          -- mutable view, can write elements.
+// - DynArraySlice<const ArrayT>    -- read-only view.
+// - const DynArraySlice<X>         -- pointer/range fixed; element access
+//                                     follows X's mutability rules.
+template <typename ArrayT>
+class DynArraySlice : public detail::DynArraySliceImpl<ArrayT> {
+  public:
+    using detail::DynArraySliceImpl<ArrayT>::DynArraySliceImpl;
+    using detail::DynArraySliceImpl<ArrayT>::operator=;
+};
+
+// A non-owning view (like std::span) with a compile-time range. Element mutability is
+// determined by ArrayT's constness:
+// - ArraySlice<ArrayT>          -- mutable view, can write elements.
+// - ArraySlice<const ArrayT>    -- read-only view.
+// - const ArraySlice<X>         -- pointer/range fixed; element access
+//                                  follows X's mutability rules.
+template <typename ArrayT, Range R>
+class ArraySlice : public detail::ArraySliceImpl<ArrayT, R> {
+  public:
+    using detail::ArraySliceImpl<ArrayT, R>::ArraySliceImpl;
+    using detail::ArraySliceImpl<ArrayT, R>::operator=;
 };
 
 namespace detail {

--- a/cpp/include/coconext/types/dyn_array.hpp
+++ b/cpp/include/coconext/types/dyn_array.hpp
@@ -28,7 +28,15 @@
 namespace coconext::types {
 
 template <typename ValueT>
-class DynArray {
+class DynArray;
+
+namespace detail {
+
+template <typename ValueT>
+
+// The actual DynArray implementation. Separated out so it can be reused for the
+// DynLogicArray specialization.
+class DynArrayImpl {
   public:
     using value_type = ValueT;
     static_assert(!std::is_reference_v<value_type>);
@@ -39,17 +47,17 @@ class DynArray {
     using iterator = value_type*;
     using const_iterator = value_type const*;
 
-    constexpr DynArray() = delete;  // no default constructor
+    constexpr DynArrayImpl() = delete;  // no default constructor
 
-    COCONEXT_DYN_ARRAY_CONSTEXPR DynArray(DynArray&& other) noexcept = default;
+    COCONEXT_DYN_ARRAY_CONSTEXPR DynArrayImpl(DynArrayImpl&& other) noexcept = default;
 
-    COCONEXT_DYN_ARRAY_CONSTEXPR DynArray(DynArray const& other)
+    COCONEXT_DYN_ARRAY_CONSTEXPR DynArrayImpl(DynArrayImpl const& other)
         : data_(std::make_unique_for_overwrite<value_type[]>(other.range_.length())),
           range_(other.range_) {
         std::ranges::copy(other, data_.get());
     }
 
-    COCONEXT_DYN_ARRAY_CONSTEXPR DynArray& operator=(DynArray const& other) {
+    COCONEXT_DYN_ARRAY_CONSTEXPR DynArrayImpl& operator=(DynArrayImpl const& other) {
         if (this != &other) {
             auto buf = std::make_unique_for_overwrite<value_type[]>(other.range_.length());
             std::ranges::copy(other, buf.get());
@@ -59,7 +67,7 @@ class DynArray {
         return *this;
     }
 
-    COCONEXT_DYN_ARRAY_CONSTEXPR DynArray& operator=(DynArray&& other) noexcept {
+    COCONEXT_DYN_ARRAY_CONSTEXPR DynArrayImpl& operator=(DynArrayImpl&& other) noexcept {
         if (this != &other) {
             data_ = std::move(other.data_);
             range_ = other.range_;
@@ -67,16 +75,16 @@ class DynArray {
         return *this;
     }
 
-    explicit COCONEXT_DYN_ARRAY_CONSTEXPR DynArray(Range range)
+    explicit COCONEXT_DYN_ARRAY_CONSTEXPR DynArrayImpl(Range range)
         : data_(std::make_unique<value_type[]>(range.length())), range_(range) {}
 
-    COCONEXT_DYN_ARRAY_CONSTEXPR DynArray(std::initializer_list<value_type> init)
+    COCONEXT_DYN_ARRAY_CONSTEXPR DynArrayImpl(std::initializer_list<value_type> init)
         : data_(std::make_unique_for_overwrite<value_type[]>(init.size())),
           range_(init.size()) {
         std::ranges::copy(init, data_.get());
     }
 
-    COCONEXT_DYN_ARRAY_CONSTEXPR DynArray(
+    COCONEXT_DYN_ARRAY_CONSTEXPR DynArrayImpl(
         std::initializer_list<value_type> init, Range range
     )
         : range_(range) {
@@ -92,8 +100,8 @@ class DynArray {
 
     template <std::ranges::sized_range R>
         requires std::convertible_to<std::ranges::range_value_t<R>, value_type>
-                  && (!std::same_as<std::remove_cvref_t<R>, DynArray>)
-    explicit COCONEXT_DYN_ARRAY_CONSTEXPR DynArray(R const& obj)
+                  && (!std::derived_from<std::remove_cvref_t<R>, DynArrayImpl>)
+    explicit COCONEXT_DYN_ARRAY_CONSTEXPR DynArrayImpl(R const& obj)
         : data_(std::make_unique_for_overwrite<value_type[]>(std::ranges::size(obj))),
           range_(std::ranges::size(obj)) {
         std::ranges::copy(obj, data_.get());
@@ -101,7 +109,7 @@ class DynArray {
 
     template <std::ranges::sized_range R>
         requires std::convertible_to<std::ranges::range_value_t<R>, value_type>
-    COCONEXT_DYN_ARRAY_CONSTEXPR DynArray(R const& obj, Range range) : range_(range) {
+    COCONEXT_DYN_ARRAY_CONSTEXPR DynArrayImpl(R const& obj, Range range) : range_(range) {
         if (std::ranges::size(obj) != range.length()) {
             throw std::invalid_argument(
                 "Input of size " + std::to_string(std::ranges::size(obj))
@@ -120,27 +128,57 @@ class DynArray {
     COCONEXT_DYN_ARRAY_CONSTEXPR const_reference operator[](index_type idx) const {
         return access_(*this, idx);
     }
-    COCONEXT_DYN_ARRAY_CONSTEXPR DynArraySlice<DynArray> operator[](Range r) {
-        detail::subsequence_check(range_, r);
-        return DynArraySlice<DynArray>(this, r);
-    }
-    COCONEXT_DYN_ARRAY_CONSTEXPR DynArraySlice<DynArray const> operator[](Range r) const {
-        detail::subsequence_check(range_, r);
-        return DynArraySlice<DynArray const>(this, r);
-    }
 
-    // Statically-typed sub-slice. R lives in the result type, so the slice's
-    // own bounds checks fold to constants; the subsequence check against this
-    // DynArray's runtime range happens once, here.
+    // Slices route through the outer `DynArray<ValueT>` (or const variant)
+    // so they pick up the Logic/Bit slice spec when applicable.
+    COCONEXT_DYN_ARRAY_CONSTEXPR DynArraySlice<DynArray<ValueT>> operator[](Range r) {
+        detail::subsequence_check(range_, r);
+        return DynArraySlice<DynArray<ValueT>>(static_cast<DynArray<ValueT>*>(this), r);
+    }
+#if __cplusplus >= 202302L
+    COCONEXT_DYN_ARRAY_CONSTEXPR DynArraySlice<DynArray<ValueT>> operator[](
+        Range::value_type left, Range::value_type right
+    ) {
+        return operator[](Range{left, right});
+    }
+    COCONEXT_DYN_ARRAY_CONSTEXPR DynArraySlice<DynArray<ValueT>> operator[](
+        Range::value_type left, Direction dir, Range::value_type right
+    ) {
+        return operator[](Range{left, dir, right});
+    }
+#endif
+    COCONEXT_DYN_ARRAY_CONSTEXPR DynArraySlice<DynArray<ValueT> const> operator[](
+        Range r
+    ) const {
+        detail::subsequence_check(range_, r);
+        return DynArraySlice<DynArray<ValueT> const>(
+            static_cast<DynArray<ValueT> const*>(this), r
+        );
+    }
+#if __cplusplus >= 202302L
+    COCONEXT_DYN_ARRAY_CONSTEXPR DynArraySlice<DynArray<ValueT> const> operator[](
+        Range::value_type left, Range::value_type right
+    ) {
+        return operator[](Range{left, right});
+    }
+    COCONEXT_DYN_ARRAY_CONSTEXPR DynArraySlice<DynArray<ValueT> const> operator[](
+        Range::value_type left, Direction dir, Range::value_type right
+    ) {
+        return operator[](Range{left, dir, right});
+    }
+#endif
+
     template <Range R>
-    COCONEXT_DYN_ARRAY_CONSTEXPR ArraySlice<DynArray, R> slice() {
+    COCONEXT_DYN_ARRAY_CONSTEXPR ArraySlice<DynArray<ValueT>, R> slice() {
         detail::subsequence_check(range_, R);
-        return ArraySlice<DynArray, R>(this);
+        return ArraySlice<DynArray<ValueT>, R>(static_cast<DynArray<ValueT>*>(this));
     }
     template <Range R>
-    COCONEXT_DYN_ARRAY_CONSTEXPR ArraySlice<DynArray const, R> slice() const {
+    COCONEXT_DYN_ARRAY_CONSTEXPR ArraySlice<DynArray<ValueT> const, R> slice() const {
         detail::subsequence_check(range_, R);
-        return ArraySlice<DynArray const, R>(this);
+        return ArraySlice<DynArray<ValueT> const, R>(
+            static_cast<DynArray<ValueT> const*>(this)
+        );
     }
 
     COCONEXT_DYN_ARRAY_CONSTEXPR iterator begin() noexcept { return data_.get(); }
@@ -167,10 +205,6 @@ class DynArray {
     }
 
   private:
-    // Shared body for the two operator[](index_type) overloads. Self is
-    // deduced as DynArray for the non-const caller and DynArray
-    // const for the const caller; the return type follows Self's constness
-    // implicitly (via the public overload's signature).
     template <typename Self>
     static COCONEXT_DYN_ARRAY_CONSTEXPR auto& access_(Self& self, index_type idx) {
         auto it = find(self.range_, idx);
@@ -184,10 +218,15 @@ class DynArray {
     Range range_;
 };
 
-static_assert(
-    std::is_same_v<decltype(std::declval<DynArray<int>>().range()), Range const&>,
-    "DynArray::range() must return Range const& to preserve the range/storage invariant"
-);
+}  // namespace detail
+
+// Heap-allocated, runtime-bounded array indexed according to its Range.
+template <typename ValueT>
+class DynArray : public detail::DynArrayImpl<ValueT> {
+  public:
+    using detail::DynArrayImpl<ValueT>::DynArrayImpl;
+    using detail::DynArrayImpl<ValueT>::operator=;
+};
 
 template <typename ValueT>
     requires std::equality_comparable<ValueT>
@@ -207,6 +246,7 @@ constexpr bool operator==(
 
 namespace detail {
 
+// Opt into array-specific features such as formatting.
 template <typename T>
 struct is_array<DynArray<T>> : std::true_type {};
 
@@ -219,11 +259,8 @@ static_assert(RangedSequence<DynArraySlice<DynArray<int> const>>);
 static_assert(RangedSequence<ArraySlice<DynArray<int>, Range{0, Direction::TO, 3}>>);
 static_assert(RangedSequence<ArraySlice<DynArray<int> const, Range{0, Direction::TO, 3}>>);
 
-// Runtime-ranged types have no static_range, so they must not match.
 static_assert(!StaticRangedSequence<DynArray<int>>);
 static_assert(!StaticRangedSequence<DynArraySlice<DynArray<int>>>);
-// ArraySlice carries the range in its type, so it does match -- even when the
-// underlying owner's range is runtime-only.
 static_assert(StaticRangedSequence<ArraySlice<DynArray<int>, Range{0, Direction::TO, 3}>>);
 
 }  // namespace coconext::types

--- a/cpp/include/coconext/types/logic.hpp
+++ b/cpp/include/coconext/types/logic.hpp
@@ -108,7 +108,9 @@ constexpr Logic to_logic(CharType c) {
     case '-':
         return Logic::DC;
     default:
-        throw std::invalid_argument("Invalid logic literal");
+        throw std::invalid_argument(
+            std::string("Invalid logic literal: '") + static_cast<char>(c) + "'"
+        );
     }
 }
 
@@ -119,7 +121,9 @@ constexpr Bit to_bit(CharType value) {
     } else if (value == '1') {
         return Bit::_1;
     } else {
-        throw std::invalid_argument("Invalid bit value");
+        throw std::invalid_argument(
+            std::string("Invalid bit value: '") + static_cast<char>(value) + "'"
+        );
     }
 }
 
@@ -205,6 +209,10 @@ constexpr std::string_view to_string(Bit const& value) noexcept {
 constexpr char to_char(Logic const& value) noexcept {
     constexpr char char_map[] = {'0', '1', 'X', 'Z', 'U', 'W', 'L', 'H', '-'};
     return char_map[static_cast<size_t>(value.value())];
+}
+
+constexpr char to_char(Bit const& value) noexcept {
+    return value.value() == Bit::_0 ? '0' : '1';
 }
 
 constexpr int to_int(Logic const& value) {

--- a/cpp/include/coconext/types/logic_array.hpp
+++ b/cpp/include/coconext/types/logic_array.hpp
@@ -1,12 +1,262 @@
 #ifndef COCONEXT_LOGIC_ARRAY_HPP
 #define COCONEXT_LOGIC_ARRAY_HPP
 
+#include <algorithm>
 #include <coconext/types/array.hpp>
 #include <coconext/types/dyn_array.hpp>
 #include <coconext/types/logic.hpp>
+#include <coconext/types/string_literal.hpp>
+#include <cstddef>
 #include <format>
+#include <limits>
+#include <ranges>
+#include <stdexcept>
+#include <string>
 
-namespace coconext::types::detail {
+namespace coconext::types {
+
+namespace detail {
+
+// CRTP mixin providing the Logic/Bit-specific query and resolution members.
+// Inherited by the Logic/Bit specializations of Array, DynArray, ArraySlice,
+// and DynArraySlice below. The non-Logic/Bit primaries do NOT inherit this,
+// so `Array<int, R>::is_resolvable()` and friends don't exist.
+template <typename Self>
+struct LogicArrayMixin {
+    bool is_resolvable() const noexcept {
+        auto const& self = *static_cast<Self const*>(this);
+        using Elem = std::ranges::range_value_t<Self>;
+        if constexpr (std::same_as<Elem, Bit>) {
+            // Every Bit is resolvable; skip the walk.
+            return true;
+        } else {
+            return std::ranges::all_of(self, [](auto const& v) {
+                return v.is_resolvable();
+            });
+        }
+    }
+
+    // Element-wise resolve. Returns a static `Array<Elem, R>` when Self has a
+    // compile-time range, a heap-allocated `DynArray<Elem>` otherwise. The
+    // returned array preserves Self's range (an owner returns the same shape;
+    // a slice returns an owner sized like the slice's range).
+    auto resolve(ResolveMethod method) const {
+        auto const& self = *static_cast<Self const*>(this);
+        using Elem = std::ranges::range_value_t<Self>;
+        if constexpr (StaticRangedSequence<Self>) {
+            ::coconext::types::Array<Elem, Self::range()> result{};
+            std::ranges::transform(self, result.begin(), [method](auto const& v) {
+                return v.resolve(method);
+            });
+            return result;
+        } else {
+            ::coconext::types::DynArray<Elem> result(self.range());
+            std::ranges::transform(self, result.begin(), [method](auto const& v) {
+                return v.resolve(method);
+            });
+            return result;
+        }
+    }
+};
+
+}  // namespace detail
+
+// -- Logic/Bit specializations ---------------------------------------------
+//
+// These specializations make `Array<Logic, R>`, `Array<Bit, R>`,
+// `DynArray<Logic>`, `DynArray<Bit>`, and slices over Logic/Bit owners
+// inherit `LogicArrayMixin`, gaining `is_resolvable()` and `resolve(method)`
+// as members. The primary templates remain unchanged for non-Logic element
+// types -- e.g., `Array<int, R>` has no `is_resolvable()`.
+
+namespace detail {
+
+template <Range R>
+class Array<Logic, R> : public ArrayImpl<Logic, R>,
+                        public LogicArrayMixin<Array<Logic, R>> {
+  public:
+    using ArrayImpl<Logic, R>::ArrayImpl;
+    using ArrayImpl<Logic, R>::operator=;
+};
+
+template <Range R>
+class Array<Bit, R> : public ArrayImpl<Bit, R>, public LogicArrayMixin<Array<Bit, R>> {
+  public:
+    using ArrayImpl<Bit, R>::ArrayImpl;
+    using ArrayImpl<Bit, R>::operator=;
+};
+
+}  // namespace detail
+
+template <>
+class DynArray<Logic> : public detail::DynArrayImpl<Logic>,
+                        public detail::LogicArrayMixin<DynArray<Logic>> {
+  public:
+    using detail::DynArrayImpl<Logic>::DynArrayImpl;
+    using detail::DynArrayImpl<Logic>::operator=;
+};
+
+template <>
+class DynArray<Bit> : public detail::DynArrayImpl<Bit>,
+                      public detail::LogicArrayMixin<DynArray<Bit>> {
+  public:
+    using detail::DynArrayImpl<Bit>::DynArrayImpl;
+    using detail::DynArrayImpl<Bit>::operator=;
+};
+
+// Constrained partial specs that pick up any slice whose owner's element
+// type is Logic or Bit, regardless of whether the owner is Array<...>,
+// DynArray<...>, or const-qualified.
+template <typename ArrayT>
+    requires LogicType<std::ranges::range_value_t<ArrayT>>
+class DynArraySlice<ArrayT> : public detail::DynArraySliceImpl<ArrayT>,
+                              public detail::LogicArrayMixin<DynArraySlice<ArrayT>> {
+  public:
+    using detail::DynArraySliceImpl<ArrayT>::DynArraySliceImpl;
+    using detail::DynArraySliceImpl<ArrayT>::operator=;
+};
+
+template <typename ArrayT, Range R>
+    requires LogicType<std::ranges::range_value_t<ArrayT>>
+class ArraySlice<ArrayT, R> : public detail::ArraySliceImpl<ArrayT, R>,
+                              public detail::LogicArrayMixin<ArraySlice<ArrayT, R>> {
+  public:
+    using detail::ArraySliceImpl<ArrayT, R>::ArraySliceImpl;
+    using detail::ArraySliceImpl<ArrayT, R>::operator=;
+};
+
+using DynLogicArray = DynArray<Logic>;
+using DynBitArray = DynArray<Bit>;
+
+template <auto... Args>
+using LogicArray = Array<Logic, Args...>;
+
+template <auto... Args>
+using BitArray = Array<Bit, Args...>;
+
+template <typename T>
+concept LogicArrayType =
+    ArrayType<T> && LogicType<std::ranges::range_value_t<std::remove_cvref_t<T>>>;
+
+// -- Bitwise array operations -----------------------------------------------
+
+namespace detail {
+
+template <RangedSequence LHS, RangedSequence RHS, typename Op>
+    requires LogicType<std::ranges::range_value_t<LHS>>
+          && LogicType<std::ranges::range_value_t<RHS>>
+auto logic_binop(LHS const& lhs, RHS const& rhs, Op op) {
+    using result_elem = decltype(op(
+        std::declval<std::ranges::range_value_t<LHS>>(),
+        std::declval<std::ranges::range_value_t<RHS>>()
+    ));
+    // When both sides have compile-time-known ranges, fold the length check
+    // into a static_assert and return a stack-allocated static Array. A
+    // runtime range on either side forces a heap-allocated DynArray.
+    if constexpr (StaticRangedSequence<LHS> && StaticRangedSequence<RHS>) {
+        constexpr auto LR = std::remove_cvref_t<LHS>::range();
+        constexpr auto RR = std::remove_cvref_t<RHS>::range();
+        static_assert(
+            LR.length() == RR.length(), "Bitwise operation requires arrays of equal length"
+        );
+        // LR's length is already bounded by Range::value_type (int32_t).
+        Array<
+            result_elem,
+            Range{static_cast<Range::value_type>(LR.length()) - 1, Direction::DOWNTO, 0}>
+            result{};
+        std::transform(
+            std::ranges::begin(lhs),
+            std::ranges::end(lhs),
+            std::ranges::begin(rhs),
+            result.begin(),
+            op
+        );
+        return result;
+    } else {
+        if (lhs.range().length() != rhs.range().length()) {
+            throw std::invalid_argument(
+                "Bitwise operation requires arrays of equal length, got "
+                + std::to_string(lhs.range().length()) + " and "
+                + std::to_string(rhs.range().length())
+            );
+        }
+        // lhs.range() was constructed validly so its length already fits in
+        // Range::value_type.
+        auto const n = static_cast<Range::value_type>(lhs.range().length());
+        DynArray<result_elem> result(Range{n - 1, Direction::DOWNTO, 0});
+        std::transform(
+            std::ranges::begin(lhs),
+            std::ranges::end(lhs),
+            std::ranges::begin(rhs),
+            result.begin(),
+            op
+        );
+        return result;
+    }
+}
+
+}  // namespace detail
+
+template <RangedSequence LHS, RangedSequence RHS>
+    requires LogicArrayType<LHS> && LogicArrayType<RHS>
+auto operator&(LHS const& lhs, RHS const& rhs) {
+    return detail::logic_binop(lhs, rhs, [](auto const& a, auto const& b) {
+        return a & b;
+    });
+}
+
+template <RangedSequence LHS, RangedSequence RHS>
+    requires LogicArrayType<LHS> && LogicArrayType<RHS>
+auto operator|(LHS const& lhs, RHS const& rhs) {
+    return detail::logic_binop(lhs, rhs, [](auto const& a, auto const& b) {
+        return a | b;
+    });
+}
+
+template <RangedSequence LHS, RangedSequence RHS>
+    requires LogicArrayType<LHS> && LogicArrayType<RHS>
+auto operator^(LHS const& lhs, RHS const& rhs) {
+    return detail::logic_binop(lhs, rhs, [](auto const& a, auto const& b) {
+        return a ^ b;
+    });
+}
+
+template <RangedSequence T>
+    requires LogicArrayType<T>
+auto operator~(T const& arr) {
+    using elem_t = std::ranges::range_value_t<T>;
+    if constexpr (StaticRangedSequence<T>) {
+        constexpr auto AR = std::remove_cvref_t<T>::range();
+        // AR's length is already bounded by Range::value_type (int32_t).
+        Array<
+            elem_t,
+            Range{static_cast<Range::value_type>(AR.length()) - 1, Direction::DOWNTO, 0}>
+            result{};
+        std::transform(
+            std::ranges::begin(arr),
+            std::ranges::end(arr),
+            result.begin(),
+            [](auto const& v) { return ~v; }
+        );
+        return result;
+    } else {
+        // arr.range() was constructed validly so its length already fits in
+        // Range::value_type.
+        auto const n = static_cast<Range::value_type>(arr.range().length());
+        DynArray<elem_t> result(Range{n - 1, Direction::DOWNTO, 0});
+        std::transform(
+            std::ranges::begin(arr),
+            std::ranges::end(arr),
+            result.begin(),
+            [](auto const& v) { return ~v; }
+        );
+        return result;
+    }
+}
+
+// -- Conversion to/from string ------------------------------------------------
+
+namespace detail {
 
 template <LogicType T>
 constexpr std::string_view logic_type_name() {
@@ -17,10 +267,39 @@ constexpr std::string_view logic_type_name() {
     }
 }
 
-// Variant of format_array for arrays of types with a bare to_string form
-// (Logic, Bit). Prints "TypeName[range]{e1, e2, ...}" with elements rendered
-// via to_string instead of std::formatter, suppressing the per-element type
-// tag.
+template <typename ElemT, typename CharToElem>
+DynArray<ElemT> parse_logic_string(std::string_view s, CharToElem char_to_elem) {
+    size_t count = 0;
+    for (char c : s) {
+        if (c != '_') {
+            ++count;
+        }
+    }
+    if (count > static_cast<size_t>(std::numeric_limits<Range::value_type>::max())) {
+        throw std::length_error("logic string too long for Range::value_type");
+    }
+    auto const n = static_cast<Range::value_type>(count);
+    DynArray<ElemT> result(Range{n - 1, Direction::DOWNTO, 0});
+    size_t j = 0;
+    for (char c : s) {
+        if (c != '_') {
+            *(result.begin() + j++) = char_to_elem(c);
+        }
+    }
+    return result;
+}
+
+template <StringLiteral S>
+constexpr size_t count_non_underscore() {
+    size_t n = 0;
+    for (size_t i = 0; i < S.size; ++i) {
+        if (S.data[i] != '_') {
+            ++n;
+        }
+    }
+    return n;
+}
+
 template <RangedSequence ArrayT, typename OutIt>
 OutIt format_typed_array(std::string_view type_name, ArrayT const& arr, OutIt out) {
     out = std::format_to(out, "{}{}{{", type_name, arr.range());
@@ -36,11 +315,89 @@ OutIt format_typed_array(std::string_view type_name, ArrayT const& arr, OutIt ou
     return out;
 }
 
-}  // namespace coconext::types::detail
+}  // namespace detail
 
-namespace coconext::types {
+template <RangedSequence T>
+    requires LogicType<std::ranges::range_value_t<T>>
+std::string to_string(T const& arr) {
+    std::string result;
+    result.reserve(arr.range().length());
+    for (auto const& elem : arr) {
+        result += to_char(elem);
+    }
+    return result;
+}
 
-using DynLogicArray = DynArray<Logic>;
+inline DynArray<Logic> to_logic_array(std::string_view s) {
+    return detail::parse_logic_string<Logic>(s, [](char c) { return to_logic(c); });
+}
+
+inline DynArray<Bit> to_bit_array(std::string_view s) {
+    return detail::parse_logic_string<Bit>(s, [](char c) { return to_bit(c); });
+}
+
+// Convert a range of Logic to a DynArray<Bit>. Throws if any element is not
+// 0/1/L/H (i.e. every element must be resolvable). Constrained to sized_range
+// so the result can be sized up-front from std::ranges::size in O(1) and the
+// resolvability check can be fused with the fill into a single pass.
+template <std::ranges::sized_range R>
+    requires std::same_as<std::ranges::range_value_t<R>, Logic>
+DynArray<Bit> to_bit_array(R const& range) {
+    auto const sz = std::ranges::size(range);
+    if (sz > static_cast<size_t>(std::numeric_limits<Range::value_type>::max())) {
+        throw std::length_error("range too long for Range::value_type");
+    }
+    auto const n = static_cast<Range::value_type>(sz);
+    DynArray<Bit> result(Range{n - 1, Direction::DOWNTO, 0});
+    auto out = result.begin();
+    for (Logic const& v : range) {
+        if (!v.is_resolvable()) {
+            throw std::invalid_argument(
+                "Cannot convert non-resolvable Logic values to BitArray"
+            );
+        }
+        *out++ = to_int(v) ? Bit::_1 : Bit::_0;
+    }
+    return result;
+}
+
+// -- String-literal UDL ----------------------------------------------------
+
+template <StringLiteral S>
+constexpr auto operator""_l() {
+    constexpr auto N = detail::count_non_underscore<S>();
+    static_assert(
+        N <= static_cast<size_t>(std::numeric_limits<Range::value_type>::max()),
+        "logic literal too long for Range::value_type"
+    );
+    constexpr Range R{static_cast<Range::value_type>(N) - 1, Direction::DOWNTO, 0};
+    LogicArray<R> result{};
+    auto out = result.begin();
+    for (auto in = S.data; in != S.data + S.size; ++in) {
+        if (*in != '_') {
+            *out++ = to_logic(*in);
+        }
+    }
+    return result;
+}
+
+template <StringLiteral S>
+constexpr auto operator""_b() {
+    constexpr auto N = detail::count_non_underscore<S>();
+    static_assert(
+        N <= static_cast<size_t>(std::numeric_limits<Range::value_type>::max()),
+        "bit literal too long for Range::value_type"
+    );
+    constexpr Range R{static_cast<Range::value_type>(N) - 1, Direction::DOWNTO, 0};
+    BitArray<R> result{};
+    auto out = result.begin();
+    for (auto in = S.data; in != S.data + S.size; ++in) {
+        if (*in != '_') {
+            *out++ = to_bit(*in);
+        }
+    }
+    return result;
+}
 
 }  // namespace coconext::types
 

--- a/cpp/include/coconext/types/string_literal.hpp
+++ b/cpp/include/coconext/types/string_literal.hpp
@@ -1,0 +1,19 @@
+#ifndef COCONEXT_STRING_LITERAL_HPP
+#define COCONEXT_STRING_LITERAL_HPP
+
+#include <algorithm>
+#include <cstddef>
+
+namespace coconext::types {
+
+template <size_t N>
+struct StringLiteral {
+    static_assert(N >= 1, "StringLiteral requires at least the NUL terminator");
+    char data[N]{};
+    static constexpr size_t size = N - 1;
+    constexpr StringLiteral(char const (&str)[N]) { std::copy_n(str, N, data); }
+};
+
+}  // namespace coconext::types
+
+#endif  // COCONEXT_STRING_LITERAL_HPP

--- a/nanobind/src/types/bind_logic.cpp
+++ b/nanobind/src/types/bind_logic.cpp
@@ -123,7 +123,9 @@ void register_logic(nb::module_& m) {
         .def(
             "__xor__", [](Logic const& a, Bit const& b) { return a ^ b; }, nb::is_operator()
         )
-        .def("__invert__", nb::overload_cast<Logic const&>(&operator~), nb::is_operator())
+        .def(
+            "__invert__", [](Logic const& self) { return ~self; }, nb::is_operator()
+        )
         .def_prop_ro("is_resolvable", &Logic::is_resolvable)
         .def(
             "resolve",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,7 @@ cmake.version = ">=3.20"
 CMAKE_EXPORT_COMPILE_COMMANDS = true
 
 [tool.codespell]
-ignore-words-list = "sting"
+ignore-words-list = "sting,elemt"
 
 [tool.cibuildwheel]
 build = "cp*-manylinux_x86_64 cp*-macosx_x86_64 cp*-macosx_arm64"

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -20,7 +20,8 @@ add_executable(coconext_tests
     test_logic.cpp
     test_range.cpp
     test_array.cpp
-    test_static_array.cpp)
+    test_static_array.cpp
+    test_logic_array.cpp)
 target_link_libraries(coconext_tests PRIVATE coconext::coconext GTest::gtest_main)
 
 gtest_discover_tests(coconext_tests)

--- a/tests/cpp/test_array.cpp
+++ b/tests/cpp/test_array.cpp
@@ -91,6 +91,21 @@ TEST(TestDynArray, IterationConst) {
     EXPECT_EQ(sum, 6);
 }
 
+// -- Find -------------------------------------------------------------------
+
+TEST(TestDynArray, FindElement) {
+    DynArray<int> a({10, 20, 30, 40, 50});
+    auto it = std::find(a.begin(), a.end(), 30);
+    ASSERT_NE(it, a.end());
+    EXPECT_EQ(*it, 30);
+    EXPECT_EQ(std::distance(a.begin(), it), 2);
+}
+
+TEST(TestDynArray, FindElementMissing) {
+    DynArray<int> a({10, 20, 30});
+    EXPECT_EQ(std::find(a.begin(), a.end(), 99), a.end());
+}
+
 // -- Indexing ---------------------------------------------------------------
 
 TEST(TestDynArray, IndexingTO) {

--- a/tests/cpp/test_logic_array.cpp
+++ b/tests/cpp/test_logic_array.cpp
@@ -1,0 +1,745 @@
+// LCOV_EXCL_BR_START -- gtest macros generate noisy uncovered branches
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <coconext/types.hpp>
+#include <stdexcept>
+#include <vector>
+
+using namespace coconext::types;
+
+// -- Find -------------------------------------------------------------------
+
+TEST(TestLogicArray, FindLogicElement) {
+    auto a = "01XZ"_l;
+    auto it = std::find(a.begin(), a.end(), 'X'_l);
+    ASSERT_NE(it, a.end());
+    EXPECT_EQ(*it, 'X'_l);
+}
+
+// -- Bitwise array operations: AND ------------------------------------------
+
+TEST(TestLogicArray, AndLogic) {
+    DynArray<Logic> a({'1'_l, '0'_l, 'X'_l, '1'_l});
+    DynArray<Logic> b({'1'_l, '1'_l, '1'_l, '0'_l});
+    auto c = a & b;
+    static_assert(std::is_same_v<decltype(c), DynArray<Logic>>);
+    EXPECT_EQ(c.range(), Range(3, Direction::DOWNTO, 0));
+    EXPECT_EQ(c[3], '1'_l);
+    EXPECT_EQ(c[2], '0'_l);
+    EXPECT_EQ(c[1], 'X'_l);
+    EXPECT_EQ(c[0], '0'_l);
+}
+
+// -- Bitwise array operations: OR -------------------------------------------
+
+TEST(TestLogicArray, OrLogic) {
+    DynArray<Logic> a({'1'_l, '0'_l, 'X'_l, '0'_l});
+    DynArray<Logic> b({'0'_l, '0'_l, '1'_l, '0'_l});
+    auto c = a | b;
+    EXPECT_EQ(c[3], '1'_l);
+    EXPECT_EQ(c[2], '0'_l);
+    EXPECT_EQ(c[1], '1'_l);
+    EXPECT_EQ(c[0], '0'_l);
+}
+
+// -- Bitwise array operations: XOR ------------------------------------------
+
+TEST(TestLogicArray, XorLogic) {
+    DynArray<Logic> a({'1'_l, '0'_l, '1'_l, '0'_l});
+    DynArray<Logic> b({'1'_l, '1'_l, '0'_l, '0'_l});
+    auto c = a ^ b;
+    EXPECT_EQ(c[3], '0'_l);
+    EXPECT_EQ(c[2], '1'_l);
+    EXPECT_EQ(c[1], '1'_l);
+    EXPECT_EQ(c[0], '0'_l);
+}
+
+// -- Bitwise array operations: NOT ------------------------------------------
+
+TEST(TestLogicArray, NotLogic) {
+    DynArray<Logic> a({'0'_l, '1'_l, 'X'_l, 'Z'_l});
+    auto c = ~a;
+    static_assert(std::is_same_v<decltype(c), DynArray<Logic>>);
+    EXPECT_EQ(c.range(), Range(3, Direction::DOWNTO, 0));
+    EXPECT_EQ(c[3], '1'_l);
+    EXPECT_EQ(c[2], '0'_l);
+    EXPECT_EQ(c[1], 'X'_l);
+    EXPECT_EQ(c[0], 'X'_l);
+}
+
+TEST(TestLogicArray, NotBit) {
+    DynArray<Bit> a({'0'_b, '1'_b, '0'_b, '1'_b});
+    auto c = ~a;
+    static_assert(std::is_same_v<decltype(c), DynArray<Bit>>);
+    EXPECT_EQ(c.range(), Range(3, Direction::DOWNTO, 0));
+    EXPECT_EQ(c[3], '1'_b);
+    EXPECT_EQ(c[2], '0'_b);
+    EXPECT_EQ(c[1], '1'_b);
+    EXPECT_EQ(c[0], '0'_b);
+}
+
+// -- Bitwise operations: edge cases -----------------------------------------
+
+TEST(TestLogicArray, BitwiseLengthMismatch) {
+    DynArray<Logic> a({'0'_l, '1'_l});
+    DynArray<Logic> b({'0'_l, '1'_l, 'X'_l});
+    EXPECT_THROW((void)(a & b), std::invalid_argument);
+    EXPECT_THROW((void)(a | b), std::invalid_argument);
+    EXPECT_THROW((void)(a ^ b), std::invalid_argument);
+}
+
+TEST(TestLogicArray, BitwiseEmpty) {
+    DynArray<Logic> a({});
+    DynArray<Logic> b({});
+    auto c = a & b;
+    EXPECT_EQ(c.range().length(), 0U);
+}
+
+TEST(TestLogicArray, BitwiseResultRange) {
+    DynArray<Logic> a({'0'_l, '1'_l, '1'_l}, Range(5, Direction::DOWNTO, 3));
+    DynArray<Logic> b({'1'_l, '1'_l, '0'_l});
+    auto c = a & b;
+    EXPECT_EQ(c.range(), Range(2, Direction::DOWNTO, 0));
+    EXPECT_EQ(c[2], '0'_l);
+    EXPECT_EQ(c[1], '1'_l);
+    EXPECT_EQ(c[0], '0'_l);
+}
+
+TEST(TestLogicArray, BitwiseOnSlice) {
+    DynArray<Logic> a({'0'_l, '1'_l, '1'_l, '0'_l});
+    DynArray<Logic> b({'1'_l, '0'_l});
+    auto s = a[{1, 2}];
+    auto c = s & b;
+    static_assert(std::is_same_v<decltype(c), DynArray<Logic>>);
+    EXPECT_EQ(c.range(), Range(1, Direction::DOWNTO, 0));
+    EXPECT_EQ(c[1], '1'_l);
+    EXPECT_EQ(c[0], '0'_l);
+}
+
+TEST(TestLogicArray, BitwiseOnStaticArraySlice) {
+    Array<Logic, 4> a({'0'_l, '1'_l, '1'_l, '0'_l});
+    Array<Logic, 4> b({'1'_l, '0'_l, '1'_l, '1'_l});
+    auto sa = a[{1, 2}];
+    auto sb = b[{1, 2}];
+    auto c = sa & sb;
+    static_assert(std::is_same_v<decltype(c), DynArray<Logic>>);
+    EXPECT_EQ(c.range(), Range(1, Direction::DOWNTO, 0));
+    EXPECT_EQ(c[1], '0'_l);
+    EXPECT_EQ(c[0], '1'_l);
+}
+
+TEST(TestLogicArray, MixedLogicBitAnd) {
+    DynArray<Logic> a({'0'_l, '1'_l, 'X'_l});
+    DynArray<Bit> b({'1'_b, '1'_b, '1'_b});
+    auto c = a & b;
+    static_assert(std::is_same_v<decltype(c), DynArray<Logic>>);
+    EXPECT_EQ(c[2], '0'_l);
+    EXPECT_EQ(c[1], '1'_l);
+    EXPECT_EQ(c[0], 'X'_l);
+}
+
+TEST(TestLogicArray, MixedLogicBitOr) {
+    DynArray<Logic> a({'0'_l, '1'_l, 'X'_l});
+    DynArray<Bit> b({'0'_b, '0'_b, '1'_b});
+    auto c = a | b;
+    static_assert(std::is_same_v<decltype(c), DynArray<Logic>>);
+    EXPECT_EQ(c[2], '0'_l);
+    EXPECT_EQ(c[1], '1'_l);
+    EXPECT_EQ(c[0], '1'_l);
+}
+
+TEST(TestLogicArray, MixedLogicBitXor) {
+    DynArray<Logic> a({'0'_l, '1'_l, 'X'_l});
+    DynArray<Bit> b({'1'_b, '1'_b, '0'_b});
+    auto c = a ^ b;
+    static_assert(std::is_same_v<decltype(c), DynArray<Logic>>);
+    EXPECT_EQ(c[2], '1'_l);
+    EXPECT_EQ(c[1], '0'_l);
+    EXPECT_EQ(c[0], 'X'_l);
+}
+
+// -- to_logic_array from string ---------------------------------------------
+
+TEST(TestLogicArray, ToLogicArray) {
+    auto a = to_logic_array("01XZ");
+    EXPECT_EQ(a.range(), Range(3, Direction::DOWNTO, 0));
+    EXPECT_EQ(a[3], '0'_l);
+    EXPECT_EQ(a[2], '1'_l);
+    EXPECT_EQ(a[1], 'X'_l);
+    EXPECT_EQ(a[0], 'Z'_l);
+}
+
+TEST(TestLogicArray, ToLogicArrayCaseInsensitive) {
+    auto a = to_logic_array("01xzulwh-");
+    EXPECT_EQ(a[8], '0'_l);
+    EXPECT_EQ(a[7], '1'_l);
+    EXPECT_EQ(a[6], 'X'_l);
+    EXPECT_EQ(a[5], 'Z'_l);
+    EXPECT_EQ(a[4], 'U'_l);
+    EXPECT_EQ(a[3], 'L'_l);
+    EXPECT_EQ(a[2], 'W'_l);
+    EXPECT_EQ(a[1], 'H'_l);
+    EXPECT_EQ(a[0], '-'_l);
+}
+
+TEST(TestLogicArray, ToLogicArrayUnderscore) {
+    auto a = to_logic_array("01_XZ");
+    EXPECT_EQ(a.range().length(), 4U);
+    EXPECT_EQ(a[3], '0'_l);
+    EXPECT_EQ(a[0], 'Z'_l);
+}
+
+TEST(TestLogicArray, ToLogicArrayEmpty) {
+    auto a = to_logic_array("");
+    EXPECT_EQ(a.range().length(), 0U);
+}
+
+TEST(TestLogicArray, ToLogicArrayInvalidChar) {
+    EXPECT_THROW(to_logic_array("0!1"), std::invalid_argument);
+}
+
+// -- to_string on arrays ----------------------------------------------------
+
+TEST(TestLogicArray, ToStringLogic) {
+    auto a = to_logic_array("01XZULWH-");
+    EXPECT_EQ(to_string(a), "01XZULWH-");
+}
+
+TEST(TestLogicArray, ToStringEmpty) {
+    auto a = to_logic_array("");
+    EXPECT_EQ(to_string(a), "");
+}
+
+// -- is_resolvable on arrays ------------------------------------------------
+
+TEST(TestLogicArray, IsResolvableTrue) {
+    auto a = to_logic_array("01LH");
+    EXPECT_TRUE(a.is_resolvable());
+}
+
+TEST(TestLogicArray, IsResolvableFalse) {
+    EXPECT_FALSE(to_logic_array("01X0").is_resolvable());
+    EXPECT_FALSE(to_logic_array("Z").is_resolvable());
+    EXPECT_FALSE(to_logic_array("U").is_resolvable());
+    EXPECT_FALSE(to_logic_array("W").is_resolvable());
+    EXPECT_FALSE(to_logic_array("-").is_resolvable());
+}
+
+TEST(TestLogicArray, IsResolvableEmpty) {
+    auto a = to_logic_array("");
+    EXPECT_TRUE(a.is_resolvable());
+}
+
+// -- resolve on arrays ------------------------------------------------------
+
+TEST(TestLogicArray, ResolveZeros) {
+    auto a = to_logic_array("01XZULWH-");
+    auto b = a.resolve(ResolveMethod::ZEROS);
+    EXPECT_EQ(to_string(b), "010000010");
+}
+
+TEST(TestLogicArray, ResolveOnes) {
+    auto a = to_logic_array("01XZULWH-");
+    auto b = a.resolve(ResolveMethod::ONES);
+    EXPECT_EQ(to_string(b), "011110111");
+}
+
+TEST(TestLogicArray, ResolveWeak) {
+    auto a = to_logic_array("01XZULWH-");
+    auto b = a.resolve(ResolveMethod::WEAK);
+    EXPECT_EQ(to_string(b), "01XZU0X1-");
+}
+
+TEST(TestLogicArray, ResolveError) {
+    auto a = to_logic_array("01X");
+    EXPECT_THROW(a.resolve(ResolveMethod::ERROR), std::invalid_argument);
+}
+
+TEST(TestLogicArray, ResolveErrorPass) {
+    auto a = to_logic_array("01");
+    auto b = a.resolve(ResolveMethod::ERROR);
+    EXPECT_EQ(to_string(b), "01");
+}
+
+TEST(TestLogicArray, ResolveStaticReturnsStaticArray) {
+    auto a = "01XZ"_l;  // static LogicArray<Range{3, DOWNTO, 0}>
+    auto b = a.resolve(ResolveMethod::ZEROS);
+    // Static-bound input -> static-bound output of matching range. This is the
+    // payoff of memberizing resolve on the specializations: the result type
+    // preserves Self's static range when available.
+    static_assert(std::is_same_v<decltype(b), LogicArray<Range{3, Direction::DOWNTO, 0}>>);
+    EXPECT_EQ(to_string(b), "0100");
+}
+
+// -- Slice resolvability ---------------------------------------------------
+//
+// The constrained partial specs of ArraySlice and DynArraySlice inherit the
+// LogicArrayMixin too, so slices of LogicArray/BitArray/DynLogicArray/etc
+// have is_resolvable() and resolve(method) members. Sub-slicing preserves
+// the mixin via outer-name resolution in the slice impl.
+
+TEST(TestLogicArray, DynSliceIsResolvable) {
+    // to_logic_array parses MSB-first into a DOWNTO range, so "01X" has
+    // a[2]='0', a[1]='1', a[0]='X'.
+    auto a = to_logic_array("01X");
+    auto s_full = a[{2, 0}];
+    EXPECT_FALSE(s_full.is_resolvable());  // covers the X at a[0]
+    auto s_excl_x = a[{2, 1}];
+    EXPECT_TRUE(s_excl_x.is_resolvable());  // covers '0' and '1' only
+}
+
+TEST(TestLogicArray, DynSliceResolveReturnsDynArray) {
+    auto a = to_logic_array("01XZ");
+    auto s = a[{3, 0}];
+    auto r = s.resolve(ResolveMethod::ZEROS);
+    static_assert(std::is_same_v<decltype(r), DynArray<Logic>>);
+    EXPECT_EQ(to_string(r), "0100");
+}
+
+TEST(TestLogicArray, StaticSliceResolveReturnsStaticArray) {
+    auto a = "01XZ"_l;  // LogicArray<Range{3, DOWNTO, 0}>
+    auto s = a.slice<Range{2, Direction::DOWNTO, 1}>();
+    auto r = s.resolve(ResolveMethod::ZEROS);
+    static_assert(std::is_same_v<decltype(r), LogicArray<Range{2, Direction::DOWNTO, 1}>>);
+    EXPECT_EQ(to_string(r), "10");  // X->0, 1->1; slice was {X, 1} in storage order
+}
+
+TEST(TestLogicArray, StaticSliceIsResolvable) {
+    // Exercises ArraySlice<LogicArray<R>, R2>::is_resolvable() -- the constrained
+    // partial spec from logic_array.hpp. Without this test a regression that drops
+    // the mixin from the static slice spec would only be caught when user code
+    // calls .is_resolvable() on a sliced LogicArray and fails to compile.
+    auto a = "01XZ"_l;  // a[3]='0', a[2]='1', a[1]='X', a[0]='Z'
+    auto s_with_x = a.slice<Range{2, Direction::DOWNTO, 1}>();
+    EXPECT_FALSE(s_with_x.is_resolvable());  // contains '1' and 'X'
+    auto s_clean = a.slice<Range{3, Direction::DOWNTO, 2}>();
+    EXPECT_TRUE(s_clean.is_resolvable());  // '0' and '1'
+}
+
+TEST(TestLogicArray, ConstOwnerDynSliceHasMixin) {
+    // Exercises DynArraySlice<const DynArray<Logic>> -- the constrained partial
+    // spec must trigger for const-qualified Logic/Bit owners too. Without this
+    // test a regression where range_value_t<const DynArray<Logic>> doesn't reduce
+    // to Logic would leave const slices on the non-Logic primary shell and lose
+    // the mixin. The check is structural (the call has to compile and return a
+    // bool), not the value -- a const slice over a resolvable Logic array.
+    DynArray<Logic> const a = to_logic_array("01LH");
+    auto s = a[{3, 0}];
+    static_assert(
+        std::same_as<decltype(s), DynArraySlice<DynArray<Logic> const>>,
+        "const Logic owner must produce DynArraySlice<const DynArray<Logic>>"
+    );
+    EXPECT_TRUE(s.is_resolvable());  // all elements are 0/1/L/H
+    auto r = s.resolve(ResolveMethod::WEAK);
+    EXPECT_EQ(to_string(r), "0101");  // L->0, H->1
+}
+
+TEST(TestLogicArray, SubSlicePreservesMixin) {
+    auto a = to_logic_array("01XZ");
+    auto s = a[{3, 0}];
+    auto sub = s[{2, 1}];  // sub-slice via DynArraySliceImpl::operator[]
+    // The sub-slice still has is_resolvable() -- the impl returns
+    // DynArraySlice<ArrayT> by outer name, which resolves to the constrained
+    // partial spec when the element type is Logic.
+    EXPECT_FALSE(sub.is_resolvable());
+}
+
+// -- String-literal UDL ----------------------------------------------------
+
+TEST(TestLogicArray, UdlLogic) {
+    auto a = "01XZ"_l;
+    static_assert(std::is_same_v<decltype(a), LogicArray<Range{3, Direction::DOWNTO, 0}>>);
+    EXPECT_EQ(a.range(), (Range{3, Direction::DOWNTO, 0}));
+    EXPECT_EQ(a[3], '0'_l);
+    EXPECT_EQ(a[2], '1'_l);
+    EXPECT_EQ(a[1], 'X'_l);
+    EXPECT_EQ(a[0], 'Z'_l);
+}
+
+TEST(TestLogicArray, UdlLogicUnderscore) {
+    auto a = "01_XZ"_l;
+    static_assert(std::is_same_v<decltype(a), LogicArray<Range{3, Direction::DOWNTO, 0}>>);
+    EXPECT_EQ(a[3], '0'_l);
+    EXPECT_EQ(a[2], '1'_l);
+    EXPECT_EQ(a[1], 'X'_l);
+    EXPECT_EQ(a[0], 'Z'_l);
+}
+
+TEST(TestLogicArray, UdlLogicEmpty) {
+    // Empty UDL yields a zero-length static LogicArray. The Range{-1, DOWNTO, 0}
+    // construction inside the UDL is a degenerate range (length 0); verify it
+    // type-checks and produces an iterable empty array.
+    auto a = ""_l;
+    static_assert(std::is_same_v<decltype(a), LogicArray<Range{-1, Direction::DOWNTO, 0}>>);
+    EXPECT_EQ(a.range().length(), 0U);
+    EXPECT_EQ(a.begin(), a.end());
+}
+
+TEST(TestLogicArray, UdlLogicAllUnderscores) {
+    // All-underscore literal yields a zero-length array just like the empty
+    // literal -- the underscores are stripped, count_non_underscore returns 0.
+    auto a = "____"_l;
+    static_assert(std::is_same_v<decltype(a), LogicArray<Range{-1, Direction::DOWNTO, 0}>>);
+    EXPECT_EQ(a.range().length(), 0U);
+}
+
+TEST(TestLogicArray, FormatterStatic) {
+    // The LogicType-constrained std::formatter spec in logic_array.hpp must
+    // pick up static LogicArray, not just DynLogicArray (the latter is covered
+    // in test_array.cpp). Verifies the partial spec matches at the static
+    // owner type and produces the "Logic[range]{...}" form.
+    auto a = "01XZ"_l;  // LogicArray<Range{3, DOWNTO, 0}>
+    EXPECT_EQ(std::format("{}", a), "Logic[3 downto 0]{0, 1, X, Z}");
+}
+
+TEST(TestBitArray, FormatterStatic) {
+    auto a = "0101"_b;  // BitArray<Range{3, DOWNTO, 0}>
+    EXPECT_EQ(std::format("{}", a), "Bit[3 downto 0]{0, 1, 0, 1}");
+}
+
+TEST(TestLogicArray, UdlBitwiseOps) {
+    auto a = "0101"_l & "1100"_l;
+    static_assert(std::is_same_v<decltype(a), LogicArray<Range{3, Direction::DOWNTO, 0}>>);
+    EXPECT_EQ(a[3], '0'_l);
+    EXPECT_EQ(a[0], '0'_l);
+
+    auto b = "0101"_l ^ "1100"_l;
+    static_assert(std::is_same_v<decltype(b), LogicArray<Range{3, Direction::DOWNTO, 0}>>);
+    EXPECT_EQ(b[3], '1'_l);
+    EXPECT_EQ(b[0], '1'_l);
+
+    auto c = "0101"_l | "1100"_l;
+    static_assert(std::is_same_v<decltype(c), LogicArray<Range{3, Direction::DOWNTO, 0}>>);
+    EXPECT_EQ(c[3], '1'_l);
+
+    auto d = ~"0101"_l;
+    static_assert(std::is_same_v<decltype(d), LogicArray<Range{3, Direction::DOWNTO, 0}>>);
+    EXPECT_EQ(d[3], '1'_l);
+}
+
+TEST(TestLogicArray, BitwiseOpsMixedYieldsDynamic) {
+    // One static operand and one dynamic operand -> DynArray result.
+    auto lhs = "0101"_l;  // static LogicArray<4>
+    DynLogicArray rhs({'1'_l, '1'_l, '0'_l, '0'_l});
+    auto a = lhs & rhs;
+    static_assert(std::is_same_v<decltype(a), DynLogicArray>);
+    EXPECT_EQ(a.range(), (Range{3, Direction::DOWNTO, 0}));
+    EXPECT_EQ(a[3], '0'_l);
+    EXPECT_EQ(a[0], '0'_l);
+
+    auto b = ~rhs;
+    static_assert(std::is_same_v<decltype(b), DynLogicArray>);
+    EXPECT_EQ(b[3], '0'_l);
+    EXPECT_EQ(b[0], '1'_l);
+}
+
+// -- BitArray alias --------------------------------------------------------
+
+static_assert(std::is_same_v<
+              BitArray<Range{3, Direction::DOWNTO, 0}>,
+              Array<Bit, Range{3, Direction::DOWNTO, 0}>>);
+static_assert(std::is_same_v<DynBitArray, DynArray<Bit>>);
+
+// -- Bit-only bitwise operations -------------------------------------------
+
+TEST(TestBitArray, AndBit) {
+    DynBitArray a({'1'_b, '0'_b, '1'_b, '0'_b});
+    DynBitArray b({'1'_b, '1'_b, '0'_b, '0'_b});
+    auto c = a & b;
+    static_assert(std::is_same_v<decltype(c), DynBitArray>);
+    EXPECT_EQ(c.range(), Range(3, Direction::DOWNTO, 0));
+    EXPECT_EQ(c[3], '1'_b);
+    EXPECT_EQ(c[2], '0'_b);
+    EXPECT_EQ(c[1], '0'_b);
+    EXPECT_EQ(c[0], '0'_b);
+}
+
+TEST(TestBitArray, OrBit) {
+    DynBitArray a({'1'_b, '0'_b, '0'_b, '0'_b});
+    DynBitArray b({'0'_b, '0'_b, '1'_b, '0'_b});
+    auto c = a | b;
+    static_assert(std::is_same_v<decltype(c), DynBitArray>);
+    EXPECT_EQ(c.range(), Range(3, Direction::DOWNTO, 0));
+    EXPECT_EQ(c[3], '1'_b);
+    EXPECT_EQ(c[2], '0'_b);
+    EXPECT_EQ(c[1], '1'_b);
+    EXPECT_EQ(c[0], '0'_b);
+}
+
+TEST(TestBitArray, XorBit) {
+    DynBitArray a({'1'_b, '0'_b, '1'_b, '0'_b});
+    DynBitArray b({'1'_b, '1'_b, '0'_b, '0'_b});
+    auto c = a ^ b;
+    static_assert(std::is_same_v<decltype(c), DynBitArray>);
+    EXPECT_EQ(c.range(), Range(3, Direction::DOWNTO, 0));
+    EXPECT_EQ(c[3], '0'_b);
+    EXPECT_EQ(c[2], '1'_b);
+    EXPECT_EQ(c[1], '1'_b);
+    EXPECT_EQ(c[0], '0'_b);
+}
+
+// -- Cross-type promotion (Logic wins) -------------------------------------
+
+TEST(TestBitArray, StaticLogicBitAndPromotesToLogic) {
+    auto l = "0101"_l;  // static LogicArray<4>
+    auto b = "1100"_b;  // static BitArray<4>
+    auto c = l & b;
+    static_assert(std::is_same_v<decltype(c), LogicArray<Range{3, Direction::DOWNTO, 0}>>);
+    EXPECT_EQ(c[3], '0'_l);
+    EXPECT_EQ(c[2], '1'_l);
+    EXPECT_EQ(c[1], '0'_l);
+    EXPECT_EQ(c[0], '0'_l);
+}
+
+TEST(TestBitArray, StaticLogicBitOrPromotesToLogic) {
+    auto l = "0100"_l;
+    auto b = "1010"_b;
+    auto c = l | b;
+    static_assert(std::is_same_v<decltype(c), LogicArray<Range{3, Direction::DOWNTO, 0}>>);
+    EXPECT_EQ(c[3], '1'_l);
+    EXPECT_EQ(c[2], '1'_l);
+    EXPECT_EQ(c[1], '1'_l);
+    EXPECT_EQ(c[0], '0'_l);
+}
+
+TEST(TestBitArray, StaticLogicBitXorPromotesToLogic) {
+    auto l = "0011"_l;
+    auto b = "0101"_b;
+    auto c = l ^ b;
+    static_assert(std::is_same_v<decltype(c), LogicArray<Range{3, Direction::DOWNTO, 0}>>);
+    EXPECT_EQ(c[3], '0'_l);
+    EXPECT_EQ(c[2], '1'_l);
+    EXPECT_EQ(c[1], '1'_l);
+    EXPECT_EQ(c[0], '0'_l);
+}
+
+TEST(TestBitArray, StaticLogicXAndBitPromotesToLogic) {
+    // Logic side carries 'X' -- result must remain Logic to preserve it.
+    auto l = "X1"_l;
+    auto b = "11"_b;
+    auto c = l & b;
+    static_assert(std::is_same_v<decltype(c), LogicArray<Range{1, Direction::DOWNTO, 0}>>);
+    EXPECT_EQ(c[1], 'X'_l);
+    EXPECT_EQ(c[0], '1'_l);
+}
+
+TEST(TestBitArray, StaticBitBitStaysBit) {
+    auto a = "0101"_b;  // static BitArray<4>
+    auto b = "1100"_b;
+    auto c = a & b;
+    static_assert(std::is_same_v<decltype(c), BitArray<Range{3, Direction::DOWNTO, 0}>>);
+    EXPECT_EQ(c[3], '0'_b);
+    EXPECT_EQ(c[2], '1'_b);
+    EXPECT_EQ(c[1], '0'_b);
+    EXPECT_EQ(c[0], '0'_b);
+
+    auto d = ~a;
+    static_assert(std::is_same_v<decltype(d), BitArray<Range{3, Direction::DOWNTO, 0}>>);
+    EXPECT_EQ(d[3], '1'_b);
+    EXPECT_EQ(d[2], '0'_b);
+    EXPECT_EQ(d[1], '1'_b);
+    EXPECT_EQ(d[0], '0'_b);
+}
+
+TEST(TestBitArray, DynLogicBitAndPromotesToLogic) {
+    DynLogicArray l({'0'_l, '1'_l, 'X'_l, '0'_l});
+    DynBitArray b({'1'_b, '1'_b, '1'_b, '0'_b});
+    auto c = l & b;
+    static_assert(std::is_same_v<decltype(c), DynLogicArray>);
+    EXPECT_EQ(c[3], '0'_l);
+    EXPECT_EQ(c[2], '1'_l);
+    EXPECT_EQ(c[1], 'X'_l);
+    EXPECT_EQ(c[0], '0'_l);
+}
+
+TEST(TestBitArray, DynBitLogicOrPromotesToLogic) {
+    // BitArray on LHS, LogicArray on RHS -- promotion still happens.
+    DynBitArray b({'0'_b, '0'_b, '1'_b, '0'_b});
+    DynLogicArray l({'1'_l, '0'_l, '0'_l, 'X'_l});
+    auto c = b | l;
+    static_assert(std::is_same_v<decltype(c), DynLogicArray>);
+    EXPECT_EQ(c[3], '1'_l);
+    EXPECT_EQ(c[2], '0'_l);
+    EXPECT_EQ(c[1], '1'_l);
+    EXPECT_EQ(c[0], 'X'_l);
+}
+
+TEST(TestBitArray, StaticDynMixedYieldsDynLogic) {
+    // Static LogicArray + dynamic BitArray -- dynamic operand forces DynArray,
+    // and Logic wins for the element type.
+    auto l = "0101"_l;
+    DynBitArray b({'1'_b, '1'_b, '0'_b, '0'_b});
+    auto c = l & b;
+    static_assert(std::is_same_v<decltype(c), DynLogicArray>);
+    EXPECT_EQ(c[3], '0'_l);
+    EXPECT_EQ(c[0], '0'_l);
+}
+
+TEST(TestBitArray, DynBitStaticLogicAndPromotesToDynLogic) {
+    DynBitArray b({'1'_b, '1'_b, '0'_b, '0'_b});
+    auto l = "0101"_l;
+    auto c = b & l;
+    static_assert(std::is_same_v<decltype(c), DynLogicArray>);
+    EXPECT_EQ(c[3], '0'_l);
+    EXPECT_EQ(c[2], '1'_l);
+    EXPECT_EQ(c[1], '0'_l);
+    EXPECT_EQ(c[0], '0'_l);
+}
+
+TEST(TestBitArray, StaticBitDynLogicOrPromotesToDynLogic) {
+    auto b = "0010"_b;
+    DynLogicArray l({'1'_l, '0'_l, '0'_l, 'X'_l});
+    auto c = b | l;
+    static_assert(std::is_same_v<decltype(c), DynLogicArray>);
+    EXPECT_EQ(c[3], '1'_l);
+    EXPECT_EQ(c[2], '0'_l);
+    EXPECT_EQ(c[1], '1'_l);
+    EXPECT_EQ(c[0], 'X'_l);
+}
+
+// -- to_bit_array from string ----------------------------------------------
+
+TEST(TestBitArray, ToBitArray) {
+    auto a = to_bit_array("0110");
+    EXPECT_EQ(a.range(), Range(3, Direction::DOWNTO, 0));
+    EXPECT_EQ(a[3], '0'_b);
+    EXPECT_EQ(a[2], '1'_b);
+    EXPECT_EQ(a[1], '1'_b);
+    EXPECT_EQ(a[0], '0'_b);
+}
+
+TEST(TestBitArray, ToBitArrayUnderscore) {
+    auto a = to_bit_array("01_10");
+    EXPECT_EQ(a.range().length(), 4U);
+    EXPECT_EQ(a[3], '0'_b);
+    EXPECT_EQ(a[0], '0'_b);
+}
+
+TEST(TestBitArray, ToBitArrayEmpty) {
+    auto a = to_bit_array("");
+    EXPECT_EQ(a.range().length(), 0U);
+}
+
+TEST(TestBitArray, ToBitArrayInvalidChar) {
+    EXPECT_THROW(to_bit_array("01X0"), std::invalid_argument);
+    EXPECT_THROW(to_bit_array("2"), std::invalid_argument);
+}
+
+// -- to_bit_array from range of Logic --------------------------------------
+
+TEST(TestBitArray, ToBitArrayFromLogicRange) {
+    auto a = to_logic_array("01LH");
+    auto b = to_bit_array(a);
+    static_assert(std::is_same_v<decltype(b), DynBitArray>);
+    EXPECT_EQ(b.range(), Range(3, Direction::DOWNTO, 0));
+    EXPECT_EQ(b[3], '0'_b);
+    EXPECT_EQ(b[2], '1'_b);
+    EXPECT_EQ(b[1], '0'_b);
+    EXPECT_EQ(b[0], '1'_b);
+}
+
+TEST(TestBitArray, ToBitArrayFromLogicRangeNonResolvable) {
+    EXPECT_THROW(to_bit_array(to_logic_array("X")), std::invalid_argument);
+    EXPECT_THROW(to_bit_array(to_logic_array("Z")), std::invalid_argument);
+    EXPECT_THROW(to_bit_array(to_logic_array("U")), std::invalid_argument);
+    EXPECT_THROW(to_bit_array(to_logic_array("W")), std::invalid_argument);
+    EXPECT_THROW(to_bit_array(to_logic_array("-")), std::invalid_argument);
+}
+
+TEST(TestBitArray, ToBitArrayFromStdVector) {
+    // Exercises the sized_range overload with a non-coconext range. std::vector
+    // is the canonical non-coconext sized range; this verifies the constraint
+    // accepts it and the single-pass fused walk yields the same result as the
+    // coconext-array form above.
+    std::vector<Logic> const v{'0'_l, '1'_l, 'L'_l, 'H'_l};
+    auto b = to_bit_array(v);
+    static_assert(std::is_same_v<decltype(b), DynBitArray>);
+    EXPECT_EQ(b.range(), Range(3, Direction::DOWNTO, 0));
+    EXPECT_EQ(b[3], '0'_b);
+    EXPECT_EQ(b[2], '1'_b);
+    EXPECT_EQ(b[1], '0'_b);  // L -> 0
+    EXPECT_EQ(b[0], '1'_b);  // H -> 1
+}
+
+TEST(TestBitArray, ToBitArrayFromStdVectorNonResolvable) {
+    std::vector<Logic> const v{'0'_l, '1'_l, 'X'_l};
+    EXPECT_THROW(to_bit_array(v), std::invalid_argument);
+}
+
+TEST(TestBitArray, ToBitArrayFromStaticLogicArray) {
+    auto a = "01LH"_l;
+    auto b = to_bit_array(a);
+    static_assert(std::is_same_v<decltype(b), DynBitArray>);
+    EXPECT_EQ(to_string(b), "0101");
+}
+
+// -- to_string on BitArray -------------------------------------------------
+
+TEST(TestBitArray, ToStringBit) {
+    auto a = to_bit_array("0110");
+    EXPECT_EQ(to_string(a), "0110");
+}
+
+TEST(TestBitArray, ToStringStaticBit) {
+    auto a = "0101"_b;
+    EXPECT_EQ(to_string(a), "0101");
+}
+
+// -- is_resolvable on BitArray ---------------------------------------------
+
+TEST(TestBitArray, IsResolvableAlwaysTrue) {
+    auto a = to_bit_array("0110");
+    EXPECT_TRUE(a.is_resolvable());
+    auto empty = to_bit_array("");
+    EXPECT_TRUE(empty.is_resolvable());
+}
+
+// -- resolve on BitArray ---------------------------------------------------
+
+TEST(TestBitArray, ResolveBitIsIdentity) {
+    auto a = to_bit_array("0110");
+    static_assert(std::is_same_v<decltype(a.resolve(ResolveMethod::ZEROS)), DynBitArray>);
+    for (auto method :
+         {ResolveMethod::ZEROS,
+          ResolveMethod::ONES,
+          ResolveMethod::WEAK,
+          ResolveMethod::ERROR,
+          ResolveMethod::RANDOM})
+    {
+        EXPECT_EQ(to_string(a.resolve(method)), "0110");
+    }
+}
+
+// -- String-literal UDL ----------------------------------------------------
+
+TEST(TestBitArray, UdlBit) {
+    auto a = "0101"_b;
+    static_assert(std::is_same_v<decltype(a), BitArray<Range{3, Direction::DOWNTO, 0}>>);
+    EXPECT_EQ(a.range(), (Range{3, Direction::DOWNTO, 0}));
+    EXPECT_EQ(a[3], '0'_b);
+    EXPECT_EQ(a[2], '1'_b);
+    EXPECT_EQ(a[1], '0'_b);
+    EXPECT_EQ(a[0], '1'_b);
+}
+
+TEST(TestBitArray, UdlBitConstexpr) {
+    constexpr auto a = "0101"_b;
+    static_assert(a[3] == '0'_b);
+    static_assert(a[2] == '1'_b);
+    static_assert(a[1] == '0'_b);
+    static_assert(a[0] == '1'_b);
+}
+
+TEST(TestBitArray, UdlBitUnderscore) {
+    auto a = "01_10"_b;
+    static_assert(std::is_same_v<decltype(a), BitArray<Range{3, Direction::DOWNTO, 0}>>);
+    EXPECT_EQ(a[3], '0'_b);
+    EXPECT_EQ(a[2], '1'_b);
+    EXPECT_EQ(a[1], '1'_b);
+    EXPECT_EQ(a[0], '0'_b);
+}
+
+// Note: "<bad>"_b is a compile-time error (throw in constant evaluation), so
+// the UDL invalid-character path cannot be exercised by a runtime test. The
+// runtime invalid-character path is covered by ToBitArrayInvalidChar above.


### PR DESCRIPTION
Closes #160. Depends on #252. Adds dynamic-only bitwise operators (&, |, ^, ~) for arrays of Logic/Bit types, plus to_logic_array, to_string, is_resolvable, resolve, and string-literal UDL for constructing logic arrays.