### PR TITLE
`Unsigned` and `Signed`

### DIFF
--- a/cpp/include/coconext/types.hpp
+++ b/cpp/include/coconext/types.hpp
@@ -5,11 +5,13 @@
 #include "./types/array.hpp"
 #include "./types/concepts.hpp"
 #include "./types/direction.hpp"
-#include "./types/int.hpp"
 #include "./types/logic.hpp"
 #include "./types/logic_array.hpp"
 #include "./types/range.hpp"
+#include "./types/resize_mode.hpp"
 #include "./types/reverse.hpp"
+#include "./types/signed.hpp"
+#include "./types/unsigned.hpp"
 #include "./types/vector.hpp"
 // NOLINTEND(unused-includes)
 

--- a/cpp/include/coconext/types/bit_array.hpp
+++ b/cpp/include/coconext/types/bit_array.hpp
@@ -63,12 +63,14 @@ class Array<Bit, R> {
     constexpr Array(std::initializer_list<U> init) : value_(init) {}
 
     constexpr auto begin() { return value_.begin(); }
+    constexpr auto rbegin() { return value_.rbegin(); }
+    constexpr auto begin() const { return value_.begin(); }
+    constexpr auto rbegin() const { return value_.rbegin(); }
 
     constexpr auto end() { return value_.end(); }
-
-    constexpr auto begin() const { return value_.begin(); }
-
+    constexpr auto rend() { return value_.rend(); }
     constexpr auto end() const { return value_.end(); }
+    constexpr auto rend() const { return value_.rend(); }
 
     constexpr auto operator[](Range::value_type idx) {
         auto const offset = offset_of(R, idx);
@@ -136,11 +138,19 @@ class Array<Bit, R> {
     template <StringLiteral S>
     friend constexpr auto coconext::types::operator""_b();
 
+    template <Range R2>
+    friend class Unsigned;
+    template <Range R2>
+    friend class Signed;
+
   private:
     constexpr Array(Bits<R.length()> const& packed_val) : value_(packed_val) {}
 
     Bits<R.length()> value_;
 };
+
+template <Range R>
+inline constexpr bool uses_Bits<Array<Bit, R>> = true;
 
 constexpr Range::value_type offset_to_hdl_coord(
     Range r, size_t offset_from_begin

--- a/cpp/include/coconext/types/concepts.hpp
+++ b/cpp/include/coconext/types/concepts.hpp
@@ -69,7 +69,15 @@ concept Hashable = requires(T a) {
     { std::hash<T>{}(a) } -> std::convertible_to<std::size_t>;
 };
 
-// C++20 substitute for std::formattable (C++23).
+template <typename T>
+inline constexpr bool is_coconext_unsigned_v = false;
+
+template <typename T>
+inline constexpr bool is_coconext_signed_v = false;
+
+template <typename T>
+inline constexpr bool uses_Bits = false;
+
 template <typename T>
 concept Formattable = std::semiregular<std::formatter<std::remove_cvref_t<T>, char>>;
 

--- a/cpp/include/coconext/types/int.hpp
+++ b/cpp/include/coconext/types/int.hpp
@@ -1,6 +1,0 @@
-#ifndef COCONEXT_INT_HPP
-#define COCONEXT_INT_HPP
-
-#include <coconext/types/int_base.hpp>
-
-#endif

--- a/cpp/include/coconext/types/int_base.hpp
+++ b/cpp/include/coconext/types/int_base.hpp
@@ -4,17 +4,24 @@
 #include <algorithm>
 #include <bit>
 #include <coconext/types/bigint.hpp>
+#include <coconext/types/direction.hpp>
 #include <coconext/types/logic.hpp>
+#include <coconext/types/range.hpp>
+#include <coconext/types/resize_mode.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <format>
+#include <iterator>
 #include <limits>
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <tuple>
 #include <type_traits>
 
-namespace coconext::types::detail {
+namespace coconext::types {
+
+namespace detail {
 
 struct EmptyStorage {};
 
@@ -118,6 +125,8 @@ class Bits {
         constexpr explicit operator char() const {
             return parent_.get_bit(index_) ? '1' : '0';
         }
+
+        constexpr explicit operator bool() const { return parent_.get_bit(index_); }
 
         constexpr BitReference const& operator=(Bit val) const {
             parent_.set_bit(index_, static_cast<bool>(val));
@@ -230,6 +239,14 @@ class Bits {
     constexpr auto end() { return IteratorImpl<false>(this, W); }
 
     constexpr auto end() const { return IteratorImpl<true>(this, W); }
+
+    constexpr auto rbegin() noexcept { return std::make_reverse_iterator(end()); }
+
+    constexpr auto rbegin() const noexcept { return std::make_reverse_iterator(end()); }
+
+    constexpr auto rend() noexcept { return std::make_reverse_iterator(begin()); }
+
+    constexpr auto rend() const noexcept { return std::make_reverse_iterator(begin()); }
 
     constexpr BitReference operator[](size_t index) {
         if (index >= W) {
@@ -504,52 +521,6 @@ class Bits {
         }
     }
 
-    template <size_t bits>
-    constexpr auto max_unsigned_native() const {
-        static_assert(!is_not_native_int, "Not a native integer");
-        if constexpr (bits > 64 && bits <= 128) {
-            static_assert(supports_128B, "128 is not a native integer width");
-            if constexpr (bits == 128) {
-                return ~__uint128_t{0};
-            } else {
-                return ((__uint128_t)1 << bits) - 1;
-            }
-        } else if constexpr (bits == 64) {
-            return ~uint64_t{0};
-        } else if constexpr (bits < 64) {
-            return (uint64_t{1} << bits) - 1;
-        } else {
-            static_assert(bits <= 128, "Not a native integer width");
-        }
-    }
-
-    template <size_t bits>
-    constexpr auto max_unsigned_bigInt() const {
-        static_assert(is_not_native_int, "Not a BigInt");
-        return BigInt<bits>(int64_t{-1});
-    }
-
-    template <size_t bits>
-    constexpr auto max_signed_native() const {
-        static_assert(!is_not_native_int, "Not a native integer");
-        if constexpr (bits == 0) {
-            return int64_t{0};
-        } else if constexpr (bits > 64 && bits <= 128) {
-            static_assert(supports_128B, "128-bit is not supported on this platform");
-            if constexpr (bits == 128) {
-                return static_cast<__int128_t>((~__uint128_t{0}) >> 1);
-            } else {
-                return static_cast<__int128_t>(((__uint128_t)1 << (bits - 1)) - 1);
-            }
-        } else if constexpr (bits == 64) {
-            return static_cast<int64_t>((~uint64_t{0}) >> 1);
-        } else if constexpr (bits < 64) {
-            return static_cast<int64_t>((uint64_t{1} << (bits - 1)) - 1);
-        } else {
-            static_assert(bits <= 128, "Not a native integer width");
-        }
-    }
-
     std::string to_binary_string() const {
         if constexpr (W == 0) {
             return "0";
@@ -619,6 +590,7 @@ class Bits {
             res.reserve(hex_chars);
             auto val = raw();
             char const hex_digits[] = "0123456789abcdef";
+
             for (size_t i = hex_chars; i > 0; --i) {
                 uint8_t nibble = 0;
                 for (int j = 3; j >= 0; --j) {
@@ -645,6 +617,7 @@ class Bits {
             std::string res;
             res.reserve(octal_chars);
             auto val = raw();
+
             for (size_t i = octal_chars; i > 0; --i) {
                 uint8_t oct = 0;
                 for (int j = 2; j >= 0; --j) {
@@ -684,6 +657,162 @@ class Bits {
     }
 };
 
-}  // namespace coconext::types::detail
+template <size_t bits>
+constexpr auto max_unsigned() {
+    if constexpr ((bits > 64 && !supports_128B) || (bits > 128)) {
+        return BigInt<bits>(-1, true);
+    } else if constexpr (bits > 64) {
+        if constexpr (bits == 128) {
+            return ~__uint128_t{0};
+        } else {
+            return ((__uint128_t)1 << bits) - 1;
+        }
+    } else if constexpr (bits == 64) {
+        return ~uint64_t{0};
+    } else {
+        return (uint64_t{1} << bits) - 1;
+    }
+}
+
+// Build a {n-1 DOWNTO 0} Range from a length, the HDL convention for numeric
+// types. Used by Unsigned/Signed/DynUnsigned/DynSigned constructors that take
+// just a width.
+constexpr Range int_downto_range(size_t n) {
+    return Range{static_cast<Range::value_type>(n) - 1, Direction::DOWNTO, 0};
+}
+
+// Range NTTP dispatcher for the Unsigned<...>/Signed<...> template aliases.
+// Same shape as the logic_array `make_logic_static_range`: defaults to DOWNTO
+// when the user didn't pick a direction explicitly.
+//   `Unsigned<8>`        -> {7 DOWNTO 0}
+//   `Unsigned<Range{R}>` -> R (passthrough)
+//   `Unsigned<7, 0>`     -> {7 DOWNTO 0}  (auto)
+//   `Unsigned<3, 3>`     -> {3 DOWNTO 3}  (default DOWNTO when L == R)
+//   `Unsigned<0, 7>`     -> {0 TO 7}      (auto)
+//   `Unsigned<L, D, R>`  -> {L D R}       (explicit)
+template <auto... Args>
+constexpr Range make_int_range() {
+    static_assert(
+        sizeof...(Args) >= 1 && sizeof...(Args) <= 3,
+        "Unsigned/Signed takes 1 to 3 range args"
+    );
+    constexpr auto t = std::tuple{Args...};
+    if constexpr (sizeof...(Args) == 1) {
+        using First = std::remove_cvref_t<decltype(std::get<0>(t))>;
+        if constexpr (std::is_same_v<First, Range>) {
+            return std::get<0>(t);
+        } else {
+            static_assert(
+                std::integral<First>,
+                "single template arg must be a Range value or an integral length"
+            );
+            static_assert(std::get<0>(t) >= 0, "length must be non-negative");
+            return int_downto_range(static_cast<size_t>(std::get<0>(t)));
+        }
+    } else if constexpr (sizeof...(Args) == 2) {
+        constexpr Range r{
+            static_cast<Range::value_type>(std::get<0>(t)),
+            static_cast<Range::value_type>(std::get<1>(t))
+        };
+        if constexpr (r.left == r.right) {
+            return Range{r.left, Direction::DOWNTO, r.right};
+        } else {
+            return r;
+        }
+    } else {  // 3
+        static_assert(
+            std::is_same_v<std::remove_cvref_t<decltype(std::get<1>(t))>, Direction>,
+            "three-arg form requires (left, Direction, right)"
+        );
+        return Range{
+            static_cast<Range::value_type>(std::get<0>(t)),
+            std::get<1>(t),
+            static_cast<Range::value_type>(std::get<2>(t))
+        };
+    }
+}
+
+template <typename T>
+class [[nodiscard]] auto_reinterpreted {
+    T value_;
+
+  public:
+    constexpr explicit auto_reinterpreted(T v) : value_(std::forward<T>(v)) {}
+
+    auto_reinterpreted(auto_reinterpreted const&) = delete;
+    auto_reinterpreted& operator=(auto_reinterpreted const&) = delete;
+
+    constexpr auto_reinterpreted(auto_reinterpreted&& other) noexcept
+        : value_(std::forward<T>(other.value_)) {}
+
+    constexpr auto_reinterpreted& operator=(auto_reinterpreted&&) = delete;
+
+    constexpr T consume() && { return std::forward<T>(value_); }
+};
+
+template <typename T>
+class [[nodiscard]] auto_resized {
+    T value_;
+    overflow_mode ovf_;
+    round_mode rnd_;
+
+  public:
+    constexpr auto_resized(T v, overflow_mode o, round_mode r)
+        : value_(std::forward<T>(v)), ovf_(o), rnd_(r) {}
+
+    auto_resized(auto_resized const&) = delete;
+    auto_resized& operator=(auto_resized const&) = delete;
+
+    constexpr auto_resized(auto_resized&& other) noexcept
+        : value_(std::forward<T>(other.value_)), ovf_(other.ovf_), rnd_(other.rnd_) {}
+
+    constexpr auto_resized& operator=(auto_resized&&) = delete;
+    constexpr std::tuple<T, overflow_mode, round_mode> consume() && {
+        return {std::forward<T>(value_), ovf_, rnd_};
+    }
+};
+
+template <typename T>
+[[nodiscard]] constexpr auto_reinterpreted<T const&> as(T const& x) noexcept {
+    return auto_reinterpreted<T const&>(x);
+}
+
+template <typename T>
+    requires(!std::is_lvalue_reference_v<T>)
+[[nodiscard]] constexpr auto_reinterpreted<T> as(T&& x) noexcept {
+    return auto_reinterpreted<T>(std::move(x));
+}
+
+template <typename T>
+[[nodiscard]] constexpr auto_resized<T const&> resize(
+    T const& x,
+    overflow_mode ovf = overflow_mode::wrap,
+    round_mode rnd = round_mode::truncate
+) noexcept {
+    return auto_resized<T const&>(x, ovf, rnd);
+}
+
+// Prvalue (temporary) overload
+template <typename T>
+    requires(!std::is_lvalue_reference_v<T>)
+[[nodiscard]] constexpr auto_resized<T> resize(
+    T&& x, overflow_mode ovf = overflow_mode::wrap, round_mode rnd = round_mode::truncate
+) noexcept {
+    return auto_resized<T>(std::move(x), ovf, rnd);
+}
+
+}  // namespace detail
+
+template <typename Target, typename Source>
+    requires detail::uses_Bits<Target> && detail::uses_Bits<Source>
+constexpr Target as(Source const& source) noexcept {
+    static_assert(
+        Target::static_range.length() == Source::static_range.length(),
+        "as() requires equal widths."
+    );
+    return Target(static_cast<detail::Array<Bit, Source::static_range>>(source));
+}
+
+}  // namespace coconext::types
 
 #endif  // COCONEXT_INT_BASE_HPP

--- a/cpp/include/coconext/types/resize_mode.hpp
+++ b/cpp/include/coconext/types/resize_mode.hpp
@@ -1,0 +1,17 @@
+#ifndef COCONEXT_RESIZE_MODE_HPP
+#define COCONEXT_RESIZE_MODE_HPP
+
+namespace coconext::types {
+
+enum class overflow_mode {
+    wrap,
+    saturate
+};
+enum class round_mode {
+    truncate,
+    round
+};
+
+}  // namespace coconext::types
+
+#endif  // COCONEXT_RESIZE_MODE_HPP

--- a/cpp/include/coconext/types/signed.hpp
+++ b/cpp/include/coconext/types/signed.hpp
@@ -1,0 +1,849 @@
+#ifndef COCONEXT_SIGNED_HPP
+#define COCONEXT_SIGNED_HPP
+
+#include <algorithm>
+#include <coconext/types/concepts.hpp>
+#include <coconext/types/hash.hpp>
+#include <coconext/types/int_base.hpp>
+#include <coconext/types/logic_array.hpp>
+#include <coconext/types/range.hpp>
+#include <cstddef>
+#include <cstdint>
+#include <format>
+#include <functional>
+#include <limits>
+#include <stdexcept>
+#include <type_traits>
+
+namespace coconext::types {
+
+template <auto... Args, typename X>
+    requires(sizeof...(Args) > 0 && detail::is_coconext_signed_v<std::remove_cvref_t<X>>)
+constexpr auto resize(
+    X&& x, overflow_mode ovf = overflow_mode::wrap, round_mode rnd = round_mode::truncate
+);
+
+namespace detail {
+
+// for cross type constructor
+template <Range R>
+class Unsigned;
+
+template <Range R>
+class Signed {
+    static_assert(R.length() >= 0, "Signed width must not be negative");
+
+    template <typename T>
+    constexpr T to_native_int() const {
+        static_assert(
+            !detail::Bits<R.length()>::is_not_native_int,
+            "Conversion from BigInt to native int"
+        );
+
+        auto ext = value_.sra(0).raw();
+        using SType = std::make_signed_t<decltype(ext)>;
+        SType signed_val = static_cast<SType>(ext << (sizeof(ext) * 8 - R.length()))
+                        >> (sizeof(ext) * 8 - R.length());
+
+        if constexpr (
+            R.length() - 1 > std::numeric_limits<T>::digits || std::is_unsigned_v<T>
+        )
+        {
+            if (signed_val < std::numeric_limits<T>::min()
+                || signed_val > std::numeric_limits<T>::max())
+            {
+                throw std::out_of_range("Value outside destination native type range");
+            }
+        }
+
+        return static_cast<T>(signed_val);
+    }
+
+  public:
+    static constexpr Range static_range = R;
+    static constexpr Range range() noexcept { return R; }
+    static constexpr size_t size() noexcept { return R.length(); }
+
+    template <Range R2>
+    friend class Signed;
+    template <Range R2>
+    friend class Unsigned;
+
+    constexpr Signed() noexcept : value_(0) {}
+
+  private:
+    template <size_t W>
+    constexpr Signed(Bits<W> const& val) {
+        static_assert(W == R.length(), "Construction from Bits requires identical width");
+        value_ = val;
+    }
+
+  public:
+    template <NativeInteger T>
+    explicit(
+        (std::is_signed_v<T> && std::numeric_limits<T>::digits >= R.length())
+        || (std::is_unsigned_v<T> && std::numeric_limits<T>::digits >= R.length() - 1)
+    ) constexpr Signed(T v) {
+        if constexpr (std::is_unsigned_v<T>) {
+            if (v > std::numeric_limits<T>::max()) {
+                throw std::out_of_range("Unsigned value does not fit in Signed width");
+            }
+        } else {
+            if constexpr (std::numeric_limits<T>::digits >= R.length()) {
+                long long max_val = (1ULL << (R.length() - 1)) - 1;
+                long long min_val = -(1LL << (R.length() - 1));
+                if (v < min_val || v > max_val) {
+                    throw std::out_of_range("Signed value does not fit in Signed width");
+                }
+            }
+        }
+
+        value_ = detail::Bits<R.length()>(static_cast<uint64_t>(v));
+        if constexpr (R.length() > 64) {
+            if constexpr (std::is_signed_v<T>) {
+                if (v < 0) {
+                    Signed<R> temp(value_);
+                    temp = temp << (R.length() - 64);
+                    temp = temp >> (R.length() - 64);
+                    value_ = temp.value_;
+                }
+            }
+        }
+    }
+
+    template <Range R2>
+    explicit(R.length() < R2.length()) constexpr Signed(Signed<R2> const& other) {
+        if constexpr (R.length() >= R2.length()) {
+            value_ = coconext::types::resize<R.length()>(other).value_;
+        } else {
+            value_ = coconext::types::resize<R.length()>(other).value_;
+            if (coconext::types::resize<R2.length()>(Signed<R>(value_)) != other) {
+                throw std::out_of_range(
+                    "Value does not fit in narrowing Signed conversion"
+                );
+            }
+        }
+    }
+
+    template <Range R2>
+    explicit(R.length() <= R2.length()) constexpr Signed(Unsigned<R2> const& other) {
+        if constexpr (R.length() <= R2.length()) {
+            bool fits = true;
+            if constexpr (!detail::Bits<R2.length()>::is_not_native_int) {
+                auto src_val = other.value_.raw();
+                auto max_val = max_unsigned<R.length() - 1>();
+                if (src_val > max_val) {
+                    fits = false;
+                }
+            } else {
+                auto src_val = other.value_.raw();
+                auto max_val = max_unsigned<R.length() - 1>();
+                if (src_val > max_val) {
+                    fits = false;
+                }
+            }
+
+            if (!fits) {
+                throw std::out_of_range(
+                    "Unsigned value does not fit in narrowing Signed conversion"
+                );
+            }
+        }
+
+        if constexpr (
+            !Bits<R.length()>::is_not_native_int
+            && !detail::Bits<R2.length()>::is_not_native_int
+        )
+        {
+            value_ = detail::Bits<R.length()>(
+                static_cast<typename detail::Bits<R.length()>::IntType>(other.value_.raw())
+            );
+        } else {
+            value_ = detail::Bits<R.length()>(other.value_.raw());
+        }
+    }
+
+    template <Range R2>
+    explicit constexpr Signed(detail::Array<Bit, R2> const& other) {
+        static_assert(
+            R.length() == R2.length(), "BitArray reinterpret requires identical width"
+        );
+        detail::Bits<R.length()> temp_bit(0);
+        for (auto const& bit : other) {
+            temp_bit = bit ? 1 : 0;
+            value_ = (value_ << 1) | temp_bit;
+        }
+    }
+
+    template <Range R2>
+    constexpr operator detail::Array<Bit, R2>() const noexcept {
+        static_assert(
+            R.length() == R2.length(), "BitArray reinterpret requires identical width"
+        );
+        return detail::Array<Bit, R2>(value_);
+    }
+
+    template <typename SourceT>
+    constexpr Signed(auto_reinterpreted<SourceT>&& wrapper) {
+        *this = as<Signed<R>>(std::move(wrapper).consume());
+    }
+
+    template <typename SourceT>
+    constexpr Signed& operator=(auto_reinterpreted<SourceT>&& wrapper) {
+        *this = as<Signed<R>>(std::move(wrapper).consume());
+        return *this;
+    }
+
+    template <typename SourceWrapper>
+    constexpr Signed(detail::auto_resized<SourceWrapper>&& wrapper) {
+        auto [src, ovf, rnd] = std::move(wrapper).consume();
+        using ActualSource = std::remove_cvref_t<SourceWrapper>;
+
+        static_assert(
+            detail::is_coconext_signed_v<ActualSource>,
+            "resize() target and source must both be signed. Use as() for cross-type "
+            "conversions."
+        );
+
+        constexpr size_t TargetW = R.length();
+        constexpr size_t SourceW = ActualSource::size();
+
+        if constexpr (TargetW == SourceW) {
+            if constexpr (
+                !Bits<TargetW>::is_not_native_int
+                && !detail::Bits<SourceW>::is_not_native_int
+            )
+            {
+                value_ = detail::Bits<TargetW>(
+                    static_cast<typename detail::Bits<TargetW>::IntType>(src.value_.raw())
+                );
+            } else {
+                value_ = detail::Bits<TargetW>(src.value_.raw());
+            }
+        } else if constexpr (TargetW > SourceW) {
+            if constexpr (
+                !Bits<TargetW>::is_not_native_int
+                && !detail::Bits<SourceW>::is_not_native_int
+            )
+            {
+                // Sign Extension for Native Widths
+                auto ext = src.value_.raw();
+                using SType = std::make_signed_t<decltype(ext)>;
+                SType signed_val = static_cast<SType>(ext << (sizeof(ext) * 8 - SourceW))
+                                >> (sizeof(ext) * 8 - SourceW);
+                value_ = detail::Bits<TargetW>(
+                    static_cast<typename detail::Bits<TargetW>::IntType>(signed_val)
+                );
+            } else {
+                // Sign Extension for BigInts using arithmetic shifting
+                detail::Bits<TargetW> wide_zero_ext(src.value_.raw());
+                Signed<R> temp(wide_zero_ext);
+                temp = temp << (TargetW - SourceW);
+                temp = temp >> (TargetW - SourceW);
+                value_ = temp.value_;
+            }
+        } else {
+            // Narrowing
+            if (ovf == overflow_mode::wrap) {
+                if constexpr (
+                    !Bits<TargetW>::is_not_native_int
+                    && !detail::Bits<SourceW>::is_not_native_int
+                )
+                {
+                    value_ = detail::Bits<TargetW>(
+                        static_cast<typename detail::Bits<TargetW>::IntType>(
+                            src.value_.raw()
+                        )
+                    );
+                } else {
+                    value_ = detail::Bits<TargetW>(src.value_.raw());
+                }
+            } else {
+                // Signed Saturation logic
+                bool is_neg = false;
+                if constexpr (!detail::Bits<SourceW>::is_not_native_int) {
+                    is_neg = (src.value_.srl(SourceW - 1).raw() & 1) != 0;
+                } else {
+                    is_neg = (src.value_.srl(SourceW - 1).raw().get_word(0) & 1) != 0;
+                }
+
+                Signed<R> wrapped_temp;
+                if constexpr (
+                    !Bits<TargetW>::is_not_native_int
+                    && !detail::Bits<SourceW>::is_not_native_int
+                )
+                {
+                    wrapped_temp.value_ = detail::Bits<TargetW>(
+                        static_cast<typename detail::Bits<TargetW>::IntType>(
+                            src.value_.raw()
+                        )
+                    );
+                } else {
+                    wrapped_temp.value_ = detail::Bits<TargetW>(src.value_.raw());
+                }
+
+                if (coconext::types::resize<SourceW>(wrapped_temp) == src) {
+                    value_ = wrapped_temp.value_;
+                } else {
+                    if (is_neg) {
+                        detail::Bits<TargetW> min_val(1);
+                        value_ = min_val << (TargetW - 1);
+                    } else {
+                        detail::Bits<TargetW> max_val(1);
+                        max_val = (max_val << (TargetW - 1)) - detail::Bits<TargetW>(1);
+                        value_ = max_val;
+                    }
+                }
+            }
+        }
+    }
+
+    template <typename SourceWrapper>
+    constexpr Signed& operator=(detail::auto_resized<SourceWrapper>&& wrapper) {
+        *this = Signed(std::move(wrapper));
+        return *this;
+    }
+
+    friend constexpr bool operator==(Signed const& lhs, Signed const& rhs) noexcept {
+        return lhs.value_ == rhs.value_;
+    }
+
+    friend constexpr auto operator<(Signed const& lhs, Signed const& rhs) noexcept {
+        return lhs.value_.slt(rhs.value_);
+    }
+
+    friend constexpr auto operator<=(Signed const& lhs, Signed const& rhs) noexcept {
+        return lhs.value_.sle(rhs.value_);
+    }
+
+    friend constexpr auto operator>(Signed const& lhs, Signed const& rhs) noexcept {
+        return lhs.value_.sgt(rhs.value_);
+    }
+
+    friend constexpr auto operator>=(Signed const& lhs, Signed const& rhs) noexcept {
+        return lhs.value_.sge(rhs.value_);
+    }
+
+    explicit constexpr operator bool() const noexcept { return this->value_ != 0; }
+
+    explicit constexpr operator signed char() const noexcept(
+        R.length() - 1 <= std::numeric_limits<signed char>::digits
+    ) {
+        return to_native_int<signed char>();
+    }
+    explicit constexpr operator unsigned char() const noexcept(false) {
+        return to_native_int<unsigned char>();
+    }
+    explicit constexpr operator short() const noexcept(
+        R.length() - 1 <= std::numeric_limits<short>::digits
+    ) {
+        return to_native_int<short>();
+    }
+    explicit constexpr operator unsigned short() const noexcept(false) {
+        return to_native_int<unsigned short>();
+    }
+    explicit constexpr operator int() const noexcept(
+        R.length() - 1 <= std::numeric_limits<int>::digits
+    ) {
+        return to_native_int<int>();
+    }
+    explicit constexpr operator unsigned int() const noexcept(false) {
+        return to_native_int<unsigned int>();
+    }
+    explicit constexpr operator long() const noexcept(
+        R.length() - 1 <= std::numeric_limits<long>::digits
+    ) {
+        return to_native_int<long>();
+    }
+    explicit constexpr operator unsigned long() const noexcept(false) {
+        return to_native_int<unsigned long>();
+    }
+    explicit constexpr operator long long() const noexcept(
+        R.length() - 1 <= std::numeric_limits<long long>::digits
+    ) {
+        return to_native_int<long long>();
+    }
+    explicit constexpr operator unsigned long long() const noexcept(false) {
+        return to_native_int<unsigned long long>();
+    }
+
+#if defined(__SIZEOF_INT128__)
+    explicit constexpr operator __int128_t() const noexcept(
+        R.length() - 1 <= (__SIZEOF_INT128__ * 8) - 1
+    ) {
+        return to_native_int<__int128_t>();
+    }
+    explicit constexpr operator __uint128_t() const noexcept(false) {
+        return to_native_int<__uint128_t>();
+    }
+#endif
+
+    template <typename ShiftType>
+    constexpr Signed<R> operator<<(ShiftType const& shift_amount) const {
+        using CleanType = std::remove_cvref_t<ShiftType>;
+
+        static_assert(
+            std::is_integral_v<CleanType> || detail::is_coconext_unsigned_v<CleanType>
+                || detail::is_coconext_signed_v<CleanType>,
+            "Shift amount can only be a native integer, Signed, or Unsigned"
+        );
+
+        size_t safe_shift = 0;
+
+        if constexpr (std::is_integral_v<CleanType>) {
+            if constexpr (std::is_signed_v<CleanType>) {
+                if (shift_amount < 0) {
+                    throw std::invalid_argument("Negative shift amount");
+                }
+            }
+            safe_shift = static_cast<size_t>(shift_amount);
+        } else if constexpr (detail::is_coconext_unsigned_v<CleanType>) {
+            static_assert(CleanType::size() < 64, "Bit Width cap 2**64");
+            safe_shift = static_cast<size_t>(static_cast<unsigned long long>(shift_amount));
+        } else if constexpr (detail::is_coconext_signed_v<CleanType>) {
+            static_assert(CleanType::size() < 64, "Bit Width cap 2**64");
+            long long signed_val = static_cast<long long>(shift_amount);
+            if (signed_val < 0) {
+                throw std::invalid_argument("Negative shift amount");
+            }
+            safe_shift = static_cast<size_t>(signed_val);
+        }
+
+        if (safe_shift >= R.length()) {
+            return Signed<R>(0);
+        }
+
+        return Signed<R>(value_ << safe_shift);
+    }
+
+    template <typename ShiftType>
+    constexpr Signed<R> operator>>(ShiftType const& shift_amount) const {
+        using CleanType = std::remove_cvref_t<ShiftType>;
+
+        static_assert(
+            std::is_integral_v<CleanType> || detail::is_coconext_unsigned_v<CleanType>
+                || detail::is_coconext_signed_v<CleanType>,
+            "Shift amount can only be a native integer, Signed, or Unsigned"
+        );
+
+        size_t safe_shift = 0;
+
+        if constexpr (std::is_integral_v<CleanType>) {
+            if constexpr (std::is_signed_v<CleanType>) {
+                if (shift_amount < 0) {
+                    throw std::invalid_argument("Negative shift amount");
+                }
+            }
+            safe_shift = static_cast<size_t>(shift_amount);
+        } else if constexpr (detail::is_coconext_unsigned_v<CleanType>) {
+            static_assert(CleanType::size() < 64, "Bit Width cap 2**64");
+            safe_shift = static_cast<size_t>(static_cast<unsigned long long>(shift_amount));
+        } else if constexpr (detail::is_coconext_signed_v<CleanType>) {
+            static_assert(CleanType::size() < 64, "Bit Width cap 2**64");
+            long long signed_val = static_cast<long long>(shift_amount);
+            if (signed_val < 0) {
+                throw std::invalid_argument("Negative shift amount");
+            }
+            safe_shift = static_cast<size_t>(signed_val);
+        }
+
+        if (safe_shift >= R.length()) {
+            return Signed<R>(value_.sra(R.length() > 0 ? R.length() - 1 : 0));
+        }
+
+        return Signed<R>(value_.sra(safe_shift));
+    }
+
+    template <typename ShiftType>
+    constexpr Signed<R>& operator<<=(ShiftType const& amt) {
+        *this = *this << amt;
+        return *this;
+    }
+    template <typename ShiftType>
+    constexpr Signed<R>& operator>>=(ShiftType const& amt) {
+        *this = *this >> amt;
+        return *this;
+    }
+
+    constexpr auto operator+() const { return *this; }
+
+    constexpr auto operator-() const {
+        return Signed<detail::make_int_range<1>()>(0) - *this;
+    }
+
+    template <Range R2>
+    constexpr auto operator+(Signed<R2> const& rhs) const {
+        constexpr Range R_res =
+            detail::int_downto_range(std::max(R.length(), R2.length()) + 1);
+        return Signed<R_res>(
+            coconext::types::resize<R_res.length()>(*this).value_
+            + coconext::types::resize<R_res.length()>(rhs).value_
+        );
+    }
+
+    template <Range R2>
+    constexpr auto operator-(Signed<R2> const& rhs) const {
+        constexpr Range R_res =
+            detail::int_downto_range(std::max(R.length(), R2.length()) + 1);
+        return Signed<R_res>(
+            coconext::types::resize<R_res.length()>(*this).value_
+            - coconext::types::resize<R_res.length()>(rhs).value_
+        );
+    }
+
+    template <Range R2>
+    constexpr auto operator*(Signed<R2> const& rhs) const {
+        constexpr Range R_res = detail::int_downto_range(R.length() + R2.length());
+        return Signed<R_res>(
+            coconext::types::resize<R_res.length()>(*this).value_
+            * coconext::types::resize<R_res.length()>(rhs).value_
+        );
+    }
+
+    template <Range R2>
+    constexpr auto operator/(Signed<R2> const& rhs) const {
+        constexpr Range R_res = detail::int_downto_range(R.length() + 1);
+        if (!static_cast<bool>(rhs)) {
+            throw std::domain_error("Division by zero");
+        }
+        return Signed<R_res>(coconext::types::resize<R_res.length()>(*this).value_.sdiv(
+            coconext::types::resize<R_res.length()>(rhs).value_
+        ));
+    }
+
+    template <Range R2>
+    constexpr auto operator%(Signed<R2> const& rhs) const {
+        constexpr size_t W_calc = std::max(R.length(), R2.length());
+        if (!static_cast<bool>(rhs)) {
+            throw std::domain_error("Division by zero");
+        }
+        Signed<detail::int_downto_range(W_calc)> calc_result(
+            coconext::types::resize<W_calc>(*this).value_.smod(
+                coconext::types::resize<W_calc>(rhs).value_
+            )
+        );
+        return coconext::types::resize<R2.length()>(calc_result, overflow_mode::wrap);
+    }
+
+    template <Range R2>
+    constexpr Signed& operator+=(Signed<R2> const& rhs) {
+        *this = coconext::types::resize<R.length()>(*this + rhs);
+        return *this;
+    }
+    template <Range R2>
+    constexpr Signed& operator-=(Signed<R2> const& rhs) {
+        *this = coconext::types::resize<R.length()>(*this - rhs);
+        return *this;
+    }
+    template <Range R2>
+    constexpr Signed& operator*=(Signed<R2> const& rhs) {
+        *this = coconext::types::resize<R.length()>(*this * rhs);
+        return *this;
+    }
+    template <Range R2>
+    constexpr Signed& operator/=(Signed<R2> const& rhs) {
+        if (!static_cast<bool>(rhs)) {
+            throw std::domain_error("Division by zero");
+        }
+        *this = coconext::types::resize<R.length()>(*this / rhs);
+        return *this;
+    }
+    template <Range R2>
+    constexpr Signed& operator%=(Signed<R2> const& rhs) {
+        if (!static_cast<bool>(rhs)) {
+            throw std::domain_error("Division by zero");
+        }
+        *this = coconext::types::resize<R.length()>(*this % rhs);
+        return *this;
+    }
+
+    template <NativeInteger T>
+    constexpr Signed& operator+=(T const& rhs) {
+        *this = coconext::types::resize<R.length()>(
+            *this + Signed<make_int_range<R.length()>()>(rhs)
+        );
+        return *this;
+    }
+
+    template <NativeInteger T>
+    constexpr Signed& operator-=(T const& rhs) {
+        *this = coconext::types::resize<R.length()>(
+            *this - Signed<make_int_range<R.length()>()>(rhs)
+        );
+        return *this;
+    }
+
+    template <NativeInteger T>
+    constexpr Signed& operator*=(T const& rhs) {
+        *this = coconext::types::resize<R.length()>(
+            *this * Signed<make_int_range<R.length()>()>(rhs)
+        );
+        return *this;
+    }
+
+    template <NativeInteger T>
+    constexpr Signed& operator/=(T const& rhs) {
+        *this = coconext::types::resize<R.length()>(
+            *this / Signed<make_int_range<R.length()>()>(rhs)
+        );
+        return *this;
+    }
+
+    template <NativeInteger T>
+    constexpr Signed& operator%=(T const& rhs) {
+        *this = coconext::types::resize<R.length()>(
+            *this % Signed<make_int_range<R.length()>()>(rhs)
+        );
+        return *this;
+    }
+
+    template <Range R2>
+    constexpr Signed& operator+=(Unsigned<R2> const& rhs) {
+        auto res = coconext::types::resize<R.length()>(*this + (+rhs), overflow_mode::wrap);
+        *this = Signed<R>(static_cast<detail::Array<Bit, R>>(res));
+        return *this;
+    }
+
+    template <Range R2>
+    constexpr Signed& operator-=(Unsigned<R2> const& rhs) {
+        auto res = coconext::types::resize<R.length()>(*this - (+rhs), overflow_mode::wrap);
+        *this = Signed<R>(static_cast<detail::Array<Bit, R>>(res));
+        return *this;
+    }
+
+    template <Range R2>
+    constexpr Signed& operator*=(Unsigned<R2> const& rhs) {
+        auto res = coconext::types::resize<R.length()>(*this * (+rhs), overflow_mode::wrap);
+        *this = Signed<R>(static_cast<detail::Array<Bit, R>>(res));
+        return *this;
+    }
+
+    template <Range R2>
+    constexpr Signed& operator/=(Unsigned<R2> const& rhs) {
+        if (!static_cast<bool>(rhs)) {
+            throw std::domain_error("Division by zero");
+        }
+        auto res = coconext::types::resize<R.length()>(*this / (+rhs), overflow_mode::wrap);
+        *this = Signed<R>(static_cast<detail::Array<Bit, R>>(res));
+        return *this;
+    }
+
+    template <Range R2>
+    constexpr Signed& operator%=(Unsigned<R2> const& rhs) {
+        if (!static_cast<bool>(rhs)) {
+            throw std::domain_error("Division by zero");
+        }
+        auto res = coconext::types::resize<R.length()>(*this % (+rhs), overflow_mode::wrap);
+        *this = Signed<R>(static_cast<detail::Array<Bit, R>>(res));
+        return *this;
+    }
+
+    constexpr Signed& operator++() {
+        this->value_ = this->value_ + detail::Bits<R.length()>(1);
+        return *this;
+    }
+
+    constexpr Signed operator++(int) {
+        Signed tmp = *this;
+        this->value_ = this->value_ + detail::Bits<R.length()>(1);
+        return tmp;
+    }
+
+    constexpr Signed& operator--() {
+        this->value_ = this->value_ - detail::Bits<R.length()>(1);
+        return *this;
+    }
+
+    constexpr Signed operator--(int) {
+        Signed tmp = *this;
+        this->value_ = this->value_ - detail::Bits<R.length()>(1);
+        return tmp;
+    }
+
+    constexpr auto begin() const { return value_.begin(); }
+    constexpr auto rbegin() const { return value_.rbegin(); }
+
+    constexpr auto end() const { return value_.end(); }
+    constexpr auto rend() const { return value_.rend(); }
+
+    constexpr auto operator[](Range::value_type idx) const {
+        auto const offset = offset_of(R, idx);
+        if (!offset.has_value()) {
+            throw std::out_of_range("Index out of bounds");
+        }
+        size_t bit_pos = R.length() - 1 - offset.value();
+
+        return value_[bit_pos];
+    }
+
+    template <size_t N>
+    constexpr auto index() const {
+        return value_[N];
+    }
+
+    template <typename T, typename CharT>
+    friend struct std::formatter;
+    template <typename T>
+    friend struct std::hash;
+
+  private:
+    Bits<R.length()> value_;
+};
+
+template <Range R>
+inline constexpr bool is_coconext_signed_v<Signed<R>> = true;
+
+template <Range R>
+inline constexpr bool uses_Bits<Signed<R>> = true;
+
+template <Range R1, Range R2>
+constexpr auto operator+(Unsigned<R1> const& lhs, Signed<R2> const& rhs) {
+    return (+lhs) + rhs;
+}
+
+template <Range R1, Range R2>
+constexpr auto operator-(Unsigned<R1> const& lhs, Signed<R2> const& rhs) {
+    return (+lhs) - rhs;
+}
+
+template <Range R1, Range R2>
+constexpr auto operator*(Unsigned<R1> const& lhs, Signed<R2> const& rhs) {
+    return (+lhs) * rhs;
+}
+
+template <Range R1, Range R2>
+constexpr auto operator/(Unsigned<R1> const& lhs, Signed<R2> const& rhs) {
+    return (+lhs) / rhs;
+}
+
+template <Range R1, Range R2>
+constexpr auto operator%(Unsigned<R1> const& lhs, Signed<R2> const& rhs) {
+    return (+lhs) % rhs;
+}
+
+template <Range R1, Range R2>
+constexpr auto operator+(Signed<R1> const& lhs, Unsigned<R2> const& rhs) {
+    return lhs + (+rhs);
+}
+
+template <Range R1, Range R2>
+constexpr auto operator-(Signed<R1> const& lhs, Unsigned<R2> const& rhs) {
+    return lhs - (+rhs);
+}
+
+template <Range R1, Range R2>
+constexpr auto operator*(Signed<R1> const& lhs, Unsigned<R2> const& rhs) {
+    return lhs * (+rhs);
+}
+
+template <Range R1, Range R2>
+constexpr auto operator/(Signed<R1> const& lhs, Unsigned<R2> const& rhs) {
+    return lhs / (+rhs);
+}
+
+template <Range R1, Range R2>
+constexpr auto operator%(Signed<R1> const& lhs, Unsigned<R2> const& rhs) {
+    return lhs % (+rhs);
+}
+
+}  // namespace detail
+
+template <auto... Args>
+using Signed = detail::Signed<detail::make_int_range<Args...>()>;
+
+template <auto... Args, typename X>
+    requires(sizeof...(Args) > 0 && detail::is_coconext_signed_v<std::remove_cvref_t<X>>)
+constexpr auto resize(X&& x, overflow_mode ovf, round_mode rnd) {
+    constexpr Range TargetRange = detail::make_int_range<Args...>();
+    return Signed<TargetRange>(resize(std::forward<X>(x), ovf, rnd));
+}
+
+template <Range R>
+constexpr auto abs(detail::Signed<R> const& s) {
+    if (s < detail::Signed<R>(0)) {
+        return -s;
+    }
+    return resize<R.length() + 1>(s);
+}
+
+consteval Signed<8> s8(long long v) { return Signed<8>(v); }
+consteval Signed<16> s16(long long v) { return Signed<16>(v); }
+consteval Signed<32> s32(long long v) { return Signed<32>(v); }
+consteval Signed<64> s64(long long v) { return Signed<64>(v); }
+
+}  // namespace coconext::types
+
+template <coconext::types::Range R>
+struct std::formatter<coconext::types::detail::Signed<R>> {
+    char presentation = 'd';
+
+    constexpr auto parse(std::format_parse_context& ctx) {
+        auto it = ctx.begin(), end = ctx.end();
+        if (it != end && *it != '}') {
+            presentation = *it++;
+            if (presentation != 'd' && presentation != 'b' && presentation != 'o'
+                && presentation != 'x')
+            {
+                throw std::format_error("Invalid format specifier for Signed");
+            }
+        }
+        if (it != end && *it != '}') {
+            throw std::format_error("Invalid format string");
+        }
+        return it;
+    }
+
+    auto format(
+        coconext::types::detail::Signed<R> const& v, std::format_context& ctx
+    ) const {
+        std::string str_r;
+        switch (presentation) {
+        case 'b':
+            str_r = v.value_.to_binary_string();
+            break;
+        case 'o':
+            str_r = v.value_.to_octal_string();
+            break;
+        case 'x':
+            str_r = v.value_.to_hexadecimal_string();
+            break;
+        default:
+            str_r = v.value_.to_decimal_string(true);
+        }
+        return std::format_to(ctx.out(), "Signed{}{{{}}}", R, str_r);
+    }
+};
+
+template <coconext::types::Range R>
+struct std::hash<coconext::types::detail::Signed<R>> {
+    size_t operator()(coconext::types::detail::Signed<R> const& v) const noexcept {
+        std::string_view type_name = typeid(coconext::types::detail::Signed<R>).name();
+        size_t signed_seed = std::hash<std::string_view>{}(type_name);
+        constexpr size_t W = R.length();
+        size_t value_hash = 0;
+
+        if constexpr (W > 0) {
+            if constexpr (!coconext::types::detail::Bits<W>::is_not_native_int) {
+                auto raw_val = v.value_.raw();
+                if constexpr (sizeof(raw_val) > sizeof(size_t)) {
+                    uint64_t low = static_cast<uint64_t>(raw_val);
+                    uint64_t high = static_cast<uint64_t>(raw_val >> 64);
+                    value_hash = coconext::types::detail::hash_combine(low, high);
+                } else {
+                    value_hash = std::hash<decltype(raw_val)>{}(raw_val);
+                }
+            } else {
+                auto val = v.value_.raw();
+                constexpr size_t num_words = (W + 63) / 64;
+                for (size_t i = 0; i < num_words; ++i) {
+                    value_hash =
+                        coconext::types::detail::hash_combine(value_hash, val.get_word(i));
+                }
+            }
+        }
+
+        return coconext::types::detail::hash_combine(signed_seed, R, value_hash);
+    }
+};
+
+#endif  // COCONEXT_SIGNED_HPP

--- a/cpp/include/coconext/types/unsigned.hpp
+++ b/cpp/include/coconext/types/unsigned.hpp
@@ -1,0 +1,776 @@
+#ifndef COCONEXT_UNSIGNED_HPP
+#define COCONEXT_UNSIGNED_HPP
+
+#include <coconext/types/concepts.hpp>
+#include <coconext/types/hash.hpp>
+#include <coconext/types/int_base.hpp>
+#include <coconext/types/logic_array.hpp>
+#include <coconext/types/range.hpp>
+#include <cstddef>
+#include <cstdint>
+#include <format>
+#include <functional>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <typeinfo>
+
+namespace coconext::types {
+
+template <auto... Args, typename X>
+    requires(sizeof...(Args) > 0 && detail::is_coconext_unsigned_v<std::remove_cvref_t<X>>)
+constexpr auto resize(
+    X&& x, overflow_mode ovf = overflow_mode::wrap, round_mode rnd = round_mode::truncate
+);
+
+namespace detail {
+
+template <Range R>
+class Unsigned {
+    static_assert(R.length() >= 0, "Unsigned width must not be negative");
+
+    template <typename T>
+    constexpr T to_native_int() const {
+        static_assert(
+            !detail::Bits<R.length()>::is_not_native_int,
+            "Conversion from BigInt to native int"
+        );
+
+        auto val = this->value_;
+        if constexpr (R.length() > std::numeric_limits<T>::digits) {
+            if (val > std::numeric_limits<T>::max()) {
+                throw std::out_of_range("Value too large for destination native type");
+            }
+        }
+
+        return static_cast<T>(val.raw());
+    }
+
+  public:
+    static constexpr Range static_range = R;
+    static constexpr Range range() noexcept { return R; }
+    static constexpr size_t size() noexcept { return R.length(); }
+
+    // Allow different width Unsigned templates to read our private value_ (required for
+    // resize and Signed constructor)
+    template <Range R2>
+    friend class Signed;
+    template <Range R2>
+    friend class Unsigned;
+
+    constexpr Unsigned() noexcept : value_(0) {}
+
+    template <size_t W>
+    constexpr Unsigned(Bits<W> const& val) {
+        static_assert(W == R.length(), "Construction from Bits requires identical width");
+        value_ = val;
+    }
+
+    // Construct from a native integer. Throws std::out_of_range if the value is
+    // negative or does not fit in R.length() bits.
+    template <NativeInteger T>
+    explicit(
+        std::is_signed_v<T> || std::numeric_limits<T>::digits > R.length()
+    ) constexpr Unsigned(T v) {
+        if constexpr (std::is_signed_v<T>) {
+            if (v < 0) {
+                throw std::out_of_range("negative value in Unsigned construction");
+            }
+        }
+
+        if constexpr (std::numeric_limits<T>::digits <= R.length()) {
+            value_ = v;
+        } else {
+            using unsigned_T = std::make_unsigned_t<T>;
+            if (static_cast<unsigned_T>(v) > max_unsigned<R.length()>()) {
+                throw std::out_of_range("value does not fit in Unsigned width");
+            }
+            value_ = v;
+        }
+    }
+
+    // Cross-width conversion. Throws if the source value doesn't fit in N bits.
+    template <Range R2>
+    explicit(R.length() < R2.length()) constexpr Unsigned(Unsigned<R2> const& other) {
+        if constexpr (R.length() >= R2.length()) {
+            value_ = other.value_;
+        } else {
+            if constexpr (!detail::Bits<R.length()>::is_not_native_int) {
+                if (other.value_.ule(max_unsigned<R.length()>())) {
+                    if constexpr (R.length() != R2.length()) {
+                        value_ = coconext::types::resize<R.length()>(other).value_;
+                    } else {
+                        value_ = other.value_;
+                    }
+                } else {
+                    throw std::out_of_range("value does not fit in Unsigned width");
+                }
+            } else {
+                if (other.value_.ule(max_unsigned<R.length()>())) {
+                    if constexpr (R.length() != R2.length()) {
+                        value_ = coconext::types::resize<R.length()>(other).value_;
+                    } else {
+                        value_ = other.value_;
+                    }
+                } else {
+                    throw std::out_of_range("value does not fit in Unsigned width");
+                }
+            }
+        }
+    }
+
+    // Cross-width conversion from Signed. Throws if the source value doesn't fit in N bits
+    // or is negative.
+    template <Range R2>
+    explicit constexpr Unsigned(Signed<R2> const& other) {
+        bool is_negative = false;
+        if constexpr (!detail::Bits<R2.length()>::is_not_native_int) {
+            is_negative = (other.value_.srl(R2.length() - 1).raw() & 1) != 0;
+        } else {
+            is_negative = (other.value_.srl(R2.length() - 1).raw().get_word(0) & 1) != 0;
+        }
+
+        if (is_negative) {
+            throw std::out_of_range("Cannot construct Unsigned from negative Signed value");
+        }
+        *this = Unsigned<R>(Unsigned<R2>(other.value_));
+    }
+
+    // Construct from a BitArray. Throws if the source value is not exactly N bits.
+    template <Range R2>
+    explicit constexpr Unsigned(detail::Array<Bit, R2> const& other) {
+        static_assert(
+            R.length() == R2.length(), "BitArray reinterpret requires identical width"
+        );
+
+        value_ = other.value_;
+    }
+
+    // Implicit conversion to supertype BitArray
+    template <Range R2>
+    constexpr operator detail::Array<Bit, R2>() const noexcept {
+        static_assert(
+            R.length() == R2.length(), "BitArray reinterpret requires identical width"
+        );
+        return detail::Array<Bit, R2>(value_);
+    }
+
+    // Consume deduced-target reinterpret wrapper
+    template <typename SourceT>
+    constexpr Unsigned(auto_reinterpreted<SourceT>&& wrapper) {
+        *this = as<Unsigned<R>>(std::move(wrapper).consume());
+    }
+
+    template <typename SourceT>
+    constexpr Unsigned& operator=(auto_reinterpreted<SourceT>&& wrapper) {
+        *this = as<Unsigned<R>>(std::move(wrapper).consume());
+        return *this;
+    }
+
+    template <typename SourceWrapper>
+    constexpr Unsigned(detail::auto_resized<SourceWrapper>&& wrapper) {
+        auto [src, ovf, rnd] = std::move(wrapper).consume();
+        using ActualSource = std::remove_cvref_t<SourceWrapper>;
+
+        static_assert(
+            detail::is_coconext_unsigned_v<ActualSource>,
+            "reR.length() target and source must both be Unsigned. Use as() for cross-type "
+            "conversions."
+        );
+
+        constexpr size_t TargetW = R.length();
+        constexpr size_t SourceW = ActualSource::size();
+
+        if constexpr (TargetW >= SourceW) {
+            if constexpr (
+                !Bits<TargetW>::is_not_native_int
+                && !detail::Bits<SourceW>::is_not_native_int
+            )
+            {
+                value_ = detail::Bits<TargetW>(
+                    static_cast<typename detail::Bits<TargetW>::IntType>(src.value_.raw())
+                );
+            } else {
+                value_ = detail::Bits<TargetW>(src.value_.raw());
+            }
+        } else {
+            // Narrowing
+            if (ovf == overflow_mode::wrap) {
+                if constexpr (
+                    !Bits<TargetW>::is_not_native_int
+                    && !detail::Bits<SourceW>::is_not_native_int
+                )
+                {
+                    value_ = detail::Bits<TargetW>(
+                        static_cast<typename detail::Bits<TargetW>::IntType>(
+                            src.value_.raw()
+                        )
+                    );
+                } else {
+                    value_ = detail::Bits<TargetW>(src.value_.raw());
+                }
+            } else {
+                // Saturate Clamp to the maximum representable value of the Target width
+                if constexpr (
+                    !Bits<TargetW>::is_not_native_int
+                    && !detail::Bits<SourceW>::is_not_native_int
+                )
+                {
+                    auto src_raw = src.value_.raw();
+                    auto target_max = max_unsigned<TargetW>();
+
+                    if (src_raw > target_max) {
+                        value_ = detail::Bits<TargetW>(
+                            static_cast<typename detail::Bits<TargetW>::IntType>(target_max)
+                        );
+                    } else {
+                        value_ = detail::Bits<TargetW>(
+                            static_cast<typename detail::Bits<TargetW>::IntType>(src_raw)
+                        );
+                    }
+                } else {
+                    // BigInt saturate fallback
+                    auto src_raw = src.value_.raw();
+                    auto target_max = max_unsigned<TargetW>();
+                    if (src_raw > target_max) {
+                        value_ = detail::Bits<TargetW>(target_max);
+                    } else {
+                        value_ = detail::Bits<TargetW>(src_raw);
+                    }
+                }
+            }
+        }
+    }
+
+    template <typename SourceWrapper>
+    constexpr Unsigned& operator=(detail::auto_resized<SourceWrapper>&& wrapper) {
+        *this = Unsigned(std::move(wrapper));
+        return *this;
+    }
+
+    friend constexpr bool operator==(Unsigned const& lhs, Unsigned const& rhs) noexcept {
+        return lhs.value_ == rhs.value_;
+    }
+
+    friend constexpr auto operator<(Unsigned const& lhs, Unsigned const& rhs) noexcept {
+        return lhs.value_.ult(rhs.value_);
+    }
+
+    friend constexpr auto operator<=(Unsigned const& lhs, Unsigned const& rhs) noexcept {
+        return lhs.value_.ule(rhs.value_);
+    }
+
+    friend constexpr auto operator>(Unsigned const& lhs, Unsigned const& rhs) noexcept {
+        return lhs.value_.ugt(rhs.value_);
+    }
+
+    friend constexpr auto operator>=(Unsigned const& lhs, Unsigned const& rhs) noexcept {
+        return lhs.value_.uge(rhs.value_);
+    }
+
+    explicit constexpr operator bool() const noexcept { return this->value_ != 0; }
+
+    explicit constexpr operator signed char() const noexcept(
+        R.length() <= std::numeric_limits<signed char>::digits
+    ) {
+        return to_native_int<signed char>();
+    }
+    explicit constexpr operator unsigned char() const noexcept(
+        R.length() <= std::numeric_limits<unsigned char>::digits
+    ) {
+        return to_native_int<unsigned char>();
+    }
+    explicit constexpr operator short() const noexcept(
+        R.length() <= std::numeric_limits<short>::digits
+    ) {
+        return to_native_int<short>();
+    }
+    explicit constexpr operator unsigned short() const noexcept(
+        R.length() <= std::numeric_limits<unsigned short>::digits
+    ) {
+        return to_native_int<unsigned short>();
+    }
+    explicit constexpr operator int() const noexcept(
+        R.length() <= std::numeric_limits<int>::digits
+    ) {
+        return to_native_int<int>();
+    }
+    explicit constexpr operator unsigned int() const noexcept(
+        R.length() <= std::numeric_limits<unsigned int>::digits
+    ) {
+        return to_native_int<unsigned int>();
+    }
+    explicit constexpr operator long() const noexcept(
+        R.length() <= std::numeric_limits<long>::digits
+    ) {
+        return to_native_int<long>();
+    }
+    explicit constexpr operator unsigned long() const noexcept(
+        R.length() <= std::numeric_limits<unsigned long>::digits
+    ) {
+        return to_native_int<unsigned long>();
+    }
+    explicit constexpr operator long long() const noexcept(
+        R.length() <= std::numeric_limits<long long>::digits
+    ) {
+        return to_native_int<long long>();
+    }
+    explicit constexpr operator unsigned long long() const noexcept(
+        R.length() <= std::numeric_limits<unsigned long long>::digits
+    ) {
+        return to_native_int<unsigned long long>();
+    }
+
+#if defined(__SIZEOF_INT128__)
+    explicit constexpr operator __int128_t() const noexcept(
+        R.length() <= (__SIZEOF_INT128__ * 8) - 1
+    ) {
+        return to_native_int<__int128_t>();
+    }
+    explicit constexpr operator __uint128_t() const noexcept(
+        R.length() <= (__SIZEOF_INT128__ * 8)
+    ) {
+        return to_native_int<__uint128_t>();
+    }
+#endif
+
+    template <typename ShiftType>
+    constexpr Unsigned<R> operator<<(ShiftType const& shift_amount) const {
+        using CleanType = std::remove_cvref_t<ShiftType>;
+
+        // shift amount cannot be a BigInt i.e non native bit width, kind of an impossible
+        // thing
+        static_assert(
+            std::is_integral_v<CleanType> || detail::is_coconext_unsigned_v<CleanType>
+                || detail::is_coconext_signed_v<CleanType>,
+            "Shift amount can only be a native integer, Signed, or Unsigned"
+        );
+
+        size_t safe_shift = 0;
+
+        if constexpr (std::is_integral_v<CleanType>) {
+            if constexpr (std::is_signed_v<CleanType>) {
+                if (shift_amount < 0) {
+                    throw std::invalid_argument("Negative shift amount");
+                }
+            }
+            safe_shift = static_cast<size_t>(shift_amount);
+        } else if constexpr (detail::is_coconext_unsigned_v<CleanType>) {
+            static_assert(CleanType::size() < 64, "Bit Width cap 2**64");
+            safe_shift = static_cast<size_t>(static_cast<unsigned long long>(shift_amount));
+        } else if constexpr (detail::is_coconext_signed_v<CleanType>) {
+            static_assert(CleanType::size() < 64, "Bit Width cap 2**64");
+            long long signed_val = static_cast<long long>(shift_amount);
+            if (signed_val < 0) {
+                throw std::invalid_argument("Negative shift amount");
+            }
+            safe_shift = static_cast<size_t>(signed_val);
+        }
+
+        if (safe_shift >= R.length()) {
+            return Unsigned<R>(0);
+        }
+
+        return Unsigned<R>(value_ << safe_shift);
+    }
+
+    template <typename ShiftType>
+    constexpr Unsigned<R> operator>>(ShiftType const& shift_amount) const {
+        using CleanType = std::remove_cvref_t<ShiftType>;
+
+        // shift amount cannot be a BigInt i.e non native bit width, kind of an impossible
+        // thing
+        static_assert(
+            std::is_integral_v<CleanType> || detail::is_coconext_unsigned_v<CleanType>
+                || detail::is_coconext_signed_v<CleanType>,
+            "Shift amount can only be a native integer, Signed, or Unsigned"
+        );
+
+        size_t safe_shift = 0;
+
+        if constexpr (std::is_integral_v<CleanType>) {
+            if constexpr (std::is_signed_v<CleanType>) {
+                if (shift_amount < 0) {
+                    throw std::invalid_argument("Negative shift amount");
+                }
+            }
+            safe_shift = static_cast<size_t>(shift_amount);
+        } else if constexpr (detail::is_coconext_unsigned_v<CleanType>) {
+            static_assert(CleanType::size() < 64, "Bit Width cap 2**64");
+            safe_shift = static_cast<size_t>(static_cast<unsigned long long>(shift_amount));
+        } else if constexpr (detail::is_coconext_signed_v<CleanType>) {
+            static_assert(CleanType::size() < 64, "Bit Width cap 2**64");
+            long long signed_val = static_cast<long long>(shift_amount);
+            if (signed_val < 0) {
+                throw std::invalid_argument("Negative shift amount");
+            }
+            safe_shift = static_cast<size_t>(signed_val);
+        }
+
+        if (safe_shift >= R.length()) {
+            return Unsigned<R>(0);
+        }
+
+        return Unsigned<R>(value_.srl(safe_shift));
+    }
+
+    template <typename ShiftType>
+    constexpr Unsigned<R>& operator<<=(ShiftType const& shift_amount) {
+        *this = *this << shift_amount;
+        return *this;
+    }
+
+    template <typename ShiftType>
+    constexpr Unsigned<R>& operator>>=(ShiftType const& shift_amount) {
+        *this = *this >> shift_amount;
+        return *this;
+    }
+
+    constexpr auto operator+() const {
+        constexpr Range R_res = detail::int_downto_range(R.length() + 1);
+        return coconext::types::as<Signed<R_res>>(
+            coconext::types::resize<R_res.length()>(*this)
+        );
+    }
+
+    constexpr auto operator-() const {
+        constexpr Range R_res = detail::int_downto_range(R.length() + 1);
+        auto ext = coconext::types::resize<R_res.length()>(*this);
+        return Signed<R_res>(detail::Bits<R_res.length()>(0) - ext.value_);
+    }
+
+    template <Range R2>
+    constexpr auto operator+(Unsigned<R2> const& rhs) const {
+        constexpr Range R_res =
+            detail::int_downto_range(std::max(R.length(), R2.length()) + 1);
+
+        auto a_ext = coconext::types::resize<R_res.length()>(*this);
+        auto b_ext = coconext::types::resize<R_res.length()>(rhs);
+        return Unsigned<R_res>(a_ext.value_ + b_ext.value_);
+    }
+
+    template <Range R2>
+    constexpr auto operator-(Unsigned<R2> const& rhs) const {
+        constexpr Range R_res =
+            detail::int_downto_range(std::max(R.length(), R2.length()) + 1);
+
+        // resize then convert to signed
+        auto rs_a = coconext::types::resize<R_res.length()>(*this).value_;
+        auto rs_b = coconext::types::resize<R_res.length()>(rhs).value_;
+
+        return Signed<R_res>(rs_a - rs_b);
+    }
+
+    template <Range R2>
+    constexpr auto operator*(Unsigned<R2> const& rhs) const {
+        constexpr Range R_res = detail::int_downto_range(R.length() + R2.length());
+
+        auto a_ext = coconext::types::resize<R_res.length()>(*this);
+        auto b_ext = coconext::types::resize<R_res.length()>(rhs);
+        return Unsigned<R_res>(a_ext.value_ * b_ext.value_);
+    }
+
+    template <Range R2>
+    constexpr auto operator/(Unsigned<R2> const& rhs) const {
+        constexpr Range R_res = detail::int_downto_range(R.length() + 1);
+
+        if (!static_cast<bool>(rhs)) {
+            throw std::domain_error("Division by zero");
+        }
+
+        auto a_ext = coconext::types::resize<R_res.length()>(*this);
+        auto b_ext = coconext::types::resize<R_res.length()>(rhs);
+        return Unsigned<R_res>(a_ext.value_.udiv(b_ext.value_));
+    }
+
+    template <Range R2>
+    constexpr auto operator%(Unsigned<R2> const& rhs) const {
+        constexpr size_t W_calc = std::max(R.length(), R2.length());
+
+        if (!static_cast<bool>(rhs)) {
+            throw std::domain_error("Division by zero");
+        }
+
+        auto a_calc = coconext::types::resize<W_calc>(*this);
+        auto b_calc = coconext::types::resize<W_calc>(rhs);
+
+        Unsigned<detail::int_downto_range(W_calc)> calc_result(
+            a_calc.value_.umod(b_calc.value_)
+        );
+        return coconext::types::resize<R2.length()>(calc_result, overflow_mode::wrap);
+    }
+
+    template <Range R2>
+    constexpr Unsigned& operator+=(Unsigned<R2> const& rhs) {
+        *this = coconext::types::resize<R.length()>(*this + rhs);
+        return *this;
+    }
+
+    template <Range R2>
+    constexpr Unsigned& operator-=(Unsigned<R2> const& rhs) {
+        auto res = coconext::types::resize<R.length()>(*this - rhs);
+        *this = Unsigned<R>(static_cast<detail::Array<Bit, R>>(res));
+        return *this;
+    }
+
+    template <Range R2>
+    constexpr Unsigned& operator*=(Unsigned<R2> const& rhs) {
+        *this = coconext::types::resize<R.length()>(*this * rhs);
+        return *this;
+    }
+
+    template <Range R2>
+    constexpr Unsigned& operator/=(Unsigned<R2> const& rhs) {
+        if (!static_cast<bool>(rhs)) {
+            throw std::domain_error("Division by zero");
+        }
+        *this = coconext::types::resize<R.length()>(*this / rhs);
+        return *this;
+    }
+
+    template <Range R2>
+    constexpr Unsigned& operator%=(Unsigned<R2> const& rhs) {
+        if (!static_cast<bool>(rhs)) {
+            throw std::domain_error("Division by zero");
+        }
+        *this = coconext::types::resize<R.length()>(*this % rhs);
+        return *this;
+    }
+
+    template <NativeInteger T>
+    constexpr Unsigned& operator+=(T const& rhs) {
+        *this = coconext::types::resize<R.length()>(
+            *this + Unsigned<make_int_range<R.length()>()>(rhs)
+        );
+        return *this;
+    }
+
+    template <NativeInteger T>
+    constexpr Unsigned& operator-=(T const& rhs) {
+        auto res = coconext::types::resize<R.length()>(
+            *this - Unsigned<make_int_range<R.length()>()>(rhs)
+        );
+        *this = Unsigned<R>(static_cast<detail::Array<Bit, R>>(res));
+        return *this;
+    }
+
+    template <NativeInteger T>
+    constexpr Unsigned& operator*=(T const& rhs) {
+        *this = coconext::types::resize<R.length()>(
+            *this * Unsigned<make_int_range<R.length()>()>(rhs)
+        );
+        return *this;
+    }
+
+    template <NativeInteger T>
+    constexpr Unsigned& operator/=(T const& rhs) {
+        *this = coconext::types::resize<R.length()>(
+            *this / Unsigned<make_int_range<R.length()>()>(rhs)
+        );
+        return *this;
+    }
+
+    template <NativeInteger T>
+    constexpr Unsigned& operator%=(T const& rhs) {
+        *this = coconext::types::resize<R.length()>(
+            *this % Unsigned<make_int_range<R.length()>()>(rhs)
+        );
+        return *this;
+    }
+
+    template <Range R2>
+    constexpr Unsigned& operator+=(Signed<R2> const& rhs) {
+        auto res = coconext::types::resize<R.length()>(+(*this) + rhs, overflow_mode::wrap);
+        *this = Unsigned<R>(static_cast<detail::Array<Bit, R>>(res));
+        return *this;
+    }
+
+    template <Range R2>
+    constexpr Unsigned& operator-=(Signed<R2> const& rhs) {
+        auto res = coconext::types::resize<R.length()>(+(*this) - rhs, overflow_mode::wrap);
+        *this = Unsigned<R>(static_cast<detail::Array<Bit, R>>(res));
+        return *this;
+    }
+
+    template <Range R2>
+    constexpr Unsigned& operator*=(Signed<R2> const& rhs) {
+        auto res = coconext::types::resize<R.length()>(+(*this) * rhs, overflow_mode::wrap);
+        *this = Unsigned<R>(static_cast<detail::Array<Bit, R>>(res));
+        return *this;
+    }
+
+    template <Range R2>
+    constexpr Unsigned& operator/=(Signed<R2> const& rhs) {
+        if (!static_cast<bool>(rhs)) {
+            throw std::domain_error("Division by zero");
+        }
+        auto res = coconext::types::resize<R.length()>(+(*this) / rhs, overflow_mode::wrap);
+        *this = Unsigned<R>(static_cast<detail::Array<Bit, R>>(res));
+        return *this;
+    }
+
+    template <Range R2>
+    constexpr Unsigned& operator%=(Signed<R2> const& rhs) {
+        if (!static_cast<bool>(rhs)) {
+            throw std::domain_error("Division by zero");
+        }
+        auto res = coconext::types::resize<R.length()>(+(*this) % rhs, overflow_mode::wrap);
+        *this = Unsigned<R>(static_cast<detail::Array<Bit, R>>(res));
+        return *this;
+    }
+
+    constexpr Unsigned& operator++() {
+        this->value_ = this->value_ + detail::Bits<R.length()>(1);
+        return *this;
+    }
+
+    constexpr Unsigned operator++(int) {
+        Unsigned tmp = *this;
+        this->value_ = this->value_ + detail::Bits<R.length()>(1);
+        return tmp;
+    }
+
+    constexpr Unsigned& operator--() {
+        this->value_ = this->value_ - detail::Bits<R.length()>(1);
+        return *this;
+    }
+
+    constexpr Unsigned operator--(int) {
+        Unsigned tmp = *this;
+        this->value_ = this->value_ - detail::Bits<R.length()>(1);
+        return tmp;
+    }
+
+    constexpr auto begin() const { return value_.begin(); }
+    constexpr auto rbegin() const { return value_.rbegin(); }
+
+    constexpr auto end() const { return value_.end(); }
+    constexpr auto rend() const { return value_.rend(); }
+
+    constexpr auto operator[](Range::value_type idx) const {
+        auto const offset = offset_of(R, idx);
+        if (!offset.has_value()) {
+            throw std::out_of_range("Index out of bounds");
+        }
+        size_t bit_pos = R.length() - 1 - offset.value();
+
+        return value_[bit_pos];
+    }
+
+    template <size_t N>
+    constexpr auto index() const {
+        return value_[N];
+    }
+
+    template <typename T, typename CharT>
+    friend struct std::formatter;
+    template <typename T>
+    friend struct std::hash;
+
+  private:
+    Bits<R.length()> value_;
+};
+
+template <Range R>
+inline constexpr bool is_coconext_unsigned_v<Unsigned<R>> = true;
+
+template <Range R>
+inline constexpr bool uses_Bits<Unsigned<R>> = true;
+
+}  // namespace detail
+
+// User-facing alias: accepts the same NTTP forms as Array<T, ...>, with HDL
+// DOWNTO defaulting (see detail::make_int_range for the rules).
+template <auto... Args>
+using Unsigned = detail::Unsigned<detail::make_int_range<Args...>()>;
+
+template <auto... Args, typename X>
+    requires(sizeof...(Args) > 0 && detail::is_coconext_unsigned_v<std::remove_cvref_t<X>>)
+constexpr auto resize(X&& x, overflow_mode ovf, round_mode rnd) {
+    constexpr Range TargetRange = detail::make_int_range<Args...>();
+    return Unsigned<TargetRange>(resize(std::forward<X>(x), ovf, rnd));
+}
+
+consteval Unsigned<8> u8(unsigned long long v) { return Unsigned<8>(v); }
+consteval Unsigned<16> u16(unsigned long long v) { return Unsigned<16>(v); }
+consteval Unsigned<32> u32(unsigned long long v) { return Unsigned<32>(v); }
+consteval Unsigned<64> u64(unsigned long long v) { return Unsigned<64>(v); }
+
+}  // namespace coconext::types
+
+template <coconext::types::Range R>
+struct std::formatter<coconext::types::detail::Unsigned<R>> {
+    char presentation = 'd';
+
+    constexpr auto parse(std::format_parse_context& ctx) {
+        auto it = ctx.begin(), end = ctx.end();
+        if (it != end && *it != '}') {
+            presentation = *it++;
+            if (presentation != 'd' && presentation != 'b' && presentation != 'o'
+                && presentation != 'x')
+            {
+                throw std::format_error("Invalid format specifier for Unsigned");
+            }
+        }
+        if (it != end && *it != '}') {
+            throw std::format_error("Invalid format string");
+        }
+        return it;
+    }
+
+    auto format(
+        coconext::types::detail::Unsigned<R> const& v, std::format_context& ctx
+    ) const {
+        std::string str_r;
+        switch (presentation) {
+        case 'b':
+            str_r = v.value_.to_binary_string();
+            break;
+        case 'o':
+            str_r = v.value_.to_octal_string();
+            break;
+        case 'x':
+            str_r = v.value_.to_hexadecimal_string();
+            break;
+        default:
+            str_r = v.value_.to_decimal_string();
+        }
+        return std::format_to(ctx.out(), "Unsigned{}{{{}}}", R, str_r);
+    }
+};
+
+template <coconext::types::Range R>
+struct std::hash<coconext::types::detail::Unsigned<R>> {
+    size_t operator()(coconext::types::detail::Unsigned<R> const& v) const noexcept {
+        std::string_view type_name = typeid(coconext::types::detail::Unsigned<R>).name();
+        size_t unsigned_seed = std::hash<std::string_view>{}(type_name);
+        constexpr size_t W = R.length();
+        size_t value_hash = 0;
+
+        if constexpr (W > 0) {
+            if constexpr (!coconext::types::detail::Bits<W>::is_not_native_int) {
+                auto raw_val = v.value_.raw();
+                if constexpr (sizeof(raw_val) > sizeof(size_t)) {
+                    uint64_t low = static_cast<uint64_t>(raw_val);
+                    uint64_t high = static_cast<uint64_t>(raw_val >> 64);
+                    value_hash = coconext::types::detail::hash_combine(low, high);
+                } else {
+                    value_hash = std::hash<decltype(raw_val)>{}(raw_val);
+                }
+            } else {
+                auto val = v.value_.raw();
+                constexpr size_t num_words = (W + 63) / 64;
+                for (size_t i = 0; i < num_words; ++i) {
+                    value_hash =
+                        coconext::types::detail::hash_combine(value_hash, val.get_word(i));
+                }
+            }
+        }
+
+        return coconext::types::detail::hash_combine(unsigned_seed, R, value_hash);
+    }
+};
+
+#endif  // COCONEXT_UNSIGNED_HPP

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -23,7 +23,10 @@ add_executable(coconext_tests
     test_static_array.cpp
     test_logic_array.cpp
     test_int.cpp
-    test_reverse.cpp)
+    test_reverse.cpp
+    test_unsigned.cpp
+    test_signed.cpp)
+
 target_link_libraries(coconext_tests PRIVATE coconext::coconext GTest::gtest_main)
 
 gtest_discover_tests(coconext_tests)

--- a/tests/cpp/test_logic_array.cpp
+++ b/tests/cpp/test_logic_array.cpp
@@ -954,6 +954,33 @@ TEST(TestLogicArray, UdlLogicEmpty) {
     EXPECT_EQ(a.begin(), a.end());
 }
 
+TEST(TestBitArray, ReverseIterators) {
+    auto a = "0111001"_b;
+
+    auto rit = a.rbegin();
+    ASSERT_NE(rit, a.rend());
+    EXPECT_EQ(*rit++, '1'_b);
+    EXPECT_EQ(*rit++, '0'_b);
+    EXPECT_EQ(*rit++, '0'_b);
+    EXPECT_EQ(*rit++, '1'_b);
+    EXPECT_EQ(*rit++, '1'_b);
+    EXPECT_EQ(*rit++, '1'_b);
+    EXPECT_EQ(*rit++, '0'_b);
+    EXPECT_EQ(rit, a.rend());
+
+    auto const& ca = a;
+    auto crit = ca.rbegin();
+    ASSERT_NE(crit, ca.rend());
+    EXPECT_EQ(*crit++, '1'_b);
+    EXPECT_EQ(*crit++, '0'_b);
+    EXPECT_EQ(*crit++, '0'_b);
+    EXPECT_EQ(*crit++, '1'_b);
+    EXPECT_EQ(*crit++, '1'_b);
+    EXPECT_EQ(*crit++, '1'_b);
+    EXPECT_EQ(*crit++, '0'_b);
+    EXPECT_EQ(crit, ca.rend());
+}
+
 TEST(TestLogicArray, UdlLogicAllUnderscores) {
     // All-underscore literal strips to a zero-length array just like the empty
     // literal.

--- a/tests/cpp/test_signed.cpp
+++ b/tests/cpp/test_signed.cpp
@@ -1,0 +1,453 @@
+// LCOV_EXCL_BR_START -- gtest macros generate noisy uncovered branches
+#include <gtest/gtest.h>
+
+#include <coconext/types.hpp>
+#include <cstdint>
+#include <format>
+#include <stdexcept>
+#include <type_traits>
+#include <unordered_set>
+
+using namespace coconext::types;
+
+TEST(TestSigned, Constructors) {
+    static_assert(!std::is_convertible_v<int, Signed<6>>);
+
+    Signed<4> a(-5);
+    EXPECT_EQ(static_cast<int8_t>(a), -5);
+    EXPECT_EQ(a.size(), 4U);
+
+    EXPECT_THROW(Signed<4>(8), std::out_of_range);
+    EXPECT_THROW(Signed<4>(-9), std::out_of_range);
+
+    Signed<8> large_val(100);
+    Signed<8> small_val(-5);
+
+    Signed<4> narrow_fit(small_val);
+    EXPECT_EQ(static_cast<int8_t>(narrow_fit), -5);
+
+    EXPECT_THROW(Signed<4> narrow_fail(large_val), std::out_of_range);
+
+    BitArray<5> arr_a({'1'_b, '1'_b, '0'_b, '1'_b, '1'_b});
+    Signed<5> s_arr_a(arr_a);
+    EXPECT_EQ(static_cast<int32_t>(s_arr_a), -5);
+
+    Signed<5> arr_a_exp("11011"_b);
+    EXPECT_EQ(s_arr_a, arr_a_exp);
+
+    Unsigned<8> u(100);
+    Signed<10> s(u);
+    EXPECT_EQ(static_cast<int32_t>(s), 100);
+
+    Unsigned<8> u_large(200);
+    EXPECT_THROW(Signed<8> s_narrow(u_large), std::out_of_range);
+}
+
+TEST(TestSigned, ImplicitBitArrayConversion) {
+    Signed<6> a(-1);
+    BitArray<5, 0> b = a;
+
+    EXPECT_EQ(b[0], '1'_b);
+    EXPECT_EQ(b[4], '1'_b);
+    EXPECT_EQ(b[5], '1'_b);
+}
+
+TEST(TestSigned, ExplicitNativeCasts) {
+    Signed<16> a(-30000);
+
+    EXPECT_TRUE(static_cast<bool>(a));
+    EXPECT_FALSE(static_cast<bool>(Signed<16>(0)));
+
+    EXPECT_EQ(static_cast<int>(a), -30000);
+    EXPECT_EQ(static_cast<long long>(a), -30000LL);
+
+    Signed<4> b(-2);
+    EXPECT_EQ(static_cast<signed char>(b), -2);
+}
+
+TEST(TestSigned, ArithmeticOperators) {
+    Signed<8> a(-50);
+    Signed<8> b(20);
+
+    auto sum = a + b;
+    static_assert(std::is_same_v<decltype(sum), Signed<9>>);
+    EXPECT_EQ(static_cast<int>(sum), -30);
+
+    auto prod = a * b;
+    static_assert(std::is_same_v<decltype(prod), Signed<16>>);
+    EXPECT_EQ(static_cast<int>(prod), -1000);
+
+    auto div = a / b;
+    static_assert(std::is_same_v<decltype(div), Signed<9>>);
+    EXPECT_EQ(static_cast<int>(div), -2);
+
+    auto mod = a % Signed<4>(7);
+    static_assert(std::is_same_v<decltype(mod), Signed<4>>);
+    EXPECT_EQ(static_cast<int>(mod), -50 % 7);
+
+    EXPECT_THROW(a / Signed<4>(0), std::domain_error);
+    EXPECT_THROW(a % Signed<8>(0), std::domain_error);
+
+    auto sub_pos = a - b;
+    auto sub_neg = b - a;
+    static_assert(std::is_same_v<decltype(sub_pos), Signed<9>>);
+    static_assert(std::is_same_v<decltype(sub_neg), Signed<9>>);
+    EXPECT_EQ(static_cast<int16_t>(sub_pos), -70);
+    EXPECT_EQ(static_cast<int16_t>(sub_neg), 70);
+
+    Unsigned<8> u(10);
+    Signed<5> s2(-5);
+    auto mixed_sum = u + s2;
+    static_assert(std::is_same_v<decltype(mixed_sum), Signed<10>>);
+    EXPECT_EQ(static_cast<int>(mixed_sum), 5);
+}
+
+TEST(SignedMixedSignednessTest, CompoundAssignmentOperators) {
+    auto s1 = s8(-5);
+    s1 += u8(15);
+    EXPECT_EQ(s1, s8(10));
+
+    auto s2 = s8(120);
+    s2 += u8(20);
+    EXPECT_EQ(s2, s8(-116));
+
+    auto s3 = s8(5);
+    s3 -= u8(10);
+    EXPECT_EQ(s3, s8(-5));
+
+    auto s4 = s8(-3);
+    s4 *= u8(10);
+    EXPECT_EQ(s4, s8(-30));
+
+    auto s5 = s8(-20);
+    s5 /= u8(4);
+    EXPECT_EQ(s5, s8(-5));
+
+    auto s6 = s8(-23);
+    s6 %= u8(7);
+    EXPECT_EQ(s6, s8(-2));
+
+    auto s7 = s8(50);
+    EXPECT_THROW(s7 /= u8(0), std::domain_error);
+    EXPECT_THROW(s7 %= u8(0), std::domain_error);
+}
+
+TEST(TestSigned, as_overloads) {
+    BitArray<5> arr_a({'1'_b, '1'_b, '0'_b, '1'_b, '1'_b});
+
+    auto a = as<Signed<5>>(arr_a);
+    BitArray<4, 0> arr_exp = a;
+    static_assert(std::is_same_v<decltype(a), Signed<5>>);
+    EXPECT_EQ(static_cast<int8_t>(a), -5);
+    EXPECT_EQ(arr_a, arr_exp);
+
+    Signed<5> a1;
+    a1 = as(arr_a);
+    BitArray<4, 0> arr_exp_a1 = a1;
+    EXPECT_EQ(static_cast<int8_t>(a1), -5);
+    EXPECT_EQ(arr_a, arr_exp_a1);
+}
+
+TEST(TestSigned, resize_overloads) {
+    Signed<8> small(-10);
+
+    auto wide_spelled = resize<16>(small);
+    static_assert(std::is_same_v<decltype(wide_spelled), Signed<16>>);
+    EXPECT_EQ(static_cast<int16_t>(wide_spelled), -10);
+
+    Signed<16> wide_deduced;
+    wide_deduced = resize(small);
+    EXPECT_EQ(static_cast<int16_t>(wide_deduced), -10);
+
+    Signed<16> wide(1000);
+
+    auto narrow_wrap_spelled = resize<8>(wide);
+    static_assert(std::is_same_v<decltype(narrow_wrap_spelled), Signed<8>>);
+    EXPECT_EQ(static_cast<int8_t>(narrow_wrap_spelled), static_cast<int8_t>(1000));
+
+    Signed<8> narrow_wrap_deduced;
+    narrow_wrap_deduced = resize(wide);
+    EXPECT_EQ(static_cast<int8_t>(narrow_wrap_deduced), static_cast<int8_t>(1000));
+
+    auto narrow_sat_spelled = resize<8>(wide, overflow_mode::saturate);
+    EXPECT_EQ(static_cast<int8_t>(narrow_sat_spelled), 127);
+
+    Signed<16> wide_neg(-1000);
+    Signed<8> narrow_sat_deduced;
+    narrow_sat_deduced = resize(wide_neg, overflow_mode::saturate);
+    EXPECT_EQ(static_cast<int8_t>(narrow_sat_deduced), -128);
+
+    Signed<8> copy_init_deduced = resize(wide_neg, overflow_mode::saturate);
+    EXPECT_EQ(static_cast<int8_t>(copy_init_deduced), -128);
+}
+
+TEST(TestSigned, Comparisons) {
+    Signed<8> a(-10);
+    Signed<8> b(-10);
+    Signed<8> c(20);
+    Signed<8> d(-15);
+
+    EXPECT_TRUE(a == b);
+    EXPECT_FALSE(a == c);
+
+    EXPECT_TRUE(a != c);
+    EXPECT_FALSE(a != b);
+
+    EXPECT_TRUE(d < a);
+    EXPECT_FALSE(a < d);
+    EXPECT_FALSE(a < b);
+
+    EXPECT_TRUE(d <= a);
+    EXPECT_TRUE(a <= b);
+    EXPECT_FALSE(c <= a);
+
+    EXPECT_TRUE(c > a);
+    EXPECT_FALSE(a > c);
+    EXPECT_FALSE(a > b);
+
+    EXPECT_TRUE(c >= a);
+    EXPECT_TRUE(a >= b);
+    EXPECT_FALSE(d >= a);
+}
+
+TEST(TestSigned, CompoundAssignment) {
+    Signed<8> a(-10);
+    Signed<4> b(5);
+
+    a += b;
+    EXPECT_EQ(static_cast<int>(a), -5);
+
+    a -= Signed<8>(3);
+    EXPECT_EQ(static_cast<int>(a), -8);
+
+    a *= Signed<2>(-2);
+    EXPECT_EQ(static_cast<int>(a), 16);
+
+    a /= Signed<4>(-4);
+    EXPECT_EQ(static_cast<int>(a), -4);
+
+    a %= Signed<4>(3);
+    EXPECT_EQ(static_cast<int>(a), -1);
+
+    a += 10;
+    EXPECT_EQ(static_cast<int>(a), 9);
+
+    EXPECT_THROW(a /= 0, std::domain_error);
+}
+
+TEST(TestSigned, IncrementDecrement) {
+    Signed<8> a(-1);
+
+    EXPECT_EQ(static_cast<int>(++a), 0);
+    EXPECT_EQ(static_cast<int>(a), 0);
+
+    EXPECT_EQ(static_cast<int>(--a), -1);
+    EXPECT_EQ(static_cast<int>(a), -1);
+
+    EXPECT_EQ(static_cast<int>(a++), -1);
+    EXPECT_EQ(static_cast<int>(a), 0);
+
+    EXPECT_EQ(static_cast<int>(a--), 0);
+    EXPECT_EQ(static_cast<int>(a), -1);
+
+    Signed<4> max_val(7);
+    max_val++;
+    EXPECT_EQ(static_cast<int>(max_val), -8);
+
+    Signed<4> min_val(-8);
+    min_val--;
+    EXPECT_EQ(static_cast<int>(min_val), 7);
+}
+
+TEST(TestSigned, ShiftOperators) {
+    Signed<8> a(-4);
+
+    auto sl = a << 2;
+    EXPECT_EQ(static_cast<int>(sl), -16);
+
+    auto sr = a >> 1;
+    EXPECT_EQ(static_cast<int>(sr), -2);
+
+    EXPECT_EQ(static_cast<int>(a << 8), 0);
+    EXPECT_EQ(static_cast<int>(a >> 10), -1);
+
+    Signed<8> b(4);
+    EXPECT_EQ(static_cast<int>(b >> 10), 0);
+
+    a <<= 3;
+    EXPECT_EQ(static_cast<int>(a), -32);
+    a >>= 2;
+    EXPECT_EQ(static_cast<int>(a), -8);
+
+    EXPECT_THROW(a << -1, std::invalid_argument);
+    EXPECT_THROW(a >> -2, std::invalid_argument);
+
+    Signed<4> shift_amt(2);
+    EXPECT_EQ(static_cast<int>(a << shift_amt), -32);
+}
+
+TEST(TestSigned, Iterators) {
+    Signed<4> a(-2);  // 1110
+
+    std::vector<int> bit_vals;
+    for (auto bit : a) {
+        bit_vals.push_back(static_cast<bool>(bit) ? 1 : 0);
+    }
+
+    EXPECT_EQ(bit_vals.size(), 4);
+    EXPECT_EQ(bit_vals[0], 1);
+    EXPECT_EQ(bit_vals[1], 1);
+    EXPECT_EQ(bit_vals[2], 1);
+    EXPECT_EQ(bit_vals[3], 0);
+
+    std::vector<int> rbit_vals;
+    for (auto rit = a.rbegin(); rit != a.rend(); ++rit) {
+        rbit_vals.push_back(static_cast<bool>(*rit) ? 1 : 0);
+    }
+
+    std::vector<int> expected_rvals = {0, 1, 1, 1};
+    EXPECT_EQ(rbit_vals, expected_rvals);
+
+    std::reverse(rbit_vals.begin(), rbit_vals.end());
+    EXPECT_EQ(rbit_vals, bit_vals);
+
+    auto it = a.begin();
+    EXPECT_EQ(static_cast<bool>(*(it + 1)), true);
+    EXPECT_EQ(static_cast<bool>(it[2]), true);
+}
+
+TEST(TestSigned, index_operator) {
+    Signed<4> a(-2);  // 1110
+
+    EXPECT_TRUE(static_cast<bool>(a[3]));
+    EXPECT_TRUE(static_cast<bool>(a[2]));
+    EXPECT_TRUE(static_cast<bool>(a[1]));
+    EXPECT_FALSE(static_cast<bool>(a[0]));
+
+    EXPECT_THROW(a[4], std::out_of_range);
+}
+
+TEST(TestSigned, index) {
+    Signed<4> a(-6);  // 1010
+
+    EXPECT_TRUE(static_cast<bool>(a.index<3>()));
+    EXPECT_FALSE(static_cast<bool>(a.index<2>()));
+    EXPECT_TRUE(static_cast<bool>(a.index<1>()));
+    EXPECT_FALSE(static_cast<bool>(a.index<0>()));
+
+    EXPECT_EQ(static_cast<int>(a.index<3>()), 1);
+    EXPECT_EQ(static_cast<int>(a.index<0>()), 0);
+}
+
+TEST(TestSigned, Bitwise_ops) {
+    Signed<8> a(-10);
+    Signed<8> b(-10);
+
+    auto and_result = a & b;
+    EXPECT_EQ(and_result, BitArray<8>("11110110"_b));
+}
+
+TEST(TestSigned, const_udl) {
+    static_assert(std::is_same_v<decltype(s8(0)), Signed<8>>);
+    static_assert(std::is_same_v<decltype(s16(0)), Signed<16>>);
+    static_assert(std::is_same_v<decltype(s32(0)), Signed<32>>);
+    static_assert(std::is_same_v<decltype(s64(0)), Signed<64>>);
+
+    static_assert(static_cast<int>(s8(-128)) == -128);
+    static_assert(static_cast<int>(s8(127)) == 127);
+    static_assert(static_cast<int>(s8(-5)) == -5);
+
+    static_assert(static_cast<int>(s16(-32768)) == -32768);
+    static_assert(static_cast<int>(s16(32767)) == 32767);
+
+    static_assert(static_cast<long long>(s32(-2147483648LL)) == -2147483648LL);
+    static_assert(static_cast<long long>(s32(2147483647LL)) == 2147483647LL);
+
+    static_assert(
+        static_cast<long long>(s64(-9223372036854775807LL - 1))
+        == -9223372036854775807LL - 1
+    );
+    static_assert(
+        static_cast<long long>(s64(9223372036854775807LL)) == 9223372036854775807LL
+    );
+
+    static_assert(s8(-42) == s8(-42));
+    static_assert(s16(1024) == s16(1024));
+}
+
+TEST(TestSigned, Formatter) {
+    Signed<10> small(-102);
+
+    EXPECT_EQ(std::format("{:b}", small), "Signed[9 downto 0]{1110011010}");
+
+    EXPECT_EQ(std::format("{}", small), "Signed[9 downto 0]{-102}");
+
+    EXPECT_EQ(std::format("{:o}", small), "Signed[9 downto 0]{1632}");
+
+    EXPECT_EQ(std::format("{:x}", small), "Signed[9 downto 0]{39a}");
+}
+
+TEST(TestSigned, HashDeterminism) {
+    Signed<10> a(-102);
+    Signed<10> b(-102);
+
+    std::hash<Signed<10>> hasher;
+
+    EXPECT_EQ(hasher(a), hasher(a));
+    EXPECT_EQ(hasher(a), hasher(b));
+}
+
+TEST(TestSigned, HashCollisionResistance) {
+    Signed<10> val1(-102);
+    Signed<10> val2(-103);
+
+    std::hash<Signed<10>> hasher10;
+
+    EXPECT_NE(hasher10(val1), hasher10(val2));
+
+    Signed<20> val3(-102);
+    std::hash<Signed<20>> hasher20;
+
+    EXPECT_NE(hasher10(val1), hasher20(val3));
+}
+
+TEST(TestSigned, HashUnorderedSetIntegration) {
+    std::unordered_set<Signed<10>> hash_set;
+
+    Signed<10> a(-10);
+    Signed<10> b(20);
+    Signed<10> a_copy(-10);
+
+    hash_set.insert(a);
+    hash_set.insert(b);
+    hash_set.insert(a_copy);
+
+    EXPECT_EQ(hash_set.size(), 2);
+
+    EXPECT_TRUE(hash_set.find(a) != hash_set.end());
+    EXPECT_TRUE(hash_set.find(b) != hash_set.end());
+
+    Signed<10> c(-30);
+    EXPECT_TRUE(hash_set.find(c) == hash_set.end());
+}
+
+TEST(TestSigned, unary_ops) {
+    Signed<8> a(-100);
+
+    auto neg_a = -a;
+    static_assert(std::is_same_v<decltype(neg_a), Signed<9>>);
+    EXPECT_EQ(static_cast<int>(neg_a), 100);
+
+    Signed<4> b(5);
+    auto neg_b = -b;
+    static_assert(std::is_same_v<decltype(neg_b), Signed<5>>);
+    EXPECT_EQ(static_cast<int>(neg_b), -5);
+
+    auto pos_a = +a;
+    static_assert(std::is_same_v<decltype(pos_a), Signed<8>>);
+    EXPECT_EQ(static_cast<int>(pos_a), -100);
+
+    auto abs_a = abs(a);
+    static_assert(std::is_same_v<decltype(abs_a), Signed<9>>);
+    EXPECT_EQ(static_cast<int>(abs_a), 100);
+}

--- a/tests/cpp/test_unsigned.cpp
+++ b/tests/cpp/test_unsigned.cpp
@@ -1,0 +1,491 @@
+// LCOV_EXCL_BR_START -- gtest macros generate noisy uncovered branches
+#include <gtest/gtest.h>
+
+#include <coconext/types.hpp>
+#include <cstdint>
+#include <format>
+#include <stdexcept>
+#include <type_traits>
+#include <unordered_set>
+
+using namespace coconext::types;
+
+TEST(TestUnsigned, Constructors) {
+    static_assert(!std::is_convertible_v<int, Unsigned<6>>);
+
+    Unsigned<4> a(15);
+    EXPECT_EQ(static_cast<uint8_t>(a), 15U);
+    EXPECT_EQ(a.size(), 4U);
+
+    EXPECT_THROW(Unsigned<4>(16), std::out_of_range);
+    EXPECT_THROW(Unsigned<4>(-1), std::out_of_range);
+
+    Unsigned<8> large_val(200);
+    Unsigned<8> small_val(10);
+
+    Unsigned<4> narrow_fit(small_val);
+    EXPECT_EQ(static_cast<uint8_t>(narrow_fit), 10U);
+
+    EXPECT_THROW(Unsigned<4> narrow_fail(large_val), std::out_of_range);
+
+    BitArray<5> arr_a({'0'_b, '1'_b, '0'_b, '0'_b, '1'_b});
+    Unsigned<5> u_arr_a(arr_a);
+    EXPECT_EQ(static_cast<uint32_t>(u_arr_a), 9U);
+
+    Unsigned<5> arr_a_exp("01001"_b);
+    EXPECT_EQ(u_arr_a, arr_a_exp);
+
+    Signed<20> s(2000);
+    Unsigned<20> u(s);
+
+    EXPECT_EQ(static_cast<uint32_t>(u), 2000U);
+}
+
+TEST(TestUnsigned, ImplicitBitArrayConversion) {
+    Unsigned<6> a(31);
+    BitArray<5, 0> b = a;
+
+    EXPECT_EQ(b[0], '1'_b);
+    EXPECT_EQ(b[4], '1'_b);
+    EXPECT_EQ(b[5], '0'_b);
+}
+
+TEST(TestUnsigned, ExplicitNativeCasts) {
+    Unsigned<16> a(42000);
+
+    EXPECT_TRUE(static_cast<bool>(a));
+    EXPECT_FALSE(static_cast<bool>(Unsigned<16>(0)));
+
+    EXPECT_EQ(static_cast<int>(a), 42000);
+    EXPECT_EQ(static_cast<unsigned int>(a), 42000U);
+    EXPECT_EQ(static_cast<long long>(a), 42000LL);
+    EXPECT_EQ(static_cast<unsigned long long>(a), 42000ULL);
+
+    Unsigned<4> b(10);
+    EXPECT_EQ(static_cast<unsigned char>(b), 10);
+    EXPECT_EQ(static_cast<signed char>(b), 10);
+}
+
+TEST(TestUnsigned, ArithmeticOperators) {
+    Unsigned<8> a(150);
+    Unsigned<8> b(50);
+
+    auto sum = a + b;
+    static_assert(std::is_same_v<decltype(sum), Unsigned<9>>);
+    EXPECT_EQ(static_cast<int>(sum), 200);
+
+    auto prod = a * b;
+    static_assert(std::is_same_v<decltype(prod), Unsigned<16>>);
+    EXPECT_EQ(static_cast<int>(prod), 7500);
+
+    auto div = a / b;
+    EXPECT_EQ(static_cast<int>(div), 3);
+
+    auto mod = a % Unsigned<4>(7);
+    EXPECT_EQ(static_cast<int>(mod), 150 % 7);
+
+    EXPECT_THROW(a / Unsigned<4>(0), std::domain_error);
+    EXPECT_THROW(a % Unsigned<8>(0), std::domain_error);
+
+    auto sub_pos = a - b;
+    auto sub_neg = b - a;
+    static_assert(std::is_same_v<decltype(sub_pos), Signed<9>>);
+    static_assert(std::is_same_v<decltype(sub_neg), Signed<9>>);
+    EXPECT_EQ(static_cast<int16_t>(sub_pos), 100);
+    EXPECT_EQ(static_cast<int16_t>(sub_neg), -100);
+}
+
+TEST(UnsignedMixedSignednessTest, CompoundAssignmentOperators) {
+    auto u1 = u8(15);
+    u1 += s8(-5);
+    EXPECT_EQ(u1, u8(10));
+
+    auto u2 = u8(250);
+    u2 += s8(10);
+    EXPECT_EQ(u2, u8(4));
+
+    auto u3 = u8(5);
+    u3 -= s8(10);
+    EXPECT_EQ(u3, u8(251));
+
+    auto u4 = u8(10);
+    u4 *= s8(-3);
+    EXPECT_EQ(u4, u8(226));
+
+    auto u5 = u8(20);
+    u5 /= s8(-4);
+    EXPECT_EQ(u5, u8(251));
+
+    auto u6 = u8(23);
+    u6 %= s8(-7);
+    EXPECT_EQ(u6, u8(2));
+
+    auto u7 = u8(50);
+    EXPECT_THROW(u7 /= s8(0), std::domain_error);
+    EXPECT_THROW(u7 %= s8(0), std::domain_error);
+}
+
+TEST(TestUnsigned, as_overloads) {
+    BitArray<5> arr_a({'0'_b, '1'_b, '0'_b, '0'_b, '1'_b});
+
+    auto a = as<Unsigned<5>>(arr_a);
+    BitArray<4, 0> arr_exp = a;
+    static_assert(std::is_same_v<decltype(a), Unsigned<5>>);
+    EXPECT_EQ(static_cast<uint8_t>(a), 9U);  // explicit conversion to int
+    EXPECT_EQ(arr_a, arr_exp);
+
+    Unsigned<5> a1;
+    a1 = as(arr_a);
+    BitArray<4, 0> arr_exp_a1 = a1;
+    EXPECT_EQ(static_cast<uint8_t>(a1), 9U);
+    EXPECT_EQ(arr_a, arr_exp_a1);
+}
+
+TEST(TestUnsigned, resize_overloads) {
+    Unsigned<8> small(200);
+
+    auto wide_spelled = resize<16>(small);
+    static_assert(std::is_same_v<decltype(wide_spelled), Unsigned<16>>);
+    EXPECT_EQ(static_cast<uint16_t>(wide_spelled), 200U);
+
+    Unsigned<16> wide_deduced;
+    wide_deduced = resize(small);
+    EXPECT_EQ(static_cast<uint16_t>(wide_deduced), 200U);
+
+    Unsigned<16> wide(1000);
+
+    auto narrow_wrap_spelled = resize<8>(wide);
+    static_assert(std::is_same_v<decltype(narrow_wrap_spelled), Unsigned<8>>);
+    EXPECT_EQ(static_cast<uint8_t>(narrow_wrap_spelled), 232U);
+
+    Unsigned<8> narrow_wrap_deduced;
+    narrow_wrap_deduced = resize(wide);
+    EXPECT_EQ(static_cast<uint8_t>(narrow_wrap_deduced), 232U);
+
+    auto narrow_sat_spelled = resize<8>(wide, overflow_mode::saturate);
+    EXPECT_EQ(static_cast<uint8_t>(narrow_sat_spelled), 255U);
+
+    Unsigned<8> narrow_sat_deduced;
+    narrow_sat_deduced = resize(wide, overflow_mode::saturate);
+    EXPECT_EQ(static_cast<uint8_t>(narrow_sat_deduced), 255U);
+
+    Unsigned<8> copy_init_deduced = resize(wide, overflow_mode::saturate);
+    EXPECT_EQ(static_cast<uint8_t>(copy_init_deduced), 255U);
+}
+
+TEST(TestUnsigned, Comparisons) {
+    Unsigned<8> a(10);
+    Unsigned<8> b(10);
+    Unsigned<8> c(20);
+    Unsigned<8> d(5);
+
+    EXPECT_TRUE(a == b);
+    EXPECT_FALSE(a == c);
+
+    EXPECT_TRUE(a != c);
+    EXPECT_FALSE(a != b);
+
+    EXPECT_TRUE(d < a);
+    EXPECT_FALSE(a < d);
+    EXPECT_FALSE(a < b);
+
+    EXPECT_TRUE(d <= a);
+    EXPECT_TRUE(a <= b);
+    EXPECT_FALSE(c <= a);
+
+    EXPECT_TRUE(c > a);
+    EXPECT_FALSE(a > c);
+    EXPECT_FALSE(a > b);
+
+    EXPECT_TRUE(c >= a);
+    EXPECT_TRUE(a >= b);
+    EXPECT_FALSE(d >= a);
+}
+
+TEST(TestUnsigned, CompoundAssignment) {
+    Unsigned<8> a(10);
+    Unsigned<4> b(5);
+
+    a += b;
+    EXPECT_EQ(static_cast<int>(a), 15);
+
+    a -= Unsigned<8>(3);
+    EXPECT_EQ(static_cast<int>(a), 12);
+
+    a *= Unsigned<2>(2);
+    EXPECT_EQ(static_cast<int>(a), 24);
+
+    a /= Unsigned<4>(4);
+    EXPECT_EQ(static_cast<int>(a), 6);
+
+    a %= Unsigned<4>(4);
+    EXPECT_EQ(static_cast<int>(a), 2);
+
+    a += 10;
+    EXPECT_EQ(static_cast<int>(a), 12);
+
+    EXPECT_THROW(a /= 0, std::domain_error);
+}
+
+TEST(TestUnsigned, IncrementDecrement) {
+    Unsigned<8> a(10);
+
+    EXPECT_EQ(static_cast<int>(++a), 11);
+    EXPECT_EQ(static_cast<int>(a), 11);
+
+    EXPECT_EQ(static_cast<int>(--a), 10);
+    EXPECT_EQ(static_cast<int>(a), 10);
+
+    EXPECT_EQ(static_cast<int>(a++), 10);
+    EXPECT_EQ(static_cast<int>(a), 11);
+
+    EXPECT_EQ(static_cast<int>(a--), 11);
+    EXPECT_EQ(static_cast<int>(a), 10);
+
+    Unsigned<4> max_val(15);
+    max_val++;
+    EXPECT_EQ(static_cast<int>(max_val), 0);
+
+    Unsigned<4> min_val(0);
+    min_val--;
+    EXPECT_EQ(static_cast<int>(min_val), 15);
+}
+
+TEST(TestUnsigned, ShiftOperators) {
+    Unsigned<8> a(5);
+
+    auto sl = a << 2;
+    EXPECT_EQ(static_cast<int>(sl), 20);
+
+    auto sr = a >> 1;
+    EXPECT_EQ(static_cast<int>(sr), 2);
+
+    EXPECT_EQ(static_cast<int>(a << 8), 0);
+    EXPECT_EQ(static_cast<int>(a >> 10), 0);
+
+    a <<= 3;
+    EXPECT_EQ(static_cast<int>(a), 40);
+    a >>= 2;
+    EXPECT_EQ(static_cast<int>(a), 10);
+
+    EXPECT_THROW(a << -1, std::invalid_argument);
+    EXPECT_THROW(a >> -2, std::invalid_argument);
+
+    Unsigned<4> shift_amt(2);
+    EXPECT_EQ(static_cast<int>(a << shift_amt), 40);
+}
+
+TEST(TestUnsigned, Iterators) {
+    Unsigned<4> a(8);  // 1000
+
+    std::vector<int> bit_vals;
+    for (auto bit : a) {
+        bit_vals.push_back(static_cast<bool>(bit) ? 1 : 0);
+    }
+
+    EXPECT_EQ(bit_vals.size(), 4);
+    EXPECT_EQ(bit_vals[0], 1);
+    EXPECT_EQ(bit_vals[1], 0);
+    EXPECT_EQ(bit_vals[2], 0);
+    EXPECT_EQ(bit_vals[3], 0);
+
+    std::vector<int> rbit_vals;
+    for (auto rit = a.rbegin(); rit != a.rend(); ++rit) {
+        rbit_vals.push_back(static_cast<bool>(*rit) ? 1 : 0);
+    }
+
+    std::vector<int> expected_rvals = {0, 0, 0, 1};
+    EXPECT_EQ(rbit_vals, expected_rvals);
+
+    std::reverse(rbit_vals.begin(), rbit_vals.end());
+    EXPECT_EQ(rbit_vals, bit_vals);
+
+    auto it = a.begin();
+    EXPECT_EQ(static_cast<bool>(*(it + 1)), false);
+    EXPECT_EQ(static_cast<bool>(it[0]), true);
+}
+
+TEST(TestUnsigned, index_operator) {
+    Unsigned<4> a(2);  // 0010
+
+    EXPECT_FALSE(static_cast<bool>(a[3]));
+    EXPECT_FALSE(static_cast<bool>(a[2]));
+    EXPECT_TRUE(static_cast<bool>(a[1]));
+    EXPECT_FALSE(static_cast<bool>(a[0]));
+
+    EXPECT_THROW(a[4], std::out_of_range);
+}
+
+TEST(TestUnsigned, index) {
+    Unsigned<4> a(6);  // 0110
+
+    EXPECT_FALSE(static_cast<bool>(a.index<3>()));
+    EXPECT_TRUE(static_cast<bool>(a.index<2>()));
+    EXPECT_TRUE(static_cast<bool>(a.index<1>()));
+    EXPECT_FALSE(static_cast<bool>(a.index<0>()));
+
+    EXPECT_EQ(static_cast<int>(a.index<3>()), 0);
+    EXPECT_EQ(static_cast<int>(a.index<1>()), 1);
+}
+
+TEST(TestUnsigned, Bitwise_ops) {
+    // test if Unsigned support Bitwise operations via
+    // LogicArrayType and RangedSequence
+    Unsigned<8> a(10);
+    Unsigned<8> b(10);
+
+    auto and_result = a & b;
+    EXPECT_EQ(and_result, BitArray<8>("00001010"_b));
+}
+
+TEST(TestUnsigned, const_udl) {
+    static_assert(std::is_same_v<decltype(u8(0)), Unsigned<8>>, "u8 type mismatch");
+    static_assert(std::is_same_v<decltype(u16(0)), Unsigned<16>>, "u16 type mismatch");
+    static_assert(std::is_same_v<decltype(u32(0)), Unsigned<32>>, "u32 type mismatch");
+    static_assert(std::is_same_v<decltype(u64(0)), Unsigned<64>>, "u64 type mismatch");
+
+    static_assert(static_cast<int>(u8(0)) == 0, "u8 min value failed");
+    static_assert(static_cast<int>(u8(5)) == 5, "u8 mid value failed");
+    static_assert(static_cast<int>(u8(255)) == 255, "u8 max value failed");
+
+    static_assert(static_cast<int>(u16(0)) == 0, "u16 min value failed");
+    static_assert(static_cast<int>(u16(65535)) == 65535, "u16 max value failed");
+
+    static_assert(static_cast<long long>(u32(0)) == 0, "u32 min value failed");
+    static_assert(
+        static_cast<long long>(u32(4294967295ULL)) == 4294967295ULL, "u32 max value failed"
+    );
+
+    static_assert(static_cast<unsigned long long>(u64(0)) == 0ULL, "u64 min value failed");
+    static_assert(
+        static_cast<unsigned long long>(u64(18446744073709551615ULL))
+            == 18446744073709551615ULL,
+        "u64 max value failed"
+    );
+
+    static_assert(u8(42) == u8(42), "u8 equality failed");
+    static_assert(u16(1024) == u16(1024), "u16 equality failed");
+}
+
+TEST(TestUnsigned, Formatter) {
+    Unsigned<10> small(102);
+    Unsigned<39> mid(0x0AFFFE9001);
+    Unsigned<139> very_large(0x0AFFFE90010AFFFE);
+    Unsigned<139> chunk1(0x0AFFFE9001);  // Top 40 bits
+    Unsigned<139> chunk2(0x0AFFFE9001);  // Next 40 bits
+    Unsigned<139> chunk3(0x0AFFFE9001);  // Next 40 bits
+    Unsigned<139> chunk4(0xFFFFF);       // Bottom 20 bits
+
+    very_large = as<Unsigned<139>>(
+        as<Unsigned<139>>(as<Unsigned<139>>(chunk1 << 100 | chunk2 << 60) | chunk3 << 20)
+        | chunk4
+    );
+
+    EXPECT_EQ(std::format("{:b}", small), "Unsigned[9 downto 0]{0001100110}");
+    EXPECT_EQ(
+        std::format("{:b}", mid),
+        "Unsigned[38 downto 0]{000101011111111111111101001000000000001}"
+    );
+    EXPECT_EQ(
+        std::format("{:b}", very_large),
+        "Unsigned[138 downto "
+        "0]{"
+        "0001010111111111111111010010000000000010000101011111111111111101001000000000001000"
+        "010101111111111111110100100000000000111111111111111111111}"
+    );
+
+    EXPECT_EQ(std::format("{}", small), "Unsigned[9 downto 0]{102}");
+    EXPECT_EQ(std::format("{}", mid), "Unsigned[38 downto 0]{47244546049}");
+    EXPECT_EQ(
+        std::format("{}", very_large),
+        "Unsigned[138 downto 0]{59889577156579543121862034195167783682047}"
+    );
+
+    EXPECT_EQ(std::format("{:o}", small), "Unsigned[9 downto 0]{0146}");
+    EXPECT_EQ(std::format("{:o}", mid), "Unsigned[38 downto 0]{0537777510001}");
+    EXPECT_EQ(
+        std::format("{:o}", very_large),
+        "Unsigned[138 downto 0]{01277777220002053777751000102577776440007777777}"
+    );
+
+    EXPECT_EQ(std::format("{:x}", small), "Unsigned[9 downto 0]{066}");
+    EXPECT_EQ(std::format("{:x}", mid), "Unsigned[38 downto 0]{0afffe9001}");
+    EXPECT_EQ(
+        std::format("{:x}", very_large),
+        "Unsigned[138 downto 0]{0afffe90010afffe90010afffe9001fffff}"
+    );
+}
+
+TEST(TestUnsigned, HashDeterminism) {
+    Unsigned<10> a(102);
+    Unsigned<10> b(102);
+
+    std::hash<Unsigned<10>> hasher;
+
+    EXPECT_EQ(hasher(a), hasher(a));
+
+    EXPECT_EQ(hasher(a), hasher(b));
+}
+
+TEST(TestUnsigned, HashCollisionResistance) {
+    Unsigned<10> val1(102);
+    Unsigned<10> val2(103);
+
+    std::hash<Unsigned<10>> hasher10;
+
+    EXPECT_NE(hasher10(val1), hasher10(val2));
+
+    Unsigned<20> val3(102);
+    std::hash<Unsigned<20>> hasher20;
+
+    EXPECT_NE(hasher10(val1), hasher20(val3));
+}
+
+TEST(TestUnsigned, HashUnorderedSetIntegration) {
+    std::unordered_set<Unsigned<10>> hash_set;
+
+    Unsigned<10> a(10);
+    Unsigned<10> b(20);
+    Unsigned<10> a_copy(10);
+
+    hash_set.insert(a);
+    hash_set.insert(b);
+
+    hash_set.insert(a_copy);
+
+    EXPECT_EQ(hash_set.size(), 2);
+
+    EXPECT_TRUE(hash_set.find(a) != hash_set.end());
+    EXPECT_TRUE(hash_set.find(b) != hash_set.end());
+
+    Unsigned<10> c(30);
+    EXPECT_TRUE(hash_set.find(c) == hash_set.end());
+}
+
+TEST(TestUnsigned, unary_ops) {
+    Unsigned<8> a(150);
+
+    auto neg_a = -a;
+    static_assert(
+        std::is_same_v<decltype(neg_a), Signed<9>>,
+        "Unary minus should promote to Signed<W+1>"
+    );
+    EXPECT_EQ(static_cast<int>(neg_a), -150);
+
+    Unsigned<4> b(5);
+    auto neg_b = -b;
+    static_assert(
+        std::is_same_v<decltype(neg_b), Signed<5>>,
+        "Unary minus should promote to Signed<W+1>"
+    );
+    EXPECT_EQ(static_cast<int>(neg_b), -5);
+
+    auto pos_a = +a;
+    static_assert(
+        std::is_same_v<decltype(pos_a), Signed<9>>,
+        "Unary plus should promote to Signed<W+1>"
+    );
+    EXPECT_EQ(static_cast<int>(pos_a), 150);
+}
+
+// LCOV_EXCL_BR_STOP


### PR DESCRIPTION
Closes #191.

These are useful for implementing a bunch of features currently found in cocotb's `LogicArray` (e.g. `from_unsigned`, `to_unsigned`) that we for binding coconext's `DynLogicArray` to Python in a way it can sit in place of cocotb's using the patcher.

This just uses `uint64_t` and `int64_t`. We will adapt `UInt`, and `SInt` from #278 once it's done.