### PR TITLE
Add clang-tidy lint

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,4 @@
+Checks: >
+  -*,
+  misc-include-cleaner
+HeaderFilterRegex: '(cpp|nanobind)/include/'

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -1,0 +1,41 @@
+name: clang-tidy
+
+on:
+  push:
+    branches:
+    - dev
+    paths-ignore:
+    - 'docs/dev/**'
+  pull_request:
+    branches:
+    - dev
+    paths-ignore:
+    - 'docs/dev/**'
+
+jobs:
+  clang-tidy:
+    name: clang-tidy
+    runs-on: ubuntu-24.04
+
+    steps:
+    - uses: actions/checkout@v6.0.2
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v8.1.0
+      with:
+        activate-environment: "true"
+
+    - name: Install build and analysis dependencies
+      run: |
+        sudo apt install -y make libgtest-dev clang-tidy
+
+    - name: Build and run clang-tidy
+      env:
+        DEV_BUILD_DEP_GROUP: dev_tests
+      run: |
+        make clang_tidy
+
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !contains(github.ref, 'dev') }}

--- a/Makefile
+++ b/Makefile
@@ -72,3 +72,12 @@ docs:
 	uv sync --dev --no-install-project
 	sphinx-build docs/ '$(DOCS_OUTDIR)/' --color -b html
 	@echo "Documentation built at $(DOCS_OUTDIR)/index.html"
+
+# This default assumes you are running on a system where run-clang-tidy is fairly new.
+# We require clang-tidy 18 at a minimum to support misc-include-cleaner.
+# you may need to set it to run-clang-tidy-18 or similar.
+RUN_CLANG_TIDY_EXECUTABLE ?= run-clang-tidy
+
+.PHONY: clang_tidy
+clang_tidy: dev_build
+	$(RUN_CLANG_TIDY_EXECUTABLE) -p . -warnings-as-errors='*' -quiet 'coconext/(cpp|nanobind)/src/'

--- a/cpp/src/logic.cpp
+++ b/cpp/src/logic.cpp
@@ -1,6 +1,6 @@
-#include <coconext/random.hpp>
 #include <coconext/types/logic.hpp>
 #include <random>
+#include <stdexcept>
 
 #include "./random.hpp"
 

--- a/nanobind/src/bind.cpp
+++ b/nanobind/src/bind.cpp
@@ -1,10 +1,6 @@
 #include <nanobind/nanobind.h>
 
-#include <coconext/types/concepts.hpp>
-
 namespace nb = nanobind;
-
-using namespace coconext::types;
 
 void register_logic(nb::module_& m);
 void register_range(nb::module_& m);

--- a/nanobind/src/types/bind_logic.cpp
+++ b/nanobind/src/types/bind_logic.cpp
@@ -1,11 +1,11 @@
 #include <nanobind/nanobind.h>
-#include <nanobind/operators.h>        // Required for operator overloading
-#include <nanobind/stl/string.h>       // Required for std::string conversions
-#include <nanobind/stl/string_view.h>  // Required for std::string_view conversions
+#include <nanobind/stl/string.h>       // IWYU pragma: keep -- std::string caster
+#include <nanobind/stl/string_view.h>  // IWYU pragma: keep -- std::string_view caster
 
-#include <coconext/types/concepts.hpp>
 #include <coconext/types/logic.hpp>
-#include <type_traits>
+#include <stdexcept>
+#include <string>
+#include <string_view>
 
 namespace nb = nanobind;
 using namespace nb::literals;

--- a/nanobind/src/types/bind_range.cpp
+++ b/nanobind/src/types/bind_range.cpp
@@ -1,13 +1,17 @@
-#include <nanobind/make_iterator.h>  // Required for making iterators
 #include <nanobind/nanobind.h>
 #include <nanobind/operators.h>        // Required for operator overloading
-#include <nanobind/stl/string.h>       // Required for std::string conversions
-#include <nanobind/stl/string_view.h>  // Required for std::string_view conversions
+#include <nanobind/stl/string.h>       // IWYU pragma: keep -- std::string caster
+#include <nanobind/stl/string_view.h>  // IWYU pragma: keep -- std::string_view caster
 
-#include <coconext/types/concepts.hpp>
+#include <algorithm>
+#include <coconext/types/direction.hpp>
 #include <coconext/types/range.hpp>
+#include <cstddef>
 #include <cstdint>
 #include <format>
+#include <iterator>
+#include <stdexcept>
+#include <string_view>
 
 namespace nb = nanobind;
 using namespace nb::literals;


### PR DESCRIPTION
This just checks includes since I've noticed we have some stale ones.