### PR TITLE
`is_resolvable` changes

### DIFF
--- a/cpp/include/coconext/types/logic.hpp
+++ b/cpp/include/coconext/types/logic.hpp
@@ -10,6 +10,14 @@
 
 namespace coconext::types {
 
+enum class ResolveMethod {
+    ERROR,
+    WEAK,
+    ZEROS,
+    ONES,
+    RANDOM,
+};
+
 class Logic {
   public:
     enum class value_type : uint8_t {
@@ -29,6 +37,12 @@ class Logic {
     constexpr Logic(value_type value) noexcept : value_(value) {}
     constexpr value_type value() const noexcept { return value_; }
 
+    constexpr bool is_resolvable() const noexcept {
+        return value_ == _0 || value_ == _1 || value_ == L || value_ == H;
+    }
+
+    Logic resolve(ResolveMethod method) const;
+
   private:
     value_type value_ = _0;
 };
@@ -44,6 +58,10 @@ class Bit {
     constexpr Bit() noexcept = default;
     constexpr Bit(value_type value) noexcept : value_(value) {}
     constexpr value_type value() const noexcept { return value_; }
+
+    constexpr bool is_resolvable() const noexcept { return true; }
+
+    constexpr Bit resolve(ResolveMethod) const noexcept { return *this; }
 
     // Implicit conversion from Bit to Logic mimics subtype upcasting.
     constexpr operator Logic() const noexcept {
@@ -291,25 +309,6 @@ constexpr Logic operator~(Logic const& value) noexcept {
 constexpr Bit operator~(Bit const& value) noexcept {
     return value.value() == Bit::_0 ? Bit::_1 : Bit::_0;
 }
-
-constexpr bool is_resolvable(Logic const& value) noexcept {
-    return value == Logic::_0 || value == Logic::_1 || value == Logic::L
-        || value == Logic::H;
-}
-
-constexpr bool is_resolvable(Bit const&) noexcept { return true; }
-
-enum class ResolveMethod {
-    ERROR,
-    WEAK,
-    ZEROS,
-    ONES,
-    RANDOM,
-};
-
-Logic resolve(Logic const& value, ResolveMethod method);
-
-inline Bit resolve(Bit const& value, ResolveMethod method) { return value; }
 
 template <typename T>
 struct is_logic : std::false_type {};

--- a/cpp/include/coconext/types/logic.hpp
+++ b/cpp/include/coconext/types/logic.hpp
@@ -292,12 +292,12 @@ constexpr Bit operator~(Bit const& value) noexcept {
     return value.value() == Bit::_0 ? Bit::_1 : Bit::_0;
 }
 
-constexpr bool is_01(Logic const& value) noexcept {
+constexpr bool is_resolvable(Logic const& value) noexcept {
     return value == Logic::_0 || value == Logic::_1 || value == Logic::L
         || value == Logic::H;
 }
 
-constexpr bool is_01(Bit const&) noexcept { return true; }
+constexpr bool is_resolvable(Bit const&) noexcept { return true; }
 
 enum class ResolveMethod {
     ERROR,

--- a/cpp/src/logic.cpp
+++ b/cpp/src/logic.cpp
@@ -8,66 +8,66 @@ using namespace coconext::types;
 
 namespace coconext::types {
 
-Logic resolve(Logic const& value, ResolveMethod method) {
+Logic Logic::resolve(ResolveMethod method) const {
     switch (method) {
     case ResolveMethod::ERROR:
-        switch (value.value()) {
-        case Logic::_0:
-        case Logic::_1:
-            return value;
+        switch (value_) {
+        case _0:
+        case _1:
+            return *this;
         default:
             throw std::invalid_argument("Logic value is not resolvable");
         }
     case ResolveMethod::WEAK:
-        switch (value.value()) {
-        case Logic::_0:
-        case Logic::_1:
-            return value;
-        case Logic::L:
-            return Logic::_0;
-        case Logic::H:
-            return Logic::_1;
-        case Logic::W:
-            return Logic::X;
+        switch (value_) {
+        case _0:
+        case _1:
+            return *this;
+        case L:
+            return _0;
+        case H:
+            return _1;
+        case W:
+            return X;
         default:
-            return value;
+            return *this;
         }
     case ResolveMethod::ZEROS:
-        switch (value.value()) {
-        case Logic::_0:
-        case Logic::_1:
-            return value;
-        case Logic::L:
-            return Logic::_0;
-        case Logic::H:
-            return Logic::_1;
+        switch (value_) {
+        case _0:
+        case _1:
+            return *this;
+        case L:
+            return _0;
+        case H:
+            return _1;
         default:
-            return Logic::_0;
+            return _0;
         }
     case ResolveMethod::ONES:
-        switch (value.value()) {
-        case Logic::_0:
-        case Logic::_1:
-            return value;
-        case Logic::L:
-            return Logic::_0;
-        case Logic::H:
-            return Logic::_1;
+        switch (value_) {
+        case _0:
+        case _1:
+            return *this;
+        case L:
+            return _0;
+        case H:
+            return _1;
         default:
-            return Logic::_1;
+            return _1;
         }
     case ResolveMethod::RANDOM: {
-        switch (value.value()) {
-        case Logic::_0:
-        case Logic::_1:
-            return value;
-        case Logic::L:
-            return Logic::_0;
-        case Logic::H:
-            return Logic::_1;
+        switch (value_) {
+        case _0:
+        case _1:
+            return *this;
+        case L:
+            return _0;
+        case H:
+            return _1;
         default: {
             auto& rng = get_rng();
-            return (rng() % 2 == 0) ? Logic::_0 : Logic::_1;
+            return (rng() % 2 == 0) ? _0 : _1;
         }
         }
     }

--- a/nanobind/src/types/bind_logic.cpp
+++ b/nanobind/src/types/bind_logic.cpp
@@ -124,17 +124,14 @@ void register_logic(nb::module_& m) {
             "__xor__", [](Logic const& a, Bit const& b) { return a ^ b; }, nb::is_operator()
         )
         .def("__invert__", nb::overload_cast<Logic const&>(&operator~), nb::is_operator())
-        .def_prop_ro("is_resolvable", nb::overload_cast<Logic const&>(&is_resolvable))
+        .def_prop_ro("is_resolvable", &Logic::is_resolvable)
         .def(
             "resolve",
-            [](Logic const& value, std::string_view method) {
-                return resolve(value, string_to_resolve_method(method));
+            [](Logic const& self, std::string_view method) {
+                return self.resolve(string_to_resolve_method(method));
             }
         )
-        .def(
-            "resolve",
-            [](Logic const& self, ResolveMethod method) { return resolve(self, method); }
-        )
+        .def("resolve", &Logic::resolve)
         .def("__copy__", [](Logic const& self) { return Logic(self); })
         .def("__deepcopy__", [](Logic const& self, nb::dict /* memo */) {
             return Logic(self);
@@ -226,17 +223,14 @@ void register_logic(nb::module_& m) {
         .def(
             "__invert__", [](Bit const& self) { return ~self; }, nb::is_operator()
         )
-        .def_prop_ro("is_resolvable", [](Bit const&) { return true; })
+        .def_prop_ro("is_resolvable", &Bit::is_resolvable)
         .def(
             "resolve",
-            [](Bit const& value, std::string_view method) {
-                return resolve(value, string_to_resolve_method(method));
+            [](Bit const& self, std::string_view method) {
+                return self.resolve(string_to_resolve_method(method));
             }
         )
-        .def(
-            "resolve",
-            [](Bit const& self, ResolveMethod method) { return resolve(self, method); }
-        )
+        .def("resolve", &Bit::resolve)
         .def("__copy__", [](Bit const& self) { return Bit(self); })
         .def("__deepcopy__", [](Bit const& self, nb::dict /* memo */) {
             return Bit(self);

--- a/nanobind/src/types/bind_logic.cpp
+++ b/nanobind/src/types/bind_logic.cpp
@@ -124,7 +124,7 @@ void register_logic(nb::module_& m) {
             "__xor__", [](Logic const& a, Bit const& b) { return a ^ b; }, nb::is_operator()
         )
         .def("__invert__", nb::overload_cast<Logic const&>(&operator~), nb::is_operator())
-        .def_prop_ro("is_resolvable", nb::overload_cast<Logic const&>(&is_01))
+        .def_prop_ro("is_resolvable", nb::overload_cast<Logic const&>(&is_resolvable))
         .def(
             "resolve",
             [](Logic const& value, std::string_view method) {

--- a/tests/cpp/test_logic.cpp
+++ b/tests/cpp/test_logic.cpp
@@ -95,24 +95,24 @@ TEST(TestBit, BitConversions) {
 // Test Logic bool conversions
 TEST(TestLogic, LogicBoolConversions) {
     // Convertible to true
-    EXPECT_EQ(is_01('1'_l), true);
-    EXPECT_EQ(is_01('H'_l), true);
+    EXPECT_EQ(is_resolvable('1'_l), true);
+    EXPECT_EQ(is_resolvable('H'_l), true);
 
     // Convertible to false
-    EXPECT_EQ(is_01('0'_l), true);
-    EXPECT_EQ(is_01('L'_l), true);
+    EXPECT_EQ(is_resolvable('0'_l), true);
+    EXPECT_EQ(is_resolvable('L'_l), true);
 
     // Non-convertible values
-    EXPECT_EQ(is_01('X'_l), false);
-    EXPECT_EQ(is_01('Z'_l), false);
-    EXPECT_EQ(is_01('U'_l), false);
-    EXPECT_EQ(is_01('W'_l), false);
-    EXPECT_EQ(is_01('-'_l), false);
+    EXPECT_EQ(is_resolvable('X'_l), false);
+    EXPECT_EQ(is_resolvable('Z'_l), false);
+    EXPECT_EQ(is_resolvable('U'_l), false);
+    EXPECT_EQ(is_resolvable('W'_l), false);
+    EXPECT_EQ(is_resolvable('-'_l), false);
 }
 
 TEST(TestBit, BitBoolConversions) {
-    EXPECT_EQ(is_01('0'_b), true);
-    EXPECT_EQ(is_01('1'_b), true);
+    EXPECT_EQ(is_resolvable('0'_b), true);
+    EXPECT_EQ(is_resolvable('1'_b), true);
 }
 
 // Test Logic string conversions
@@ -330,23 +330,23 @@ TEST(TestLogic, RuntimeIntAndBitConversions) {
     EXPECT_EQ(resolve(bits[1], ResolveMethod::ZEROS), '1'_b);
 }
 
-// Test Logic is_resolvable (checked via is_01)
+// Test Logic is_resolvable
 TEST(TestLogic, LogicIsResolvable) {
-    EXPECT_TRUE(is_01(Logic::_0));
-    EXPECT_TRUE(is_01(Logic::_1));
-    EXPECT_TRUE(is_01('L'_l));
-    EXPECT_TRUE(is_01('H'_l));
+    EXPECT_TRUE(is_resolvable(Logic::_0));
+    EXPECT_TRUE(is_resolvable(Logic::_1));
+    EXPECT_TRUE(is_resolvable('L'_l));
+    EXPECT_TRUE(is_resolvable('H'_l));
 
-    EXPECT_FALSE(is_01('U'_l));
-    EXPECT_FALSE(is_01('X'_l));
-    EXPECT_FALSE(is_01('Z'_l));
-    EXPECT_FALSE(is_01('W'_l));
-    EXPECT_FALSE(is_01('-'_l));
+    EXPECT_FALSE(is_resolvable('U'_l));
+    EXPECT_FALSE(is_resolvable('X'_l));
+    EXPECT_FALSE(is_resolvable('Z'_l));
+    EXPECT_FALSE(is_resolvable('W'_l));
+    EXPECT_FALSE(is_resolvable('-'_l));
 }
 
 TEST(TestBit, BitIsResolvable) {
-    EXPECT_TRUE(is_01('0'_b));
-    EXPECT_TRUE(is_01('1'_b));
+    EXPECT_TRUE(is_resolvable('0'_b));
+    EXPECT_TRUE(is_resolvable('1'_b));
 }
 
 TEST(TestLogic, LogicIsHashable) {

--- a/tests/cpp/test_logic.cpp
+++ b/tests/cpp/test_logic.cpp
@@ -95,24 +95,24 @@ TEST(TestBit, BitConversions) {
 // Test Logic bool conversions
 TEST(TestLogic, LogicBoolConversions) {
     // Convertible to true
-    EXPECT_EQ(is_resolvable('1'_l), true);
-    EXPECT_EQ(is_resolvable('H'_l), true);
+    EXPECT_EQ(('1'_l).is_resolvable(), true);
+    EXPECT_EQ(('H'_l).is_resolvable(), true);
 
     // Convertible to false
-    EXPECT_EQ(is_resolvable('0'_l), true);
-    EXPECT_EQ(is_resolvable('L'_l), true);
+    EXPECT_EQ(('0'_l).is_resolvable(), true);
+    EXPECT_EQ(('L'_l).is_resolvable(), true);
 
     // Non-convertible values
-    EXPECT_EQ(is_resolvable('X'_l), false);
-    EXPECT_EQ(is_resolvable('Z'_l), false);
-    EXPECT_EQ(is_resolvable('U'_l), false);
-    EXPECT_EQ(is_resolvable('W'_l), false);
-    EXPECT_EQ(is_resolvable('-'_l), false);
+    EXPECT_EQ(('X'_l).is_resolvable(), false);
+    EXPECT_EQ(('Z'_l).is_resolvable(), false);
+    EXPECT_EQ(('U'_l).is_resolvable(), false);
+    EXPECT_EQ(('W'_l).is_resolvable(), false);
+    EXPECT_EQ(('-'_l).is_resolvable(), false);
 }
 
 TEST(TestBit, BitBoolConversions) {
-    EXPECT_EQ(is_resolvable('0'_b), true);
-    EXPECT_EQ(is_resolvable('1'_b), true);
+    EXPECT_EQ(('0'_b).is_resolvable(), true);
+    EXPECT_EQ(('1'_b).is_resolvable(), true);
 }
 
 // Test Logic string conversions
@@ -227,89 +227,89 @@ TEST(TestBit, BitInvert) {
 // Test Logic resolve with different methods
 TEST(TestLogic, LogicResolve) {
     // Test WEAK resolution
-    EXPECT_EQ(resolve('U'_l, ResolveMethod::WEAK), 'U'_l);
-    EXPECT_EQ(resolve('X'_l, ResolveMethod::WEAK), 'X'_l);
-    EXPECT_EQ(resolve('0'_l, ResolveMethod::WEAK), '0'_l);
-    EXPECT_EQ(resolve('1'_l, ResolveMethod::WEAK), '1'_l);
-    EXPECT_EQ(resolve('Z'_l, ResolveMethod::WEAK), 'Z'_l);
-    EXPECT_EQ(resolve('W'_l, ResolveMethod::WEAK), 'X'_l);
-    EXPECT_EQ(resolve('L'_l, ResolveMethod::WEAK), '0'_l);
-    EXPECT_EQ(resolve('H'_l, ResolveMethod::WEAK), '1'_l);
-    EXPECT_EQ(resolve('-'_l, ResolveMethod::WEAK), '-'_l);
+    EXPECT_EQ(('U'_l).resolve(ResolveMethod::WEAK), 'U'_l);
+    EXPECT_EQ(('X'_l).resolve(ResolveMethod::WEAK), 'X'_l);
+    EXPECT_EQ(('0'_l).resolve(ResolveMethod::WEAK), '0'_l);
+    EXPECT_EQ(('1'_l).resolve(ResolveMethod::WEAK), '1'_l);
+    EXPECT_EQ(('Z'_l).resolve(ResolveMethod::WEAK), 'Z'_l);
+    EXPECT_EQ(('W'_l).resolve(ResolveMethod::WEAK), 'X'_l);
+    EXPECT_EQ(('L'_l).resolve(ResolveMethod::WEAK), '0'_l);
+    EXPECT_EQ(('H'_l).resolve(ResolveMethod::WEAK), '1'_l);
+    EXPECT_EQ(('-'_l).resolve(ResolveMethod::WEAK), '-'_l);
 
     // Test ZEROS resolution
-    EXPECT_EQ(resolve('U'_l, ResolveMethod::ZEROS), '0'_l);
-    EXPECT_EQ(resolve('X'_l, ResolveMethod::ZEROS), '0'_l);
-    EXPECT_EQ(resolve('0'_l, ResolveMethod::ZEROS), '0'_l);
-    EXPECT_EQ(resolve('1'_l, ResolveMethod::ZEROS), '1'_l);
-    EXPECT_EQ(resolve('Z'_l, ResolveMethod::ZEROS), '0'_l);
-    EXPECT_EQ(resolve('W'_l, ResolveMethod::ZEROS), '0'_l);
-    EXPECT_EQ(resolve('L'_l, ResolveMethod::ZEROS), '0'_l);
-    EXPECT_EQ(resolve('H'_l, ResolveMethod::ZEROS), '1'_l);
-    EXPECT_EQ(resolve('-'_l, ResolveMethod::ZEROS), '0'_l);
+    EXPECT_EQ(('U'_l).resolve(ResolveMethod::ZEROS), '0'_l);
+    EXPECT_EQ(('X'_l).resolve(ResolveMethod::ZEROS), '0'_l);
+    EXPECT_EQ(('0'_l).resolve(ResolveMethod::ZEROS), '0'_l);
+    EXPECT_EQ(('1'_l).resolve(ResolveMethod::ZEROS), '1'_l);
+    EXPECT_EQ(('Z'_l).resolve(ResolveMethod::ZEROS), '0'_l);
+    EXPECT_EQ(('W'_l).resolve(ResolveMethod::ZEROS), '0'_l);
+    EXPECT_EQ(('L'_l).resolve(ResolveMethod::ZEROS), '0'_l);
+    EXPECT_EQ(('H'_l).resolve(ResolveMethod::ZEROS), '1'_l);
+    EXPECT_EQ(('-'_l).resolve(ResolveMethod::ZEROS), '0'_l);
 
     // Test ONES resolution
-    EXPECT_EQ(resolve('U'_l, ResolveMethod::ONES), '1'_l);
-    EXPECT_EQ(resolve('X'_l, ResolveMethod::ONES), '1'_l);
-    EXPECT_EQ(resolve('0'_l, ResolveMethod::ONES), '0'_l);
-    EXPECT_EQ(resolve('1'_l, ResolveMethod::ONES), '1'_l);
-    EXPECT_EQ(resolve('Z'_l, ResolveMethod::ONES), '1'_l);
-    EXPECT_EQ(resolve('W'_l, ResolveMethod::ONES), '1'_l);
-    EXPECT_EQ(resolve('L'_l, ResolveMethod::ONES), '0'_l);
-    EXPECT_EQ(resolve('H'_l, ResolveMethod::ONES), '1'_l);
-    EXPECT_EQ(resolve('-'_l, ResolveMethod::ONES), '1'_l);
+    EXPECT_EQ(('U'_l).resolve(ResolveMethod::ONES), '1'_l);
+    EXPECT_EQ(('X'_l).resolve(ResolveMethod::ONES), '1'_l);
+    EXPECT_EQ(('0'_l).resolve(ResolveMethod::ONES), '0'_l);
+    EXPECT_EQ(('1'_l).resolve(ResolveMethod::ONES), '1'_l);
+    EXPECT_EQ(('Z'_l).resolve(ResolveMethod::ONES), '1'_l);
+    EXPECT_EQ(('W'_l).resolve(ResolveMethod::ONES), '1'_l);
+    EXPECT_EQ(('L'_l).resolve(ResolveMethod::ONES), '0'_l);
+    EXPECT_EQ(('H'_l).resolve(ResolveMethod::ONES), '1'_l);
+    EXPECT_EQ(('-'_l).resolve(ResolveMethod::ONES), '1'_l);
 
     // Test RANDOM resolution
-    auto resolved_u = resolve('U'_l, ResolveMethod::RANDOM);
+    auto resolved_u = ('U'_l).resolve(ResolveMethod::RANDOM);
     EXPECT_TRUE(resolved_u == '0'_l || resolved_u == '1'_l);
 
-    auto resolved_x = resolve('X'_l, ResolveMethod::RANDOM);
+    auto resolved_x = ('X'_l).resolve(ResolveMethod::RANDOM);
     EXPECT_TRUE(resolved_x == '0'_l || resolved_x == '1'_l);
 
-    EXPECT_EQ(resolve('0'_l, ResolveMethod::RANDOM), '0'_l);
-    EXPECT_EQ(resolve('1'_l, ResolveMethod::RANDOM), '1'_l);
+    EXPECT_EQ(('0'_l).resolve(ResolveMethod::RANDOM), '0'_l);
+    EXPECT_EQ(('1'_l).resolve(ResolveMethod::RANDOM), '1'_l);
 
-    auto resolved_z = resolve('Z'_l, ResolveMethod::RANDOM);
+    auto resolved_z = ('Z'_l).resolve(ResolveMethod::RANDOM);
     EXPECT_TRUE(resolved_z == '0'_l || resolved_z == '1'_l);
 
-    auto resolved_w = resolve('W'_l, ResolveMethod::RANDOM);
+    auto resolved_w = ('W'_l).resolve(ResolveMethod::RANDOM);
     EXPECT_TRUE(resolved_w == '0'_l || resolved_w == '1'_l);
 
-    EXPECT_EQ(resolve('L'_l, ResolveMethod::RANDOM), '0'_l);
-    EXPECT_EQ(resolve('H'_l, ResolveMethod::RANDOM), '1'_l);
+    EXPECT_EQ(('L'_l).resolve(ResolveMethod::RANDOM), '0'_l);
+    EXPECT_EQ(('H'_l).resolve(ResolveMethod::RANDOM), '1'_l);
 
-    auto resolved_dc = resolve('-'_l, ResolveMethod::RANDOM);
+    auto resolved_dc = ('-'_l).resolve(ResolveMethod::RANDOM);
     EXPECT_TRUE(resolved_dc == '0'_l || resolved_dc == '1'_l);
 
     // Test ERROR resolution
-    EXPECT_EQ(resolve('0'_l, ResolveMethod::ERROR), '0'_l);
-    EXPECT_EQ(resolve('1'_l, ResolveMethod::ERROR), '1'_l);
-    EXPECT_THROW((void)resolve('U'_l, ResolveMethod::ERROR), std::invalid_argument);
-    EXPECT_THROW((void)resolve('X'_l, ResolveMethod::ERROR), std::invalid_argument);
-    EXPECT_THROW((void)resolve('Z'_l, ResolveMethod::ERROR), std::invalid_argument);
-    EXPECT_THROW((void)resolve('W'_l, ResolveMethod::ERROR), std::invalid_argument);
-    EXPECT_THROW((void)resolve('L'_l, ResolveMethod::ERROR), std::invalid_argument);
-    EXPECT_THROW((void)resolve('H'_l, ResolveMethod::ERROR), std::invalid_argument);
-    EXPECT_THROW((void)resolve('-'_l, ResolveMethod::ERROR), std::invalid_argument);
+    EXPECT_EQ(('0'_l).resolve(ResolveMethod::ERROR), '0'_l);
+    EXPECT_EQ(('1'_l).resolve(ResolveMethod::ERROR), '1'_l);
+    EXPECT_THROW((void)('U'_l).resolve(ResolveMethod::ERROR), std::invalid_argument);
+    EXPECT_THROW((void)('X'_l).resolve(ResolveMethod::ERROR), std::invalid_argument);
+    EXPECT_THROW((void)('Z'_l).resolve(ResolveMethod::ERROR), std::invalid_argument);
+    EXPECT_THROW((void)('W'_l).resolve(ResolveMethod::ERROR), std::invalid_argument);
+    EXPECT_THROW((void)('L'_l).resolve(ResolveMethod::ERROR), std::invalid_argument);
+    EXPECT_THROW((void)('H'_l).resolve(ResolveMethod::ERROR), std::invalid_argument);
+    EXPECT_THROW((void)('-'_l).resolve(ResolveMethod::ERROR), std::invalid_argument);
 
     // Out-of-range ResolveMethod hits the outer `default:` arm.
     EXPECT_THROW(
-        (void)resolve('0'_l, static_cast<ResolveMethod>(99)), std::invalid_argument
+        (void)('0'_l).resolve(static_cast<ResolveMethod>(99)), std::invalid_argument
     );
 }
 
 TEST(TestBit, BitResolve) {
-    EXPECT_EQ(resolve('0'_b, ResolveMethod::WEAK), '0'_b);
-    EXPECT_EQ(resolve('1'_b, ResolveMethod::WEAK), '1'_b);
+    EXPECT_EQ(('0'_b).resolve(ResolveMethod::WEAK), '0'_b);
+    EXPECT_EQ(('1'_b).resolve(ResolveMethod::WEAK), '1'_b);
 
-    EXPECT_EQ(resolve('0'_b, ResolveMethod::ZEROS), '0'_b);
-    EXPECT_EQ(resolve('1'_b, ResolveMethod::ZEROS), '1'_b);
+    EXPECT_EQ(('0'_b).resolve(ResolveMethod::ZEROS), '0'_b);
+    EXPECT_EQ(('1'_b).resolve(ResolveMethod::ZEROS), '1'_b);
 
-    EXPECT_EQ(resolve('0'_b, ResolveMethod::ONES), '0'_b);
-    EXPECT_EQ(resolve('1'_b, ResolveMethod::ONES), '1'_b);
+    EXPECT_EQ(('0'_b).resolve(ResolveMethod::ONES), '0'_b);
+    EXPECT_EQ(('1'_b).resolve(ResolveMethod::ONES), '1'_b);
 
-    EXPECT_EQ(resolve('0'_b, ResolveMethod::RANDOM), '0'_b);
-    EXPECT_EQ(resolve('1'_b, ResolveMethod::RANDOM), '1'_b);
+    EXPECT_EQ(('0'_b).resolve(ResolveMethod::RANDOM), '0'_b);
+    EXPECT_EQ(('1'_b).resolve(ResolveMethod::RANDOM), '1'_b);
 }
 
 // Stores values in std::vector to force runtime evaluation of conversions.
@@ -326,27 +326,27 @@ TEST(TestLogic, RuntimeIntAndBitConversions) {
     std::vector<Bit> const bits{'0'_b, '1'_b};
     EXPECT_EQ(to_logic(bits[0]), '0'_l);
     EXPECT_EQ(to_logic(bits[1]), '1'_l);
-    EXPECT_EQ(resolve(bits[0], ResolveMethod::WEAK), '0'_b);
-    EXPECT_EQ(resolve(bits[1], ResolveMethod::ZEROS), '1'_b);
+    EXPECT_EQ((bits[0]).resolve(ResolveMethod::WEAK), '0'_b);
+    EXPECT_EQ((bits[1]).resolve(ResolveMethod::ZEROS), '1'_b);
 }
 
 // Test Logic is_resolvable
 TEST(TestLogic, LogicIsResolvable) {
-    EXPECT_TRUE(is_resolvable(Logic::_0));
-    EXPECT_TRUE(is_resolvable(Logic::_1));
-    EXPECT_TRUE(is_resolvable('L'_l));
-    EXPECT_TRUE(is_resolvable('H'_l));
+    EXPECT_TRUE(('0'_l).is_resolvable());
+    EXPECT_TRUE(('1'_l).is_resolvable());
+    EXPECT_TRUE(('L'_l).is_resolvable());
+    EXPECT_TRUE(('H'_l).is_resolvable());
 
-    EXPECT_FALSE(is_resolvable('U'_l));
-    EXPECT_FALSE(is_resolvable('X'_l));
-    EXPECT_FALSE(is_resolvable('Z'_l));
-    EXPECT_FALSE(is_resolvable('W'_l));
-    EXPECT_FALSE(is_resolvable('-'_l));
+    EXPECT_FALSE(('U'_l).is_resolvable());
+    EXPECT_FALSE(('X'_l).is_resolvable());
+    EXPECT_FALSE(('Z'_l).is_resolvable());
+    EXPECT_FALSE(('W'_l).is_resolvable());
+    EXPECT_FALSE(('-'_l).is_resolvable());
 }
 
 TEST(TestBit, BitIsResolvable) {
-    EXPECT_TRUE(is_resolvable('0'_b));
-    EXPECT_TRUE(is_resolvable('1'_b));
+    EXPECT_TRUE(('0'_b).is_resolvable());
+    EXPECT_TRUE(('1'_b).is_resolvable());
 }
 
 TEST(TestLogic, LogicIsHashable) {


### PR DESCRIPTION
We use is_resolvable in Python and in LogicArray, so lets just make that the name. is_01 isn't even an accurate name.

Also memberize is_resolvable and resolve since there isn't much value making them free functions.