### PR TITLE
Update Codecov action to version 7.0.0

### DIFF
--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         if: github.repository == 'ktbarrett/coconext' && inputs.collect_coverage
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7.0.0
         with:
           disable_search: true
           plugins: noop


### PR DESCRIPTION
Their tags are broken. We are already on 7.0.