### PR TITLE
replace COCOTB_USER_COVERAGE dependence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,19 +30,18 @@ CPP_TESTS_BUILD_DIR ?= build/tests
 
 .PHONY: dev_tests
 dev_tests: dev_build
-	COCOTB_USER_COVERAGE=1 pytest --cov=coconext --cov-branch --cov-report= tests/python/
+	pytest --cov --cov-report= tests/python/
 	cmake -S tests/cpp -B "$(CPP_TESTS_BUILD_DIR)" \
 	    -DCMAKE_PREFIX_PATH="$$(coconext-config --cmake-prefix)" \
 	    -DCMAKE_CXX_STANDARD=$(CXX_STANDARD) \
 	    -DCMAKE_EXE_LINKER_FLAGS=--coverage
 	cmake --build "$(CPP_TESTS_BUILD_DIR)"
 	ctest --output-on-failure --test-dir "$(CPP_TESTS_BUILD_DIR)"
-	find . -name ".coverage*" | xargs coverage combine
 
 .PHONY: integration_tests
 integration_tests: dev_build
 	COCOTB_DIR_PATH="$(COCOTB_DIR_PATH)" \
-	pytest --cov=coconext --cov-branch --cov-append --cov-report= tests/integration_tests/
+	pytest --cov --cov-append --cov-report= tests/integration_tests/
 
 .PHONY: generate_report
 generate_report:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ dev_tests = [
     "cmake>=3.20",
     "scikit-build-core",
     "setuptools",
-    "coverage[toml]>=7.2",  # Require 7.2+ for builtin coverage excludes and "exclude_also"
+    "coverage[toml]>=7.10",  # Require 7.2+ for builtin coverage excludes and "exclude_also"
     "pytest-cov",
     "pytest",
     "gcovr>=8.4,!=8.5",  # 8.4 introduced block exclusions, 8.5 was broken
@@ -119,6 +119,11 @@ exclude_also = [
     "@(abc\\.)?abstractmethod",
     "@(typing\\.)?overload",
 ]
+
+[tool.coverage.run]
+patch = ["subprocess"]
+branch = true
+source = ["coconext"]
 
 [tool.scikit-build]
 build-dir = "build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ exclude_also = [
 [tool.coverage.run]
 patch = ["subprocess"]
 branch = true
-source = ["coconext"]
+source = ["coconext", "tests"]
 
 [tool.scikit-build]
 build-dir = "build"

--- a/uv.lock
+++ b/uv.lock
@@ -280,7 +280,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "cmake", specifier = ">=3.20" },
-    { name = "coverage", extras = ["toml"], specifier = ">=7.2" },
+    { name = "coverage", extras = ["toml"], specifier = ">=7.10" },
     { name = "gcovr", specifier = ">=8.4,!=8.5" },
     { name = "mypy" },
     { name = "nanobind" },
@@ -293,7 +293,7 @@ dev = [
 ]
 dev-tests = [
     { name = "cmake", specifier = ">=3.20" },
-    { name = "coverage", extras = ["toml"], specifier = ">=7.2" },
+    { name = "coverage", extras = ["toml"], specifier = ">=7.10" },
     { name = "gcovr", specifier = ">=8.4,!=8.5" },
     { name = "nanobind" },
     { name = "pytest" },
@@ -597,7 +597,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [


### PR DESCRIPTION
Fixes #236 
replaced `COCOTB_USER_COVERAGE` with subprocess support. Doing so also eliminated the need to combine coverage because it now only produces one file for dev_tests