### PR TITLE
Add index/rindex members on Array/DynArray and slices

### DIFF
--- a/cpp/include/coconext/types/array.hpp
+++ b/cpp/include/coconext/types/array.hpp
@@ -12,6 +12,7 @@
 #include <initializer_list>
 #include <iterator>
 #include <limits>
+#include <optional>
 #include <ranges>
 #include <stdexcept>
 #include <string>
@@ -144,6 +145,13 @@ class ArrayImpl {
     constexpr auto rbegin() const noexcept { return data_.rbegin(); }
     constexpr auto rend() noexcept { return data_.rend(); }
     constexpr auto rend() const noexcept { return data_.rend(); }
+
+    constexpr std::optional<index_type> index(value_type const& v) const {
+        return detail::index_in(*this, v);
+    }
+    constexpr std::optional<index_type> rindex(value_type const& v) const {
+        return detail::rindex_in(*this, v);
+    }
 
   private:
     template <typename Self>

--- a/cpp/include/coconext/types/array_base.hpp
+++ b/cpp/include/coconext/types/array_base.hpp
@@ -9,6 +9,7 @@
 #include <format>
 #include <initializer_list>
 #include <iterator>
+#include <optional>
 #include <ranges>
 #include <stdexcept>
 #include <string>
@@ -68,6 +69,44 @@ constexpr void subsequence_check(Range parent, Range child) {
     if (!child.is_subsequence_of(parent)) {
         throw std::invalid_argument("Range is not a valid sub-range of the parent");
     }
+}
+
+// Convert a 0-based offset into the data buffer (iteration order) to the
+// corresponding HDL coordinate for the given range's direction.
+constexpr Range::value_type offset_to_hdl_coord(
+    Range r, size_t offset_from_begin
+) noexcept {
+    auto const off = static_cast<Range::value_type>(offset_from_begin);
+    return r.direction == Direction::TO ? r.left + off : r.left - off;
+}
+
+// First HDL coordinate (from the left in iteration order) whose element equals
+// `v`, or nullopt if not found. Used by Array/DynArray/slice members.
+template <RangedSequence S>
+constexpr std::optional<Range::value_type> index_in(
+    S const& s, std::ranges::range_value_t<S> const& v
+) {
+    auto const it = std::ranges::find(s, v);
+    if (it == s.end()) {
+        return std::nullopt;
+    }
+    return offset_to_hdl_coord(
+        s.range(), static_cast<size_t>(std::ranges::distance(s.begin(), it))
+    );
+}
+
+// First HDL coordinate from the right (i.e. the last matching element in
+// iteration order), or nullopt if not found.
+template <RangedSequence S>
+constexpr std::optional<Range::value_type> rindex_in(
+    S const& s, std::ranges::range_value_t<S> const& v
+) {
+    auto const rit = std::find(s.rbegin(), s.rend(), v);
+    if (rit == s.rend()) {
+        return std::nullopt;
+    }
+    auto const off_from_end = static_cast<size_t>(std::distance(s.rbegin(), rit));
+    return offset_to_hdl_coord(s.range(), s.range().length() - 1 - off_from_end);
 }
 
 }  // namespace detail
@@ -191,6 +230,15 @@ class DynArraySliceImpl {
     constexpr iterator end() const noexcept { return begin_ + range_.length(); }
     constexpr auto rbegin() const noexcept { return std::reverse_iterator(end()); }
     constexpr auto rend() const noexcept { return std::reverse_iterator(begin()); }
+
+    // First HDL coordinate (from the left/right respectively) whose element
+    // equals `v`, or nullopt if not found.
+    constexpr std::optional<index_type> index(value_type const& v) const {
+        return detail::index_in(*this, v);
+    }
+    constexpr std::optional<index_type> rindex(value_type const& v) const {
+        return detail::rindex_in(*this, v);
+    }
 
   private:
     // Cache the begin pointer. This is just one stack pointer for a temporary object, and
@@ -347,6 +395,13 @@ class ArraySliceImpl {
     constexpr iterator end() const noexcept { return begin() + R.length(); }
     constexpr auto rbegin() const noexcept { return std::reverse_iterator(end()); }
     constexpr auto rend() const noexcept { return std::reverse_iterator(begin()); }
+
+    constexpr std::optional<index_type> index(value_type const& v) const {
+        return detail::index_in(*this, v);
+    }
+    constexpr std::optional<index_type> rindex(value_type const& v) const {
+        return detail::rindex_in(*this, v);
+    }
 
   private:
     ArrayT* arr_;

--- a/cpp/include/coconext/types/dyn_array.hpp
+++ b/cpp/include/coconext/types/dyn_array.hpp
@@ -11,6 +11,7 @@
 #include <initializer_list>
 #include <iterator>
 #include <memory>
+#include <optional>
 #include <ranges>
 #include <stdexcept>
 #include <string>
@@ -202,6 +203,17 @@ class DynArrayImpl {
     }
     COCONEXT_DYN_ARRAY_CONSTEXPR auto rend() const noexcept {
         return std::reverse_iterator(begin());
+    }
+
+    COCONEXT_DYN_ARRAY_CONSTEXPR std::optional<index_type> index(
+        value_type const& v
+    ) const {
+        return detail::index_in(*this, v);
+    }
+    COCONEXT_DYN_ARRAY_CONSTEXPR std::optional<index_type> rindex(
+        value_type const& v
+    ) const {
+        return detail::rindex_in(*this, v);
     }
 
   private:

--- a/tests/cpp/test_array.cpp
+++ b/tests/cpp/test_array.cpp
@@ -106,6 +106,85 @@ TEST(TestDynArray, FindElementMissing) {
     EXPECT_EQ(std::find(a.begin(), a.end(), 99), a.end());
 }
 
+// -- index / rindex ---------------------------------------------------------
+//
+// index(v) returns the first HDL coordinate (from the left in iteration
+// order) whose element equals v; rindex(v) is the same from the right (i.e.
+// the last matching element). Both return nullopt when not found.
+
+TEST(TestDynArray, IndexFoundTO) {
+    DynArray<int> a(std::vector<int>{10, 20, 30, 20}, Range(0, Direction::TO, 3));
+    auto i = a.index(20);
+    ASSERT_TRUE(i.has_value());
+    EXPECT_EQ(*i, 1);  // first 20 is at HDL coord 1
+}
+
+TEST(TestDynArray, IndexFoundDOWNTO) {
+    DynArray<int> a({10, 20, 30});  // default DOWNTO {2..0}: a[2]=10, a[1]=20, a[0]=30
+    auto i = a.index(20);
+    ASSERT_TRUE(i.has_value());
+    EXPECT_EQ(*i, 1);  // 20 is at HDL coord 1 (DOWNTO)
+}
+
+TEST(TestDynArray, IndexNotFound) {
+    DynArray<int> a({10, 20, 30});
+    EXPECT_FALSE(a.index(99).has_value());
+}
+
+TEST(TestDynArray, IndexEmpty) {
+    DynArray<int> a({});
+    EXPECT_FALSE(a.index(0).has_value());
+}
+
+TEST(TestDynArray, RindexFindsLastOccurrenceTO) {
+    DynArray<int> a(std::vector<int>{10, 20, 30, 20}, Range(0, Direction::TO, 3));
+    auto i = a.rindex(20);
+    ASSERT_TRUE(i.has_value());
+    EXPECT_EQ(*i, 3);  // last 20 is at HDL coord 3
+}
+
+TEST(TestDynArray, RindexFindsLastOccurrenceDOWNTO) {
+    DynArray<int> a(std::vector<int>{10, 20, 30, 20}, Range(3, Direction::DOWNTO, 0));
+    // a[3]=10, a[2]=20, a[1]=30, a[0]=20. Last 20 in iteration is at HDL 0.
+    auto i = a.rindex(20);
+    ASSERT_TRUE(i.has_value());
+    EXPECT_EQ(*i, 0);
+}
+
+TEST(TestDynArray, RindexNotFound) {
+    DynArray<int> a({10, 20, 30});
+    EXPECT_FALSE(a.rindex(99).has_value());
+}
+
+TEST(TestDynArray, IndexOnSlice) {
+    // Generic DynArray<int> defaults to TO {0..4}.
+    DynArray<int> a({10, 20, 30, 40, 50});
+    auto s = a[{1, 3}];  // TO slice covering HDL coords 1, 2, 3 -> 20, 30, 40
+    auto i = s.index(30);
+    ASSERT_TRUE(i.has_value());
+    EXPECT_EQ(*i, 2);
+}
+
+TEST(TestStaticArray, IndexAndRindex) {
+    Array<int, Range{0, Direction::TO, 4}> a({10, 20, 30, 20, 50});
+    auto first = a.index(20);
+    auto last = a.rindex(20);
+    ASSERT_TRUE(first.has_value() && last.has_value());
+    EXPECT_EQ(*first, 1);
+    EXPECT_EQ(*last, 3);
+    EXPECT_FALSE(a.index(99).has_value());
+}
+
+TEST(TestDynArrayStaticSlice, IndexAndRindex) {
+    DynArray<int> a({10, 20, 30, 20, 50}, Range(0, Direction::TO, 4));
+    auto s = a.slice<Range{1, Direction::TO, 3}>();  // values 20, 30, 20
+    auto first = s.index(20);
+    auto last = s.rindex(20);
+    ASSERT_TRUE(first.has_value() && last.has_value());
+    EXPECT_EQ(*first, 1);
+    EXPECT_EQ(*last, 3);
+}
+
 // -- Indexing ---------------------------------------------------------------
 
 TEST(TestDynArray, IndexingTO) {

--- a/tests/cpp/test_logic_array.cpp
+++ b/tests/cpp/test_logic_array.cpp
@@ -437,6 +437,24 @@ TEST(TestLogicArray, SubSlicePreservesMixin) {
     EXPECT_FALSE(sub.is_resolvable());
 }
 
+// -- index / rindex on Logic/Bit arrays -----------------------------------
+
+TEST(TestLogicArray, IndexInheritedOnDynLogicArray) {
+    auto a = "10X10"_l;  // DOWNTO {4..0}: a[4]=1, a[3]=0, a[2]=X, a[1]=1, a[0]=0
+    auto first_one = a.index('1'_l);
+    auto last_one = a.rindex('1'_l);
+    ASSERT_TRUE(first_one.has_value() && last_one.has_value());
+    EXPECT_EQ(*first_one, 4);  // first '1' in iteration -> highest HDL coord
+    EXPECT_EQ(*last_one, 1);
+    EXPECT_FALSE(a.index('U'_l).has_value());
+}
+
+TEST(TestBitArray, IndexInheritedOnStaticBitArray) {
+    BitArray<4> a({'1'_b, '0'_b, '1'_b, '0'_b});
+    EXPECT_EQ(*a.index('1'_b), 3);   // DOWNTO {3..0}, first '1' is a[3]
+    EXPECT_EQ(*a.rindex('1'_b), 1);  // last '1' is a[1]
+}
+
 // -- Reductions: and_reduce / or_reduce / xor_reduce -----------------------
 
 TEST(TestLogicArray, AndReduceAllOnes) {


### PR DESCRIPTION
This is the range-based equivalent of `find` and mimics `Sequence.index` on Python.