### PR TITLE
Change`Range`

### DIFF
--- a/cpp/include/coconext/types/range.hpp
+++ b/cpp/include/coconext/types/range.hpp
@@ -78,32 +78,6 @@ struct Range {
         return left - index;
     }
 
-    constexpr Range operator()(size_t start, size_t stop) const {
-        if (stop > length()) {
-            throw std::out_of_range("Stop index out of range");
-        }
-        if (start > stop) {
-            throw std::invalid_argument(
-                "Start index must be less than or equal to stop index"
-            );
-        }
-        auto const from_start = static_cast<int64_t>(start);
-        auto const from_last = static_cast<int64_t>(stop) - 1;
-        auto const new_left = static_cast<value_type>(
-            direction == Direction::TO ? left + from_start : left - from_start
-        );
-        auto const new_right = static_cast<value_type>(
-            direction == Direction::TO ? left + from_last : left - from_last
-        );
-        return Range(new_left, direction, new_right);
-    }
-
-#if __cplusplus >= 202302L
-    constexpr Range operator[](size_t start, size_t stop) const {
-        return this->operator()(start, stop);
-    }
-#endif
-
     // This range is a valid subsequence of `parent` iff every value in this
     // range appears (in order) in parent. The rule collapses to:
     //   - length 0:   always a subsequence (any direction, any bounds)

--- a/cpp/include/coconext/types/range.hpp
+++ b/cpp/include/coconext/types/range.hpp
@@ -15,27 +15,27 @@
 namespace coconext::types {
 
 struct Range {
-    using value_type = int32_t;
+    using value_type = int64_t;
     using iterator = CountIterator<value_type>;
 
     constexpr Range() noexcept = default;
 
     constexpr Range(value_type l, Direction d, value_type r) noexcept
-        : left(l), direction(d), right(r) {}
+        : left(l), right(r), direction(d) {}
 
     constexpr Range(value_type l, value_type r) noexcept
-        : left(l), direction(l > r ? Direction::DOWNTO : Direction::TO), right(r) {}
+        : left(l), right(r), direction(l > r ? Direction::DOWNTO : Direction::TO) {}
 
     explicit constexpr Range(size_t length)
-        : left(0), direction(Direction::TO), right(static_cast<value_type>(length) - 1) {
+        : left(0), right(static_cast<value_type>(length) - 1), direction(Direction::TO) {
         if (length > static_cast<size_t>(std::numeric_limits<value_type>::max())) {
             throw std::length_error("Range length overflows value_type");
         }
     }
 
     value_type left = 0;
-    Direction direction = Direction::TO;
     value_type right = -1;
+    Direction direction = Direction::TO;
 
     constexpr size_t length() const noexcept {
         int64_t len = direction == Direction::TO ? static_cast<int64_t>(right) - left + 1

--- a/nanobind/src/types/bind_range.cpp
+++ b/nanobind/src/types/bind_range.cpp
@@ -14,6 +14,15 @@ using namespace nb::literals;
 
 using namespace coconext::types;
 
+Range slice_range(Range const& r, size_t start, size_t stop) {
+    if (stop > r.length()) {
+        throw std::out_of_range("Stop index out of range");
+    }
+    auto new_left = r[start];
+    auto new_right = r[stop - 1];
+    return Range(new_left, r.direction, new_right);
+}
+
 void register_range(nb::module_& m) {
     nb::object range_func = nb::module_::import_("builtins").attr("range");
 
@@ -112,7 +121,7 @@ void register_range(nb::module_& m) {
                 if (step != 1) {
                     throw std::invalid_argument("Slicing with step is not supported");
                 }
-                return self(start, stop);
+                return slice_range(self, start, stop);
             },
             nb::arg().noconvert()
         )
@@ -148,7 +157,7 @@ void register_range(nb::module_& m) {
                     throw nb::value_error("Value not found in range");
                 }
 
-                auto sliced = self(start, len);
+                auto sliced = slice_range(self, start, len);
 
                 auto it = find(sliced, value);
 
@@ -175,7 +184,7 @@ void register_range(nb::module_& m) {
                     throw nb::value_error("Value not found in range");
                 }
 
-                auto sliced = self(start, stop);
+                auto sliced = slice_range(self, start, stop);
 
                 auto it = find(sliced, value);
 

--- a/tests/cpp/test_range.cpp
+++ b/tests/cpp/test_range.cpp
@@ -26,7 +26,6 @@ TEST(TestRange, ToRange) {
     EXPECT_EQ(r[7], 8);
     EXPECT_THROW((void)r[8], std::out_of_range);
 
-    EXPECT_EQ(r(3, 7), Range(4, Direction::TO, 7));
     EXPECT_NE(find(r, 8), r.end());
     EXPECT_EQ(find(r, 10), r.end());
 }
@@ -48,7 +47,6 @@ TEST(TestRange, DowntoRange) {
     EXPECT_EQ(r[7], -3);
     EXPECT_THROW((void)r[8], std::out_of_range);
 
-    EXPECT_EQ(r(3, 7), Range(1, Direction::DOWNTO, -2));
     EXPECT_NE(find(r, 0), r.end());
     EXPECT_EQ(find(r, 10), r.end());
 }
@@ -117,16 +115,6 @@ TEST(TestDirection, Formatter) {
 TEST(TestRange, UppercaseDirection) {
     Range const r(1, to_direction("TO"), 8);
     EXPECT_EQ(r.direction, Direction::TO);
-}
-
-TEST(TestRange, BadGetitemEquivalent) {
-    Range const r(10, Direction::DOWNTO, 4);
-    EXPECT_THROW((void)r(8, 4), std::invalid_argument);
-}
-
-TEST(TestRange, SliceStopOutOfRange) {
-    Range const r(1, Direction::TO, 5);
-    EXPECT_THROW((void)r(0, 100), std::out_of_range);
 }
 
 TEST(TestRange, Copy) {


### PR DESCRIPTION
Use 64-bit indexes in range since that's what the simulator is giving us, and remove slicing since the STL can handle operating on Range as a 0-indexed random access range object. Slicing can be handled with `std::span`.