### PR TITLE
Memberize Logic/Bit and Range

### DIFF
--- a/cpp/include/coconext/types/array.hpp
+++ b/cpp/include/coconext/types/array.hpp
@@ -151,7 +151,7 @@ class Array {
     template <Range R2>
     constexpr ArraySlice<Array, R2> slice() {
         static_assert(
-            is_subsequence(R, R2),
+            R2.is_subsequence_of(R),
             "static sub-slice range is not a sub-range of the parent Array"
         );
         return ArraySlice<Array, R2>(this);
@@ -159,7 +159,7 @@ class Array {
     template <Range R2>
     constexpr ArraySlice<Array const, R2> slice() const {
         static_assert(
-            is_subsequence(R, R2),
+            R2.is_subsequence_of(R),
             "static sub-slice range is not a sub-range of the parent Array"
         );
         return ArraySlice<Array const, R2>(this);

--- a/cpp/include/coconext/types/array_base.hpp
+++ b/cpp/include/coconext/types/array_base.hpp
@@ -104,7 +104,7 @@ concept ArrayType = detail::is_array<std::remove_cvref_t<T>>::value;
 namespace detail {
 
 constexpr void subsequence_check(Range parent, Range child) {
-    if (!is_subsequence(parent, child)) {
+    if (!child.is_subsequence_of(parent)) {
         throw std::invalid_argument("Range is not a valid sub-range of the parent");
     }
 }
@@ -288,7 +288,7 @@ class ArraySlice {
     template <Range R2>
     constexpr ArraySlice<ArrayT, R2> slice() const {
         static_assert(
-            is_subsequence(R, R2),
+            R2.is_subsequence_of(R),
             "static sub-slice range is not a sub-range of the parent slice"
         );
         return ArraySlice<ArrayT, R2>(arr_);

--- a/cpp/include/coconext/types/logic.hpp
+++ b/cpp/include/coconext/types/logic.hpp
@@ -10,6 +10,14 @@
 
 namespace coconext::types {
 
+enum class ResolveMethod {
+    ERROR,
+    WEAK,
+    ZEROS,
+    ONES,
+    RANDOM,
+};
+
 class Logic {
   public:
     enum class value_type : uint8_t {
@@ -29,6 +37,12 @@ class Logic {
     constexpr Logic(value_type value) noexcept : value_(value) {}
     constexpr value_type value() const noexcept { return value_; }
 
+    constexpr bool is_resolvable() const noexcept {
+        return value_ == _0 || value_ == _1 || value_ == L || value_ == H;
+    }
+
+    Logic resolve(ResolveMethod method) const;
+
   private:
     value_type value_ = _0;
 };
@@ -44,6 +58,10 @@ class Bit {
     constexpr Bit() noexcept = default;
     constexpr Bit(value_type value) noexcept : value_(value) {}
     constexpr value_type value() const noexcept { return value_; }
+
+    constexpr bool is_resolvable() const noexcept { return true; }
+
+    constexpr Bit resolve(ResolveMethod) const noexcept { return *this; }
 
     // Implicit conversion from Bit to Logic mimics subtype upcasting.
     constexpr operator Logic() const noexcept {
@@ -291,25 +309,6 @@ constexpr Logic operator~(Logic const& value) noexcept {
 constexpr Bit operator~(Bit const& value) noexcept {
     return value.value() == Bit::_0 ? Bit::_1 : Bit::_0;
 }
-
-constexpr bool is_resolvable(Logic const& value) noexcept {
-    return value == Logic::_0 || value == Logic::_1 || value == Logic::L
-        || value == Logic::H;
-}
-
-constexpr bool is_resolvable(Bit const&) noexcept { return true; }
-
-enum class ResolveMethod {
-    ERROR,
-    WEAK,
-    ZEROS,
-    ONES,
-    RANDOM,
-};
-
-Logic resolve(Logic const& value, ResolveMethod method);
-
-inline Bit resolve(Bit const& value, ResolveMethod method) { return value; }
 
 template <typename T>
 struct is_logic : std::false_type {};

--- a/cpp/include/coconext/types/range.hpp
+++ b/cpp/include/coconext/types/range.hpp
@@ -104,6 +104,42 @@ struct Range {
     }
 #endif
 
+    // This range is a valid subsequence of `parent` iff every value in this
+    // range appears (in order) in parent. The rule collapses to:
+    //   - length 0:   always a subsequence (any direction, any bounds)
+    //   - length 1:   the single value must exist in parent; this range's
+    //                 direction is irrelevant (a one-element ordering is the
+    //                 same either way)
+    //   - length 2+:  this range's direction must match parent's (otherwise
+    //                 the values appear in parent but in reversed order,
+    //                 which isn't a subsequence) and both endpoints must
+    //                 exist in parent
+    //
+    // constexpr-evaluable, so callers can static_assert it at compile time as
+    // well as use it as a runtime predicate.
+    constexpr bool is_subsequence_of(Range parent) const noexcept {
+        auto const in_parent = [&](value_type v) {
+            if (parent.direction == Direction::TO) {
+                return v >= parent.left && v <= parent.right;
+            }
+            return v <= parent.left && v >= parent.right;
+        };
+        auto const len = length();
+        if (len == 0) {
+            return true;
+        }
+        if (!in_parent(left)) {
+            return false;
+        }
+        if (len == 1) {
+            return true;
+        }
+        if (direction != parent.direction) {
+            return false;
+        }
+        return in_parent(right);
+    }
+
     friend constexpr bool operator==(Range const& lhs, Range const& rhs) noexcept {
         auto left_len = lhs.length();
         if (left_len != rhs.length()) {
@@ -126,45 +162,6 @@ struct Range {
         return true;
     }
 };
-
-// A child range is a valid subsequence of a parent range iff every value in
-// the child appears (in order) in the parent. The rule collapses to:
-//   - length 0:   always a subsequence (any direction, any bounds)
-//   - length 1:   the single value must exist in the parent; the child's
-//                 direction is irrelevant (a one-element ordering is the same
-//                 either way)
-//   - length 2+:  the child's direction must match the parent's (otherwise
-//                 the child's values appear in the parent but in reversed
-//                 order, which isn't a subsequence) and both endpoints must
-//                 exist in the parent
-//
-// constexpr-evaluable, so callers can static_assert it at compile time as
-// well as use it as a runtime predicate.
-constexpr bool is_subsequence(Range parent, Range child) noexcept {
-    auto const in_parent = [&](Range::value_type v) {
-        if (parent.direction == Direction::TO) {
-            return v >= parent.left && v <= parent.right;
-        }
-        return v <= parent.left && v >= parent.right;
-    };
-    // This follows similar logic to operator==, but with in_parent predicate,
-    // and we aren't checking for equality of length, so we have
-    // to check for direction and right endpoint for length >= 2 cases.
-    auto const len = child.length();
-    if (len == 0) {
-        return true;
-    }
-    if (!in_parent(child.left)) {
-        return false;
-    }
-    if (len == 1) {
-        return true;
-    }
-    if (child.direction != parent.direction) {
-        return false;
-    }
-    return in_parent(child.right);
-}
 
 // more optimal implementation of std::ranges::find for Range
 constexpr Range::iterator find(Range const& range, Range::value_type value) {

--- a/cpp/src/logic.cpp
+++ b/cpp/src/logic.cpp
@@ -8,66 +8,66 @@ using namespace coconext::types;
 
 namespace coconext::types {
 
-Logic resolve(Logic const& value, ResolveMethod method) {
+Logic Logic::resolve(ResolveMethod method) const {
     switch (method) {
     case ResolveMethod::ERROR:
-        switch (value.value()) {
-        case Logic::_0:
-        case Logic::_1:
-            return value;
+        switch (value_) {
+        case _0:
+        case _1:
+            return *this;
         default:
             throw std::invalid_argument("Logic value is not resolvable");
         }
     case ResolveMethod::WEAK:
-        switch (value.value()) {
-        case Logic::_0:
-        case Logic::_1:
-            return value;
-        case Logic::L:
-            return Logic::_0;
-        case Logic::H:
-            return Logic::_1;
-        case Logic::W:
-            return Logic::X;
+        switch (value_) {
+        case _0:
+        case _1:
+            return *this;
+        case L:
+            return _0;
+        case H:
+            return _1;
+        case W:
+            return X;
         default:
-            return value;
+            return *this;
         }
     case ResolveMethod::ZEROS:
-        switch (value.value()) {
-        case Logic::_0:
-        case Logic::_1:
-            return value;
-        case Logic::L:
-            return Logic::_0;
-        case Logic::H:
-            return Logic::_1;
+        switch (value_) {
+        case _0:
+        case _1:
+            return *this;
+        case L:
+            return _0;
+        case H:
+            return _1;
         default:
-            return Logic::_0;
+            return _0;
         }
     case ResolveMethod::ONES:
-        switch (value.value()) {
-        case Logic::_0:
-        case Logic::_1:
-            return value;
-        case Logic::L:
-            return Logic::_0;
-        case Logic::H:
-            return Logic::_1;
+        switch (value_) {
+        case _0:
+        case _1:
+            return *this;
+        case L:
+            return _0;
+        case H:
+            return _1;
         default:
-            return Logic::_1;
+            return _1;
         }
     case ResolveMethod::RANDOM: {
-        switch (value.value()) {
-        case Logic::_0:
-        case Logic::_1:
-            return value;
-        case Logic::L:
-            return Logic::_0;
-        case Logic::H:
-            return Logic::_1;
+        switch (value_) {
+        case _0:
+        case _1:
+            return *this;
+        case L:
+            return _0;
+        case H:
+            return _1;
         default: {
             auto& rng = get_rng();
-            return (rng() % 2 == 0) ? Logic::_0 : Logic::_1;
+            return (rng() % 2 == 0) ? _0 : _1;
         }
         }
     }

--- a/nanobind/src/types/bind_logic.cpp
+++ b/nanobind/src/types/bind_logic.cpp
@@ -124,17 +124,14 @@ void register_logic(nb::module_& m) {
             "__xor__", [](Logic const& a, Bit const& b) { return a ^ b; }, nb::is_operator()
         )
         .def("__invert__", nb::overload_cast<Logic const&>(&operator~), nb::is_operator())
-        .def_prop_ro("is_resolvable", nb::overload_cast<Logic const&>(&is_resolvable))
+        .def_prop_ro("is_resolvable", &Logic::is_resolvable)
         .def(
             "resolve",
-            [](Logic const& value, std::string_view method) {
-                return resolve(value, string_to_resolve_method(method));
+            [](Logic const& self, std::string_view method) {
+                return self.resolve(string_to_resolve_method(method));
             }
         )
-        .def(
-            "resolve",
-            [](Logic const& self, ResolveMethod method) { return resolve(self, method); }
-        )
+        .def("resolve", &Logic::resolve)
         .def("__copy__", [](Logic const& self) { return Logic(self); })
         .def("__deepcopy__", [](Logic const& self, nb::dict /* memo */) {
             return Logic(self);
@@ -226,17 +223,14 @@ void register_logic(nb::module_& m) {
         .def(
             "__invert__", [](Bit const& self) { return ~self; }, nb::is_operator()
         )
-        .def_prop_ro("is_resolvable", [](Bit const&) { return true; })
+        .def_prop_ro("is_resolvable", &Bit::is_resolvable)
         .def(
             "resolve",
-            [](Bit const& value, std::string_view method) {
-                return resolve(value, string_to_resolve_method(method));
+            [](Bit const& self, std::string_view method) {
+                return self.resolve(string_to_resolve_method(method));
             }
         )
-        .def(
-            "resolve",
-            [](Bit const& self, ResolveMethod method) { return resolve(self, method); }
-        )
+        .def("resolve", &Bit::resolve)
         .def("__copy__", [](Bit const& self) { return Bit(self); })
         .def("__deepcopy__", [](Bit const& self, nb::dict /* memo */) {
             return Bit(self);

--- a/tests/cpp/test_logic.cpp
+++ b/tests/cpp/test_logic.cpp
@@ -95,24 +95,24 @@ TEST(TestBit, BitConversions) {
 // Test Logic bool conversions
 TEST(TestLogic, LogicBoolConversions) {
     // Convertible to true
-    EXPECT_EQ(is_resolvable('1'_l), true);
-    EXPECT_EQ(is_resolvable('H'_l), true);
+    EXPECT_EQ('1'_l.is_resolvable(), true);
+    EXPECT_EQ('H'_l.is_resolvable(), true);
 
     // Convertible to false
-    EXPECT_EQ(is_resolvable('0'_l), true);
-    EXPECT_EQ(is_resolvable('L'_l), true);
+    EXPECT_EQ('0'_l.is_resolvable(), true);
+    EXPECT_EQ('L'_l.is_resolvable(), true);
 
     // Non-convertible values
-    EXPECT_EQ(is_resolvable('X'_l), false);
-    EXPECT_EQ(is_resolvable('Z'_l), false);
-    EXPECT_EQ(is_resolvable('U'_l), false);
-    EXPECT_EQ(is_resolvable('W'_l), false);
-    EXPECT_EQ(is_resolvable('-'_l), false);
+    EXPECT_EQ('X'_l.is_resolvable(), false);
+    EXPECT_EQ('Z'_l.is_resolvable(), false);
+    EXPECT_EQ('U'_l.is_resolvable(), false);
+    EXPECT_EQ('W'_l.is_resolvable(), false);
+    EXPECT_EQ('-'_l.is_resolvable(), false);
 }
 
 TEST(TestBit, BitBoolConversions) {
-    EXPECT_EQ(is_resolvable('0'_b), true);
-    EXPECT_EQ(is_resolvable('1'_b), true);
+    EXPECT_EQ('0'_b.is_resolvable(), true);
+    EXPECT_EQ('1'_b.is_resolvable(), true);
 }
 
 // Test Logic string conversions
@@ -227,89 +227,100 @@ TEST(TestBit, BitInvert) {
 // Test Logic resolve with different methods
 TEST(TestLogic, LogicResolve) {
     // Test WEAK resolution
-    EXPECT_EQ(resolve('U'_l, ResolveMethod::WEAK), 'U'_l);
-    EXPECT_EQ(resolve('X'_l, ResolveMethod::WEAK), 'X'_l);
-    EXPECT_EQ(resolve('0'_l, ResolveMethod::WEAK), '0'_l);
-    EXPECT_EQ(resolve('1'_l, ResolveMethod::WEAK), '1'_l);
-    EXPECT_EQ(resolve('Z'_l, ResolveMethod::WEAK), 'Z'_l);
-    EXPECT_EQ(resolve('W'_l, ResolveMethod::WEAK), 'X'_l);
-    EXPECT_EQ(resolve('L'_l, ResolveMethod::WEAK), '0'_l);
-    EXPECT_EQ(resolve('H'_l, ResolveMethod::WEAK), '1'_l);
-    EXPECT_EQ(resolve('-'_l, ResolveMethod::WEAK), '-'_l);
+    EXPECT_EQ('U'_l.resolve(ResolveMethod::WEAK), 'U'_l);
+    EXPECT_EQ('X'_l.resolve(ResolveMethod::WEAK), 'X'_l);
+    EXPECT_EQ('0'_l.resolve(ResolveMethod::WEAK), '0'_l);
+    EXPECT_EQ('1'_l.resolve(ResolveMethod::WEAK), '1'_l);
+    EXPECT_EQ('Z'_l.resolve(ResolveMethod::WEAK), 'Z'_l);
+    EXPECT_EQ('W'_l.resolve(ResolveMethod::WEAK), 'X'_l);
+    EXPECT_EQ('L'_l.resolve(ResolveMethod::WEAK), '0'_l);
+    EXPECT_EQ('H'_l.resolve(ResolveMethod::WEAK), '1'_l);
+    EXPECT_EQ('-'_l.resolve(ResolveMethod::WEAK), '-'_l);
 
     // Test ZEROS resolution
-    EXPECT_EQ(resolve('U'_l, ResolveMethod::ZEROS), '0'_l);
-    EXPECT_EQ(resolve('X'_l, ResolveMethod::ZEROS), '0'_l);
-    EXPECT_EQ(resolve('0'_l, ResolveMethod::ZEROS), '0'_l);
-    EXPECT_EQ(resolve('1'_l, ResolveMethod::ZEROS), '1'_l);
-    EXPECT_EQ(resolve('Z'_l, ResolveMethod::ZEROS), '0'_l);
-    EXPECT_EQ(resolve('W'_l, ResolveMethod::ZEROS), '0'_l);
-    EXPECT_EQ(resolve('L'_l, ResolveMethod::ZEROS), '0'_l);
-    EXPECT_EQ(resolve('H'_l, ResolveMethod::ZEROS), '1'_l);
-    EXPECT_EQ(resolve('-'_l, ResolveMethod::ZEROS), '0'_l);
+    EXPECT_EQ('U'_l.resolve(ResolveMethod::ZEROS), '0'_l);
+    EXPECT_EQ('X'_l.resolve(ResolveMethod::ZEROS), '0'_l);
+    EXPECT_EQ('0'_l.resolve(ResolveMethod::ZEROS), '0'_l);
+    EXPECT_EQ('1'_l.resolve(ResolveMethod::ZEROS), '1'_l);
+    EXPECT_EQ('Z'_l.resolve(ResolveMethod::ZEROS), '0'_l);
+    EXPECT_EQ('W'_l.resolve(ResolveMethod::ZEROS), '0'_l);
+    EXPECT_EQ('L'_l.resolve(ResolveMethod::ZEROS), '0'_l);
+    EXPECT_EQ('H'_l.resolve(ResolveMethod::ZEROS), '1'_l);
+    EXPECT_EQ('-'_l.resolve(ResolveMethod::ZEROS), '0'_l);
 
     // Test ONES resolution
-    EXPECT_EQ(resolve('U'_l, ResolveMethod::ONES), '1'_l);
-    EXPECT_EQ(resolve('X'_l, ResolveMethod::ONES), '1'_l);
-    EXPECT_EQ(resolve('0'_l, ResolveMethod::ONES), '0'_l);
-    EXPECT_EQ(resolve('1'_l, ResolveMethod::ONES), '1'_l);
-    EXPECT_EQ(resolve('Z'_l, ResolveMethod::ONES), '1'_l);
-    EXPECT_EQ(resolve('W'_l, ResolveMethod::ONES), '1'_l);
-    EXPECT_EQ(resolve('L'_l, ResolveMethod::ONES), '0'_l);
-    EXPECT_EQ(resolve('H'_l, ResolveMethod::ONES), '1'_l);
-    EXPECT_EQ(resolve('-'_l, ResolveMethod::ONES), '1'_l);
+    EXPECT_EQ('U'_l.resolve(ResolveMethod::ONES), '1'_l);
+    EXPECT_EQ('X'_l.resolve(ResolveMethod::ONES), '1'_l);
+    EXPECT_EQ('0'_l.resolve(ResolveMethod::ONES), '0'_l);
+    EXPECT_EQ('1'_l.resolve(ResolveMethod::ONES), '1'_l);
+    EXPECT_EQ('Z'_l.resolve(ResolveMethod::ONES), '1'_l);
+    EXPECT_EQ('W'_l.resolve(ResolveMethod::ONES), '1'_l);
+    EXPECT_EQ('L'_l.resolve(ResolveMethod::ONES), '0'_l);
+    EXPECT_EQ('H'_l.resolve(ResolveMethod::ONES), '1'_l);
+    EXPECT_EQ('-'_l.resolve(ResolveMethod::ONES), '1'_l);
 
     // Test RANDOM resolution
-    auto resolved_u = resolve('U'_l, ResolveMethod::RANDOM);
+    auto resolved_u = 'U'_l.resolve(ResolveMethod::RANDOM);
     EXPECT_TRUE(resolved_u == '0'_l || resolved_u == '1'_l);
 
-    auto resolved_x = resolve('X'_l, ResolveMethod::RANDOM);
+    auto resolved_x = 'X'_l.resolve(ResolveMethod::RANDOM);
     EXPECT_TRUE(resolved_x == '0'_l || resolved_x == '1'_l);
 
-    EXPECT_EQ(resolve('0'_l, ResolveMethod::RANDOM), '0'_l);
-    EXPECT_EQ(resolve('1'_l, ResolveMethod::RANDOM), '1'_l);
+    EXPECT_EQ('0'_l.resolve(ResolveMethod::RANDOM), '0'_l);
+    EXPECT_EQ('1'_l.resolve(ResolveMethod::RANDOM), '1'_l);
 
-    auto resolved_z = resolve('Z'_l, ResolveMethod::RANDOM);
+    auto resolved_z = 'Z'_l.resolve(ResolveMethod::RANDOM);
     EXPECT_TRUE(resolved_z == '0'_l || resolved_z == '1'_l);
 
-    auto resolved_w = resolve('W'_l, ResolveMethod::RANDOM);
+    auto resolved_w = 'W'_l.resolve(ResolveMethod::RANDOM);
     EXPECT_TRUE(resolved_w == '0'_l || resolved_w == '1'_l);
 
-    EXPECT_EQ(resolve('L'_l, ResolveMethod::RANDOM), '0'_l);
-    EXPECT_EQ(resolve('H'_l, ResolveMethod::RANDOM), '1'_l);
+    EXPECT_EQ('L'_l.resolve(ResolveMethod::RANDOM), '0'_l);
+    EXPECT_EQ('H'_l.resolve(ResolveMethod::RANDOM), '1'_l);
 
-    auto resolved_dc = resolve('-'_l, ResolveMethod::RANDOM);
+    auto resolved_dc = '-'_l.resolve(ResolveMethod::RANDOM);
     EXPECT_TRUE(resolved_dc == '0'_l || resolved_dc == '1'_l);
 
     // Test ERROR resolution
-    EXPECT_EQ(resolve('0'_l, ResolveMethod::ERROR), '0'_l);
-    EXPECT_EQ(resolve('1'_l, ResolveMethod::ERROR), '1'_l);
-    EXPECT_THROW((void)resolve('U'_l, ResolveMethod::ERROR), std::invalid_argument);
-    EXPECT_THROW((void)resolve('X'_l, ResolveMethod::ERROR), std::invalid_argument);
-    EXPECT_THROW((void)resolve('Z'_l, ResolveMethod::ERROR), std::invalid_argument);
-    EXPECT_THROW((void)resolve('W'_l, ResolveMethod::ERROR), std::invalid_argument);
-    EXPECT_THROW((void)resolve('L'_l, ResolveMethod::ERROR), std::invalid_argument);
-    EXPECT_THROW((void)resolve('H'_l, ResolveMethod::ERROR), std::invalid_argument);
-    EXPECT_THROW((void)resolve('-'_l, ResolveMethod::ERROR), std::invalid_argument);
+    EXPECT_EQ('0'_l.resolve(ResolveMethod::ERROR), '0'_l);
+    EXPECT_EQ('1'_l.resolve(ResolveMethod::ERROR), '1'_l);
+    EXPECT_THROW((void)'U'_l.resolve(ResolveMethod::ERROR), std::invalid_argument);
+    EXPECT_THROW((void)'X'_l.resolve(ResolveMethod::ERROR), std::invalid_argument);
+    EXPECT_THROW((void)'Z'_l.resolve(ResolveMethod::ERROR), std::invalid_argument);
+    EXPECT_THROW((void)'W'_l.resolve(ResolveMethod::ERROR), std::invalid_argument);
+    EXPECT_THROW((void)'L'_l.resolve(ResolveMethod::ERROR), std::invalid_argument);
+    EXPECT_THROW((void)'H'_l.resolve(ResolveMethod::ERROR), std::invalid_argument);
+    EXPECT_THROW((void)'-'_l.resolve(ResolveMethod::ERROR), std::invalid_argument);
 
     // Out-of-range ResolveMethod hits the outer `default:` arm.
     EXPECT_THROW(
-        (void)resolve('0'_l, static_cast<ResolveMethod>(99)), std::invalid_argument
+        (void)'0'_l.resolve(static_cast<ResolveMethod>(99)), std::invalid_argument
     );
 }
 
 TEST(TestBit, BitResolve) {
-    EXPECT_EQ(resolve('0'_b, ResolveMethod::WEAK), '0'_b);
-    EXPECT_EQ(resolve('1'_b, ResolveMethod::WEAK), '1'_b);
+    // Every Bit value is resolvable, so resolve() is a no-op regardless of
+    // method -- including ERROR (which throws on Logic for non-binary values)
+    // and out-of-range method values.
+    EXPECT_EQ('0'_b.resolve(ResolveMethod::ERROR), '0'_b);
+    EXPECT_EQ('1'_b.resolve(ResolveMethod::ERROR), '1'_b);
 
-    EXPECT_EQ(resolve('0'_b, ResolveMethod::ZEROS), '0'_b);
-    EXPECT_EQ(resolve('1'_b, ResolveMethod::ZEROS), '1'_b);
+    EXPECT_EQ('0'_b.resolve(ResolveMethod::WEAK), '0'_b);
+    EXPECT_EQ('1'_b.resolve(ResolveMethod::WEAK), '1'_b);
 
-    EXPECT_EQ(resolve('0'_b, ResolveMethod::ONES), '0'_b);
-    EXPECT_EQ(resolve('1'_b, ResolveMethod::ONES), '1'_b);
+    EXPECT_EQ('0'_b.resolve(ResolveMethod::ZEROS), '0'_b);
+    EXPECT_EQ('1'_b.resolve(ResolveMethod::ZEROS), '1'_b);
 
-    EXPECT_EQ(resolve('0'_b, ResolveMethod::RANDOM), '0'_b);
-    EXPECT_EQ(resolve('1'_b, ResolveMethod::RANDOM), '1'_b);
+    EXPECT_EQ('0'_b.resolve(ResolveMethod::ONES), '0'_b);
+    EXPECT_EQ('1'_b.resolve(ResolveMethod::ONES), '1'_b);
+
+    EXPECT_EQ('0'_b.resolve(ResolveMethod::RANDOM), '0'_b);
+    EXPECT_EQ('1'_b.resolve(ResolveMethod::RANDOM), '1'_b);
+
+    // Out-of-range method values are silently accepted (Bit::resolve is
+    // noexcept and ignores its argument).
+    EXPECT_EQ('0'_b.resolve(static_cast<ResolveMethod>(99)), '0'_b);
+    EXPECT_EQ('1'_b.resolve(static_cast<ResolveMethod>(99)), '1'_b);
 }
 
 // Stores values in std::vector to force runtime evaluation of conversions.
@@ -326,27 +337,27 @@ TEST(TestLogic, RuntimeIntAndBitConversions) {
     std::vector<Bit> const bits{'0'_b, '1'_b};
     EXPECT_EQ(to_logic(bits[0]), '0'_l);
     EXPECT_EQ(to_logic(bits[1]), '1'_l);
-    EXPECT_EQ(resolve(bits[0], ResolveMethod::WEAK), '0'_b);
-    EXPECT_EQ(resolve(bits[1], ResolveMethod::ZEROS), '1'_b);
+    EXPECT_EQ(bits[0].resolve(ResolveMethod::WEAK), '0'_b);
+    EXPECT_EQ(bits[1].resolve(ResolveMethod::ZEROS), '1'_b);
 }
 
 // Test Logic is_resolvable
 TEST(TestLogic, LogicIsResolvable) {
-    EXPECT_TRUE(is_resolvable(Logic::_0));
-    EXPECT_TRUE(is_resolvable(Logic::_1));
-    EXPECT_TRUE(is_resolvable('L'_l));
-    EXPECT_TRUE(is_resolvable('H'_l));
+    EXPECT_TRUE('0'_l.is_resolvable());
+    EXPECT_TRUE('1'_l.is_resolvable());
+    EXPECT_TRUE('L'_l.is_resolvable());
+    EXPECT_TRUE('H'_l.is_resolvable());
 
-    EXPECT_FALSE(is_resolvable('U'_l));
-    EXPECT_FALSE(is_resolvable('X'_l));
-    EXPECT_FALSE(is_resolvable('Z'_l));
-    EXPECT_FALSE(is_resolvable('W'_l));
-    EXPECT_FALSE(is_resolvable('-'_l));
+    EXPECT_FALSE('U'_l.is_resolvable());
+    EXPECT_FALSE('X'_l.is_resolvable());
+    EXPECT_FALSE('Z'_l.is_resolvable());
+    EXPECT_FALSE('W'_l.is_resolvable());
+    EXPECT_FALSE('-'_l.is_resolvable());
 }
 
 TEST(TestBit, BitIsResolvable) {
-    EXPECT_TRUE(is_resolvable('0'_b));
-    EXPECT_TRUE(is_resolvable('1'_b));
+    EXPECT_TRUE('0'_b.is_resolvable());
+    EXPECT_TRUE('1'_b.is_resolvable());
 }
 
 TEST(TestLogic, LogicIsHashable) {

--- a/tests/cpp/test_range.cpp
+++ b/tests/cpp/test_range.cpp
@@ -155,14 +155,16 @@ TEST(TestRange, RangeIsHashable) {
     EXPECT_EQ(different.size(), 2U);
 }
 
-// -- is_subsequence ---------------------------------------------------------
+// -- is_subsequence_of ------------------------------------------------------
 
 TEST(TestRange, IsSubsequenceLengthZero) {
     // A length-0 child is a subsequence of any parent, regardless of bounds
     // or direction.
-    EXPECT_TRUE(is_subsequence(Range{0, Direction::TO, 4}, Range{99, Direction::TO, 50}));
     EXPECT_TRUE(
-        is_subsequence(Range{0, Direction::TO, 4}, Range{50, Direction::DOWNTO, 99})
+        (Range{99, Direction::TO, 50}).is_subsequence_of(Range{0, Direction::TO, 4})
+    );
+    EXPECT_TRUE(
+        (Range{50, Direction::DOWNTO, 99}).is_subsequence_of(Range{0, Direction::TO, 4})
     );
 }
 
@@ -170,35 +172,35 @@ TEST(TestRange, IsSubsequenceLengthOneDirectionAgnostic) {
     // A length-1 child is valid iff its single value is in the parent;
     // direction is irrelevant for one element.
     Range parent{0, Direction::TO, 4};
-    EXPECT_TRUE(is_subsequence(parent, Range{2, Direction::TO, 2}));
-    EXPECT_TRUE(is_subsequence(parent, Range{2, Direction::DOWNTO, 2}));
-    EXPECT_FALSE(is_subsequence(parent, Range{99, Direction::TO, 99}));
+    EXPECT_TRUE((Range{2, Direction::TO, 2}).is_subsequence_of(parent));
+    EXPECT_TRUE((Range{2, Direction::DOWNTO, 2}).is_subsequence_of(parent));
+    EXPECT_FALSE((Range{99, Direction::TO, 99}).is_subsequence_of(parent));
 }
 
 TEST(TestRange, IsSubsequenceLengthTwoPlus) {
     Range parent{0, Direction::TO, 4};
-    EXPECT_TRUE(is_subsequence(parent, Range{1, Direction::TO, 3}));
-    EXPECT_FALSE(is_subsequence(parent, Range{1, Direction::DOWNTO, 0}));  // dir
-    EXPECT_FALSE(is_subsequence(parent, Range{99, Direction::TO, 100}));   // left
-    EXPECT_FALSE(is_subsequence(parent, Range{0, Direction::TO, 99}));     // right
+    EXPECT_TRUE((Range{1, Direction::TO, 3}).is_subsequence_of(parent));
+    EXPECT_FALSE((Range{1, Direction::DOWNTO, 0}).is_subsequence_of(parent));  // dir
+    EXPECT_FALSE((Range{99, Direction::TO, 100}).is_subsequence_of(parent));   // left
+    EXPECT_FALSE((Range{0, Direction::TO, 99}).is_subsequence_of(parent));     // right
 }
 
 TEST(TestRange, IsSubsequenceDOWNTOParent) {
     // Exercise the DOWNTO branch of the in_parent helper, mirrored from the
     // TO test above.
     Range parent{4, Direction::DOWNTO, 0};
-    EXPECT_TRUE(is_subsequence(parent, Range{3, Direction::DOWNTO, 1}));
-    EXPECT_FALSE(is_subsequence(parent, Range{1, Direction::TO, 3}));  // dir
-    EXPECT_FALSE(is_subsequence(parent, Range{99, Direction::DOWNTO, 1}));
-    EXPECT_FALSE(is_subsequence(parent, Range{3, Direction::DOWNTO, -99}));
+    EXPECT_TRUE((Range{3, Direction::DOWNTO, 1}).is_subsequence_of(parent));
+    EXPECT_FALSE((Range{1, Direction::TO, 3}).is_subsequence_of(parent));  // dir
+    EXPECT_FALSE((Range{99, Direction::DOWNTO, 1}).is_subsequence_of(parent));
+    EXPECT_FALSE((Range{3, Direction::DOWNTO, -99}).is_subsequence_of(parent));
 }
 
 TEST(TestRange, IsSubsequenceConstexpr) {
     // Usable in constant evaluation; downstream slice<R>() forms rely on this
     // for their static_assert.
-    static_assert(is_subsequence(Range{0, Direction::TO, 4}, Range{1, Direction::TO, 3}));
+    static_assert(Range{1, Direction::TO, 3}.is_subsequence_of(Range{0, Direction::TO, 4}));
     static_assert(
-        !is_subsequence(Range{0, Direction::TO, 4}, Range{1, Direction::DOWNTO, 0})
+        !Range{1, Direction::DOWNTO, 0}.is_subsequence_of(Range{0, Direction::TO, 4})
     );
 }
 // LCOV_EXCL_BR_STOP


### PR DESCRIPTION
For things that don't need to be free since they are coconext-specific, we are moving them to members. This PR memberizes `is_resolvable` and `resolve` on `Logic` and `Bit`. I will also do that to `LogicArray` and `BitArray`. It also memberizes `is_subsequence_of` check for Ranges.

`find`, `hash`, and `formatter` are all free so they play with stdlib functionality. But eventually a `index` and `rindex` function will be added to Range, Array, LogicArray, BitArray, etc.