### PR TITLE
Simplify how range objects are retrieved

### DIFF
--- a/cpp/include/coconext/types/array.hpp
+++ b/cpp/include/coconext/types/array.hpp
@@ -95,8 +95,6 @@ class Array {
     using iterator = typename std::array<value_type, R.length()>::iterator;
     using const_iterator = typename std::array<value_type, R.length()>::const_iterator;
 
-    static constexpr Range static_range = R;
-
     constexpr Array()
         requires std::default_initializable<value_type>
         : data_{} {}
@@ -131,18 +129,18 @@ class Array {
         std::ranges::copy(obj, data_.begin());
     }
 
-    constexpr Range range() const noexcept { return R; }
+    static constexpr Range range() noexcept { return R; }
 
     constexpr reference operator[](index_type idx) { return access_(*this, idx); }
     constexpr const_reference operator[](index_type idx) const {
         return access_(*this, idx);
     }
     constexpr DynArraySlice<Array> operator[](Range r) {
-        detail::subsequence_check(static_range, r);
+        detail::subsequence_check(R, r);
         return DynArraySlice<Array>(this, r);
     }
     constexpr DynArraySlice<Array const> operator[](Range r) const {
-        detail::subsequence_check(static_range, r);
+        detail::subsequence_check(R, r);
         return DynArraySlice<Array const>(this, r);
     }
 
@@ -201,15 +199,6 @@ constexpr bool operator==(Array<T, R> const& lhs, Array<T, R> const& rhs) noexce
 
 template <typename T, Range R>
 struct is_array<Array<T, R>> : std::true_type {};
-
-}  // namespace detail
-
-template <typename T, Range R>
-struct static_range_of<detail::Array<T, R>> {
-    static constexpr Range value = R;
-};
-
-namespace detail {
 
 static_assert(RangedSequence<Array<int, Range{0, Direction::TO, 7}>>);
 static_assert(RangedSequence<Array<int, Range{0, Direction::TO, 7}> const>);

--- a/cpp/include/coconext/types/array_base.hpp
+++ b/cpp/include/coconext/types/array_base.hpp
@@ -16,7 +16,7 @@
 
 namespace coconext::types {
 
-// -- Concepts and traits ------------------------------------------------------
+// -- Concepts -----------------------------------------------------------------
 
 namespace detail {
 
@@ -27,70 +27,24 @@ concept sized_input_range = std::ranges::sized_range<R> && std::ranges::input_ra
 template <typename T>
 struct is_array : std::false_type {};
 
-template <typename T>
-concept has_range_member = requires(T const& t) {
-    { t.range() } -> std::convertible_to<Range>;
-};
-
-template <typename T>
-concept has_static_range_member = requires {
-    { T::static_range } -> std::convertible_to<Range>;
-};
+// Helper to force a value into a constant-expression context.
+template <auto V>
+struct require_constant {};
 
 }  // namespace detail
 
-// Customization point for the compile-time range. Specialize so that ::value
-// is a Range constant expression. Non-intrusive: external/wrapper types can
-// participate without modification. A default partial specialization below
-// picks up types that expose a `static constexpr Range static_range` member,
-// so our own array types participate without writing one.
-template <typename T>
-struct static_range_of;
-
-template <detail::has_static_range_member T>
-struct static_range_of<T> {
-    static constexpr Range value = T::static_range;
-};
-
-// Customization point for the runtime range of a sequence. Specialize this
-// for external/wrapper types that can't or don't expose t.range() directly
-// (e.g. std::vector, std::string). The default partial specialization below
-// picks up any type that has either a t.range() member or a static_range_of
-// specialization, so our own array types and static-range adapters (e.g.
-// std::array, fixed-extent std::span) participate without writing one.
-template <typename T>
-struct range_of;
-
-template <typename T>
-    requires detail::has_range_member<T> || requires {
-        { static_range_of<T>::value } -> std::convertible_to<Range>;
-    }
-struct range_of<T> {
-    static constexpr Range get(T const& t) {
-        if constexpr (detail::has_range_member<T>) {
-            return t.range();
-        } else {
-            return static_range_of<T>::value;
-        }
-    }
-};
-
-// A random-access range with a runtime range (via range_of).
-// Designed to match any Array-like type and support adaption of STL containers such
-// as std::vector and std::string.
+// A random-access range whose range is queryable via `obj.range()`.
 template <typename T>
 concept RangedSequence = std::ranges::random_access_range<T> && requires(T const& t) {
-    { range_of<std::remove_cvref_t<T>>::get(t) } -> std::convertible_to<Range>;
+    { t.range() } -> std::convertible_to<Range>;
 };
 
-// A random-access range with a compile-time range (via static_range_of).
-// Designed to match any Array-like type and support adaption of STL containers with
-// compile-time bounds such as std::array and fixed-extent std::span.
+// A RangedSequence whose range is also a compile-time constant -- i.e., T
+// exposes `range()` as a static method returning a constant expression.
+// Refines RangedSequence so overload resolution prefers it when both match.
 template <typename T>
 concept StaticRangedSequence = RangedSequence<T> && requires {
-    // This is a refinement of RangedSequence so StaticRangedSequence takes priority in
-    // overload resolution when both concepts are satisfied.
-    { static_range_of<std::remove_cvref_t<T>>::value } -> std::convertible_to<Range>;
+    typename detail::require_constant<std::remove_cvref_t<T>::range()>;
 };
 
 // Any type that opts into the array machinery via is_array. Element-type
@@ -260,14 +214,12 @@ class ArraySlice {
     using iterator = std::ranges::iterator_t<ArrayT>;
     static_assert(!std::is_reference_v<value_type>);
 
-    static constexpr Range static_range = R;
-
     constexpr ArraySlice() = delete;
     constexpr ArraySlice(ArraySlice const&) = default;
     constexpr ArraySlice(ArraySlice&&) = default;
     constexpr explicit ArraySlice(ArrayT* arr) noexcept : arr_(arr) {}
 
-    constexpr Range const& range() const noexcept { return static_range; }
+    static constexpr Range range() noexcept { return R; }
 
     constexpr reference operator[](index_type idx) const {
         if constexpr (R.direction == Direction::TO) {
@@ -316,7 +268,7 @@ class ArraySlice {
     constexpr ArraySlice const& operator=(Rng const& obj) const {
         if constexpr (StaticRangedSequence<Rng>) {
             static_assert(
-                static_range_of<std::remove_cvref_t<Rng>>::value.length() == R.length(),
+                std::remove_cvref_t<Rng>::range().length() == R.length(),
                 "static-length RHS does not match the slice length"
             );
         } else if (std::ranges::size(obj) != R.length()) {
@@ -353,7 +305,7 @@ class ArraySlice {
         } else if constexpr (StaticRangedSequence<ArrayT>) {
             // Parent's range is a compile-time constant; fold the offset to
             // a constant instead of recomputing it via find()/distance().
-            constexpr auto parent = static_range_of<std::remove_cvref_t<ArrayT>>::value;
+            constexpr auto parent = std::remove_cvref_t<ArrayT>::range();
             constexpr auto offset = parent.direction == Direction::TO
                                       ? R.left - parent.left
                                       : parent.left - R.left;
@@ -390,7 +342,7 @@ struct is_array<ArraySlice<ArrayT, R>> : std::true_type {};
 template <RangedSequence ArrayT, typename OutIt>
     requires Formattable<std::ranges::range_value_t<ArrayT>>
 OutIt format_array(ArrayT const& arr, OutIt out) {
-    out = std::format_to(out, "{}{{", range_of<std::remove_cvref_t<ArrayT>>::get(arr));
+    out = std::format_to(out, "{}{{", arr.range());
     bool first = true;
     for (auto const& elem : arr) {
         if (!first) {

--- a/cpp/include/coconext/types/logic_array.hpp
+++ b/cpp/include/coconext/types/logic_array.hpp
@@ -23,9 +23,7 @@ constexpr std::string_view logic_type_name() {
 // tag.
 template <RangedSequence ArrayT, typename OutIt>
 OutIt format_typed_array(std::string_view type_name, ArrayT const& arr, OutIt out) {
-    out = std::format_to(
-        out, "{}{}{{", type_name, range_of<std::remove_cvref_t<ArrayT>>::get(arr)
-    );
+    out = std::format_to(out, "{}{}{{", type_name, arr.range());
     bool first = true;
     for (auto const& elem : arr) {
         if (!first) {

--- a/tests/cpp/test_array.cpp
+++ b/tests/cpp/test_array.cpp
@@ -1,50 +1,13 @@
 // LCOV_EXCL_BR_START -- gtest macros generate noisy uncovered branches
 #include <gtest/gtest.h>
 
-#include <array>
 #include <coconext/types.hpp>
 #include <format>
 #include <functional>
 #include <numeric>
-#include <span>
 #include <stdexcept>
-#include <string>
 #include <unordered_set>
 #include <vector>
-
-// -- Post-hoc adaptation of foreign types via range_of / static_range_of ---
-//
-// Demonstrates the customization points: any type can participate in
-// RangedSequence / StaticRangedSequence without modifying its definition.
-// For static-range adapters (std::array, fixed-extent std::span), only
-// static_range_of is specialized; the default range_of partial specialization
-// picks it up automatically.
-
-namespace coconext::types {
-
-template <typename T, size_t N>
-struct static_range_of<std::array<T, N>> {
-    static constexpr Range value = Range(N);
-};
-
-template <typename T, size_t N>
-struct static_range_of<std::span<T, N>> {
-    static constexpr Range value = Range(N);
-};
-
-template <typename T, typename A>
-struct range_of<std::vector<T, A>> {
-    static constexpr Range get(std::vector<T, A> const& v) { return Range(v.size()); }
-};
-
-template <typename C, typename Tr, typename A>
-struct range_of<std::basic_string<C, Tr, A>> {
-    static constexpr Range get(std::basic_string<C, Tr, A> const& s) {
-        return Range(s.size());
-    }
-};
-
-}  // namespace coconext::types
 
 using namespace coconext::types;
 
@@ -530,7 +493,7 @@ TEST(TestDynArrayStaticSlice, SliceHappyPath) {
         std::is_same_v<decltype(s), ArraySlice<DynArray<int>, Range{1, 3}>>,
         "DynArray::slice<R>() must return a static ArraySlice"
     );
-    static_assert(decltype(s)::static_range == Range{1, Direction::TO, 3});
+    static_assert(decltype(s)::range() == Range{1, Direction::TO, 3});
     EXPECT_EQ(s.range().length(), 3U);
     EXPECT_EQ(s[1], 20);
     EXPECT_EQ(s[3], 40);
@@ -625,25 +588,24 @@ TEST(TestDynArrayStaticSlice, NullSliceBoundsOutsideParentOK) {
 // -- Compile-time dispatch -------------------------------------------------
 
 // Single integral arg -> length-based static range starting at 0.
-static_assert(Array<int, 8>::static_range == Range{0, Direction::TO, 7});
-static_assert(Array<int, 0>::static_range == Range{0, Direction::TO, -1});
-static_assert(Array<int, 1>::static_range == Range{0, Direction::TO, 0});
+static_assert(Array<int, 8>::range() == Range{0, Direction::TO, 7});
+static_assert(Array<int, 0>::range() == Range{0, Direction::TO, -1});
+static_assert(Array<int, 1>::range() == Range{0, Direction::TO, 0});
 
 // Single Range arg -> direct passthrough.
 static_assert(
-    Array<int, Range{2, Direction::DOWNTO, -5}>::static_range
-    == Range{2, Direction::DOWNTO, -5}
+    Array<int, Range{2, Direction::DOWNTO, -5}>::range() == Range{2, Direction::DOWNTO, -5}
 );
 
 // Two args -> (left, right), direction inferred.
-static_assert(Array<int, 1, 3>::static_range == Range{1, Direction::TO, 3});
-static_assert(Array<int, 4, 0>::static_range == Range{4, Direction::DOWNTO, 0});
-static_assert(Array<int, -3, 4>::static_range == Range{-3, Direction::TO, 4});
+static_assert(Array<int, 1, 3>::range() == Range{1, Direction::TO, 3});
+static_assert(Array<int, 4, 0>::range() == Range{4, Direction::DOWNTO, 0});
+static_assert(Array<int, -3, 4>::range() == Range{-3, Direction::TO, 4});
 
 // Three args -> (left, Direction, right) verbatim.
-static_assert(Array<int, 1, Direction::TO, 3>::static_range == Range{1, Direction::TO, 3});
+static_assert(Array<int, 1, Direction::TO, 3>::range() == Range{1, Direction::TO, 3});
 static_assert(
-    Array<int, 4, Direction::DOWNTO, 0>::static_range == Range{4, Direction::DOWNTO, 0}
+    Array<int, 4, Direction::DOWNTO, 0>::range() == Range{4, Direction::DOWNTO, 0}
 );
 
 // Different spellings of the same static range collapse to the same type:
@@ -654,7 +616,7 @@ static_assert(std::is_same_v<Array<int, 4, 0>, Array<int, 4, Direction::DOWNTO, 
 
 // Forwarding the static_range of one Array into the alias of another.
 using A_1_to_4 = Array<int, 1, 4>;
-static_assert(std::is_same_v<Array<int, A_1_to_4::static_range>, Array<int, 1, 4>>);
+static_assert(std::is_same_v<Array<int, A_1_to_4::range()>, Array<int, 1, 4>>);
 
 // -- Runtime: verify the static Array alias works -------------------------
 
@@ -698,7 +660,7 @@ TEST(TestArray, StaticThreeArgViaAlias) {
 TEST(TestArray, StaticFromForeignStaticRange) {
     using Src = Array<int, 1, 3>;
     Src src({10, 20, 30});
-    Array<int, Src::static_range> dst({100, 200, 300});
+    Array<int, Src::range()> dst({100, 200, 300});
     EXPECT_EQ(dst.range(), src.range());
     EXPECT_EQ(dst[1], 100);
     EXPECT_EQ(dst[3], 300);
@@ -745,49 +707,4 @@ TEST(TestDynArraySlice, StaticSliceConstReturnsConstSlice) {
     EXPECT_EQ(s[3], 40);
 }
 
-// -- range_of / static_range_of customization-point adaptation -------------
-
-// std::array<T, N>: size is part of the type, so only static_range_of is
-// specialized; range_of falls through to it.
-static_assert(RangedSequence<std::array<int, 8>>);
-static_assert(StaticRangedSequence<std::array<int, 8>>);
-static_assert(static_range_of<std::array<int, 8>>::value == Range(8));
-
-TEST(TestRangeOf, AdaptStdArray) {
-    std::array<int, 4> a{10, 20, 30, 40};
-    EXPECT_EQ((range_of<std::array<int, 4>>::get(a)), Range(4));
-}
-
-// std::span<T, Extent>: the fixed-extent form carries Extent in its type, so
-// it also models StaticRangedSequence via static_range_of alone.
-static_assert(RangedSequence<std::span<int, 5>>);
-static_assert(StaticRangedSequence<std::span<int, 5>>);
-static_assert(static_range_of<std::span<int, 5>>::value == Range(5));
-
-TEST(TestRangeOf, AdaptStdSpanFixedExtent) {
-    int data[6] = {1, 2, 3, 4, 5, 6};
-    std::span<int, 6> s{data};
-    EXPECT_EQ((range_of<std::span<int, 6>>::get(s)), Range(6));
-}
-
-// std::vector<T>: size is runtime; specialize range_of only. The type must
-// NOT satisfy StaticRangedSequence.
-static_assert(RangedSequence<std::vector<int>>);
-static_assert(!StaticRangedSequence<std::vector<int>>);
-
-TEST(TestRangeOf, AdaptStdVector) {
-    std::vector<int> v{10, 20, 30};
-    EXPECT_EQ((range_of<std::vector<int>>::get(v)), Range(3));
-    v.push_back(40);
-    EXPECT_EQ((range_of<std::vector<int>>::get(v)), Range(4));
-}
-
-// std::string: same shape as std::vector -- runtime size, range_of only.
-static_assert(RangedSequence<std::string>);
-static_assert(!StaticRangedSequence<std::string>);
-
-TEST(TestRangeOf, AdaptStdString) {
-    std::string s = "hello";
-    EXPECT_EQ((range_of<std::string>::get(s)), Range(5));
-}
 // LCOV_EXCL_BR_STOP

--- a/tests/cpp/test_static_array.cpp
+++ b/tests/cpp/test_static_array.cpp
@@ -57,7 +57,7 @@ TEST(TestStaticArray, CopyAndMove) {
 TEST(TestStaticArray, RangeAccessor) {
     Array<int, Range{2, Direction::TO, 5}> a({1, 2, 3, 4});
     EXPECT_EQ(a.range(), (Range{2, Direction::TO, 5}));
-    static_assert(decltype(a)::static_range == Range{2, Direction::TO, 5});
+    static_assert(decltype(a)::range() == Range{2, Direction::TO, 5});
 }
 
 TEST(TestStaticArray, ForwardIteration) {
@@ -311,7 +311,7 @@ TEST(TestStaticArrayStaticSlice, SliceHappyPath) {
         std::is_same_v<decltype(s), ArraySlice<AT, Range{1, 3}>>,
         "Array::slice<R>() must return ArraySlice<Array, R>"
     );
-    static_assert(decltype(s)::static_range == Range{1, Direction::TO, 3});
+    static_assert(decltype(s)::range() == Range{1, Direction::TO, 3});
     EXPECT_EQ(s.range().length(), 3U);
     EXPECT_EQ(s[1], 20);
     EXPECT_EQ(s[3], 40);


### PR DESCRIPTION
I decided to simplify this code by removing the customization point for range-having. I doubt its useful. Removing it vastly simplifies code.

Additionally, I took advantage of the fact that `arr.range()` will call static functions as well.