### PR TITLE
Overhaul Logic resolve() and is_resolvable()

### DIFF
--- a/cpp/include/coconext/types/logic.hpp
+++ b/cpp/include/coconext/types/logic.hpp
@@ -18,6 +18,19 @@ enum class ResolveMethod {
     RANDOM,
 };
 
+// Process-wide default ResolveMethod used by the no-arg `resolve()` /
+// `is_resolvable()` overloads on Logic and arrays of Logic. Defaults to WEAK
+// (so weak strengths L/H resolve to strong 0/1 but X/Z/U/W/- still throw).
+//
+// Intended to be set once per test/regression in a single-threaded region.
+// Not synchronized -- if you mutate this from multiple threads concurrently,
+// or while resolve() calls are in flight on other threads, behavior is
+// undefined.
+ResolveMethod get_default_resolve_method() noexcept;
+void set_default_resolve_method(ResolveMethod method) noexcept;
+
+class Bit;
+
 class Logic {
   public:
     enum class value_type : uint8_t {
@@ -37,11 +50,17 @@ class Logic {
     constexpr Logic(value_type value) noexcept : value_(value) {}
     constexpr value_type value() const noexcept { return value_; }
 
-    constexpr bool is_resolvable() const noexcept {
-        return value_ == _0 || value_ == _1 || value_ == L || value_ == H;
+    // True iff `resolve(method)` would succeed (NOT throw) for the current
+    // value. ERROR accepts only 0/1; WEAK additionally accepts L/H; ZEROS,
+    // ONES, RANDOM accept anything.
+    bool is_resolvable(ResolveMethod method) const noexcept;
+    // No-arg form uses the global default.
+    bool is_resolvable() const noexcept {
+        return is_resolvable(get_default_resolve_method());
     }
 
-    Logic resolve(ResolveMethod method) const;
+    Bit resolve(ResolveMethod method) const;
+    Bit resolve() const;  // uses global default; defined after Bit is complete
 
   private:
     value_type value_ = _0;
@@ -59,9 +78,12 @@ class Bit {
     constexpr Bit(value_type value) noexcept : value_(value) {}
     constexpr value_type value() const noexcept { return value_; }
 
+    // Bit's domain is {0, 1} -- every value is resolvable under every method.
+    constexpr bool is_resolvable(ResolveMethod) const noexcept { return true; }
     constexpr bool is_resolvable() const noexcept { return true; }
 
     constexpr Bit resolve(ResolveMethod) const noexcept { return *this; }
+    constexpr Bit resolve() const noexcept { return *this; }
 
     // Implicit conversion from Bit to Logic mimics subtype upcasting.
     constexpr operator Logic() const noexcept {
@@ -79,6 +101,10 @@ class Bit {
   private:
     value_type value_ = _0;
 };
+
+// Out-of-line because Bit's return type was incomplete at the inline-body
+// position in Logic.
+inline Bit Logic::resolve() const { return resolve(get_default_resolve_method()); }
 
 constexpr bool operator==(Logic const& lhs, Logic const& rhs) noexcept {
     return lhs.value() == rhs.value();

--- a/cpp/include/coconext/types/logic_array.hpp
+++ b/cpp/include/coconext/types/logic_array.hpp
@@ -84,40 +84,49 @@ constexpr Range make_logic_static_range() {
 // so `Array<int, R>::is_resolvable()` and friends don't exist.
 template <typename Self>
 struct LogicArrayMixin {
-    bool is_resolvable() const noexcept {
+    bool is_resolvable(ResolveMethod method) const noexcept {
         auto const& self = *static_cast<Self const*>(this);
         using Elem = std::ranges::range_value_t<Self>;
         if constexpr (std::same_as<Elem, Bit>) {
-            // Every Bit is resolvable; skip the walk.
+            // Every Bit is resolvable under every method; skip the walk.
             return true;
         } else {
-            return std::ranges::all_of(self, [](auto const& v) {
-                return v.is_resolvable();
+            return std::ranges::all_of(self, [method](auto const& v) {
+                return v.is_resolvable(method);
             });
         }
     }
+    bool is_resolvable() const noexcept {
+        return is_resolvable(get_default_resolve_method());
+    }
 
-    // Element-wise resolve. Returns a static `Array<Elem, R>` when Self has a
-    // compile-time range, a heap-allocated `Vector<Elem>` otherwise. The
-    // returned array preserves Self's range (an owner returns the same shape;
-    // a slice returns an owner sized like the slice's range).
+    // Element-wise resolve. Returns a static `BitArray<R>` when Self has a
+    // compile-time range, a heap-allocated `BitVector` otherwise. The returned
+    // array preserves Self's range (an owner returns the same shape; a slice
+    // returns an owner sized like the slice's range).
     auto resolve(ResolveMethod method) const {
         auto const& self = *static_cast<Self const*>(this);
-        using Elem = std::ranges::range_value_t<Self>;
+        // `BitElem` is dependent on Self via `std::conditional`, which defers
+        // lookup of the Vector<Bit> / Array<Bit, ...> specializations to
+        // instantiation time. Without this trick the compiler would look up
+        // Vector<Bit> at template-parse time, find the primary template, and
+        // then complain when the specialization is seen later in the file.
+        using BitElem = std::conditional_t<true, Bit, Self>;
         if constexpr (StaticRangedSequence<Self>) {
-            ::coconext::types::Array<Elem, Self::static_range> result{};
+            ::coconext::types::Array<BitElem, Self::static_range> result{};
             std::ranges::transform(self, result.begin(), [method](auto const& v) {
                 return v.resolve(method);
             });
             return result;
         } else {
-            ::coconext::types::Vector<Elem> result(self.range());
+            ::coconext::types::Vector<BitElem> result(self.range());
             std::ranges::transform(self, result.begin(), [method](auto const& v) {
                 return v.resolve(method);
             });
             return result;
         }
     }
+    auto resolve() const { return resolve(get_default_resolve_method()); }
 
     // Reductions: fold over the array with the corresponding bitwise op.
     // Empty arrays return the operation's identity (1 for AND, 0 for OR/XOR),

--- a/cpp/src/logic.cpp
+++ b/cpp/src/logic.cpp
@@ -1,6 +1,7 @@
 #include <coconext/types/logic.hpp>
 #include <random>
 #include <stdexcept>
+#include <string>
 
 #include "./random.hpp"
 
@@ -8,72 +9,100 @@ using namespace coconext::types;
 
 namespace coconext::types {
 
-Logic Logic::resolve(ResolveMethod method) const {
+namespace {
+
+// Process-wide default. Single-threaded mutation is the expected usage pattern
+// (set once per test or regression); not synchronized.
+ResolveMethod g_default_resolve_method = ResolveMethod::WEAK;
+
+}  // namespace
+
+ResolveMethod get_default_resolve_method() noexcept { return g_default_resolve_method; }
+
+void set_default_resolve_method(ResolveMethod method) noexcept {
+    g_default_resolve_method = method;
+}
+
+bool Logic::is_resolvable(ResolveMethod method) const noexcept {
+    switch (method) {
+    case ResolveMethod::ERROR:
+        return value_ == _0 || value_ == _1;
+    case ResolveMethod::WEAK:
+        return value_ == _0 || value_ == _1 || value_ == L || value_ == H;
+    case ResolveMethod::ZEROS:
+    case ResolveMethod::ONES:
+    case ResolveMethod::RANDOM:
+        return true;
+    }
+    return false;
+}
+
+Bit Logic::resolve(ResolveMethod method) const {
     switch (method) {
     case ResolveMethod::ERROR:
         switch (value_) {
         case _0:
+            return Bit::_0;
         case _1:
-            return *this;
+            return Bit::_1;
         default:
-            throw std::invalid_argument("Logic value is not resolvable");
+            throw std::invalid_argument(
+                "Logic value '" + std::string(to_string(*this))
+                + "' is not resolvable under ERROR"
+            );
         }
     case ResolveMethod::WEAK:
         switch (value_) {
         case _0:
-        case _1:
-            return *this;
         case L:
-            return _0;
+            return Bit::_0;
+        case _1:
         case H:
-            return _1;
-        case W:
-            return X;
+            return Bit::_1;
         default:
-            return *this;
+            throw std::invalid_argument(
+                "Logic value '" + std::string(to_string(*this))
+                + "' is not resolvable under WEAK"
+            );
         }
     case ResolveMethod::ZEROS:
         switch (value_) {
         case _0:
-        case _1:
-            return *this;
         case L:
-            return _0;
+            return Bit::_0;
+        case _1:
         case H:
-            return _1;
+            return Bit::_1;
         default:
-            return _0;
+            return Bit::_0;
         }
     case ResolveMethod::ONES:
         switch (value_) {
         case _0:
-        case _1:
-            return *this;
         case L:
-            return _0;
+            return Bit::_0;
+        case _1:
         case H:
-            return _1;
+            return Bit::_1;
         default:
-            return _1;
+            return Bit::_1;
         }
     case ResolveMethod::RANDOM: {
         switch (value_) {
         case _0:
-        case _1:
-            return *this;
         case L:
-            return _0;
+            return Bit::_0;
+        case _1:
         case H:
-            return _1;
+            return Bit::_1;
         default: {
             auto& rng = get_rng();
-            return (rng() % 2 == 0) ? _0 : _1;
+            return (rng() % 2 == 0) ? Bit::_0 : Bit::_1;
         }
         }
     }
-    default:
-        throw std::invalid_argument("Unknown resolve method");
     }
+    throw std::invalid_argument("Unknown resolve method");
 }
 
 }  // namespace coconext::types

--- a/nanobind/src/types/bind_logic.cpp
+++ b/nanobind/src/types/bind_logic.cpp
@@ -126,14 +126,16 @@ void register_logic(nb::module_& m) {
         .def(
             "__invert__", [](Logic const& self) { return ~self; }, nb::is_operator()
         )
-        .def_prop_ro("is_resolvable", &Logic::is_resolvable)
+        .def_prop_ro(
+            "is_resolvable", [](Logic const& self) { return self.is_resolvable(); }
+        )
         .def(
             "resolve",
             [](Logic const& self, std::string_view method) {
                 return self.resolve(string_to_resolve_method(method));
             }
         )
-        .def("resolve", &Logic::resolve)
+        .def("resolve", [](Logic const& self) { return self.resolve(); })
         .def("__copy__", [](Logic const& self) { return Logic(self); })
         .def("__deepcopy__", [](Logic const& self, nb::dict /* memo */) {
             return Logic(self);
@@ -225,14 +227,14 @@ void register_logic(nb::module_& m) {
         .def(
             "__invert__", [](Bit const& self) { return ~self; }, nb::is_operator()
         )
-        .def_prop_ro("is_resolvable", &Bit::is_resolvable)
+        .def_prop_ro("is_resolvable", [](Bit const& self) { return self.is_resolvable(); })
         .def(
             "resolve",
             [](Bit const& self, std::string_view method) {
                 return self.resolve(string_to_resolve_method(method));
             }
         )
-        .def("resolve", &Bit::resolve)
+        .def("resolve", [](Bit const& self) { return self.resolve(); })
         .def("__copy__", [](Bit const& self) { return Bit(self); })
         .def("__deepcopy__", [](Bit const& self, nb::dict /* memo */) {
             return Bit(self);

--- a/tests/cpp/test_logic.cpp
+++ b/tests/cpp/test_logic.cpp
@@ -110,6 +110,57 @@ TEST(TestLogic, LogicBoolConversions) {
     EXPECT_EQ('-'_l.is_resolvable(), false);
 }
 
+TEST(TestLogic, LogicIsResolvableUnderEachMethod) {
+    // ERROR: only 0/1 are resolvable.
+    EXPECT_TRUE('0'_l.is_resolvable(ResolveMethod::ERROR));
+    EXPECT_TRUE('1'_l.is_resolvable(ResolveMethod::ERROR));
+    EXPECT_FALSE('L'_l.is_resolvable(ResolveMethod::ERROR));
+    EXPECT_FALSE('H'_l.is_resolvable(ResolveMethod::ERROR));
+    EXPECT_FALSE('X'_l.is_resolvable(ResolveMethod::ERROR));
+    EXPECT_FALSE('Z'_l.is_resolvable(ResolveMethod::ERROR));
+    EXPECT_FALSE('U'_l.is_resolvable(ResolveMethod::ERROR));
+    EXPECT_FALSE('W'_l.is_resolvable(ResolveMethod::ERROR));
+    EXPECT_FALSE('-'_l.is_resolvable(ResolveMethod::ERROR));
+
+    // WEAK: 0/1/L/H pass; metavalues (incl. W) do not.
+    EXPECT_TRUE('0'_l.is_resolvable(ResolveMethod::WEAK));
+    EXPECT_TRUE('1'_l.is_resolvable(ResolveMethod::WEAK));
+    EXPECT_TRUE('L'_l.is_resolvable(ResolveMethod::WEAK));
+    EXPECT_TRUE('H'_l.is_resolvable(ResolveMethod::WEAK));
+    EXPECT_FALSE('X'_l.is_resolvable(ResolveMethod::WEAK));
+    EXPECT_FALSE('Z'_l.is_resolvable(ResolveMethod::WEAK));
+    EXPECT_FALSE('U'_l.is_resolvable(ResolveMethod::WEAK));
+    EXPECT_FALSE('W'_l.is_resolvable(ResolveMethod::WEAK));
+    EXPECT_FALSE('-'_l.is_resolvable(ResolveMethod::WEAK));
+
+    // ZEROS / ONES / RANDOM: always resolvable (no value can throw).
+    for (auto m : {ResolveMethod::ZEROS, ResolveMethod::ONES, ResolveMethod::RANDOM}) {
+        EXPECT_TRUE('0'_l.is_resolvable(m));
+        EXPECT_TRUE('X'_l.is_resolvable(m));
+        EXPECT_TRUE('U'_l.is_resolvable(m));
+        EXPECT_TRUE('-'_l.is_resolvable(m));
+    }
+}
+
+TEST(TestLogic, GlobalDefaultResolveMethod) {
+    // Default is WEAK (preserves the pre-existing is_resolvable() semantics).
+    EXPECT_EQ(get_default_resolve_method(), ResolveMethod::WEAK);
+
+    // Setter/getter round-trips, no-arg resolve()/is_resolvable() follow it.
+    set_default_resolve_method(ResolveMethod::ERROR);
+    EXPECT_EQ(get_default_resolve_method(), ResolveMethod::ERROR);
+    EXPECT_TRUE('0'_l.is_resolvable());   // ERROR accepts 0
+    EXPECT_FALSE('L'_l.is_resolvable());  // ERROR does NOT accept L
+
+    set_default_resolve_method(ResolveMethod::ZEROS);
+    EXPECT_EQ(get_default_resolve_method(), ResolveMethod::ZEROS);
+    EXPECT_TRUE('X'_l.is_resolvable());  // ZEROS accepts everything
+    EXPECT_EQ('X'_l.resolve(), '0'_b);   // X resolves to 0 under ZEROS
+
+    // Restore so later tests run with the documented default.
+    set_default_resolve_method(ResolveMethod::WEAK);
+}
+
 TEST(TestBit, BitBoolConversions) {
     EXPECT_EQ('0'_b.is_resolvable(), true);
     EXPECT_EQ('1'_b.is_resolvable(), true);
@@ -224,66 +275,72 @@ TEST(TestBit, BitInvert) {
     EXPECT_EQ(~'1'_b, '0'_b);
 }
 
-// Test Logic resolve with different methods
+// Test Logic resolve with different methods. Logic::resolve(method) returns
+// Bit; methods throw when the value isn't representable as 0/1 under that
+// method's policy:
+//   ERROR: only 0/1 pass; throws on L/H/X/Z/U/W/-
+//   WEAK : 0/1/L/H pass (L->0, H->1); throws on X/Z/U/W/-
+//   ZEROS/ONES/RANDOM: never throw; metavalues map to 0, 1, or random
 TEST(TestLogic, LogicResolve) {
     // Test WEAK resolution
-    EXPECT_EQ('U'_l.resolve(ResolveMethod::WEAK), 'U'_l);
-    EXPECT_EQ('X'_l.resolve(ResolveMethod::WEAK), 'X'_l);
-    EXPECT_EQ('0'_l.resolve(ResolveMethod::WEAK), '0'_l);
-    EXPECT_EQ('1'_l.resolve(ResolveMethod::WEAK), '1'_l);
-    EXPECT_EQ('Z'_l.resolve(ResolveMethod::WEAK), 'Z'_l);
-    EXPECT_EQ('W'_l.resolve(ResolveMethod::WEAK), 'X'_l);
-    EXPECT_EQ('L'_l.resolve(ResolveMethod::WEAK), '0'_l);
-    EXPECT_EQ('H'_l.resolve(ResolveMethod::WEAK), '1'_l);
-    EXPECT_EQ('-'_l.resolve(ResolveMethod::WEAK), '-'_l);
+    EXPECT_THROW((void)'U'_l.resolve(ResolveMethod::WEAK), std::invalid_argument);
+    EXPECT_THROW((void)'X'_l.resolve(ResolveMethod::WEAK), std::invalid_argument);
+    EXPECT_EQ('0'_l.resolve(ResolveMethod::WEAK), '0'_b);
+    EXPECT_EQ('1'_l.resolve(ResolveMethod::WEAK), '1'_b);
+    EXPECT_THROW((void)'Z'_l.resolve(ResolveMethod::WEAK), std::invalid_argument);
+    EXPECT_THROW((void)'W'_l.resolve(ResolveMethod::WEAK), std::invalid_argument);
+    EXPECT_EQ('L'_l.resolve(ResolveMethod::WEAK), '0'_b);
+    EXPECT_EQ('H'_l.resolve(ResolveMethod::WEAK), '1'_b);
+    EXPECT_THROW((void)'-'_l.resolve(ResolveMethod::WEAK), std::invalid_argument);
 
     // Test ZEROS resolution
-    EXPECT_EQ('U'_l.resolve(ResolveMethod::ZEROS), '0'_l);
-    EXPECT_EQ('X'_l.resolve(ResolveMethod::ZEROS), '0'_l);
-    EXPECT_EQ('0'_l.resolve(ResolveMethod::ZEROS), '0'_l);
-    EXPECT_EQ('1'_l.resolve(ResolveMethod::ZEROS), '1'_l);
-    EXPECT_EQ('Z'_l.resolve(ResolveMethod::ZEROS), '0'_l);
-    EXPECT_EQ('W'_l.resolve(ResolveMethod::ZEROS), '0'_l);
-    EXPECT_EQ('L'_l.resolve(ResolveMethod::ZEROS), '0'_l);
-    EXPECT_EQ('H'_l.resolve(ResolveMethod::ZEROS), '1'_l);
-    EXPECT_EQ('-'_l.resolve(ResolveMethod::ZEROS), '0'_l);
+    EXPECT_EQ('U'_l.resolve(ResolveMethod::ZEROS), '0'_b);
+    EXPECT_EQ('X'_l.resolve(ResolveMethod::ZEROS), '0'_b);
+    EXPECT_EQ('0'_l.resolve(ResolveMethod::ZEROS), '0'_b);
+    EXPECT_EQ('1'_l.resolve(ResolveMethod::ZEROS), '1'_b);
+    EXPECT_EQ('Z'_l.resolve(ResolveMethod::ZEROS), '0'_b);
+    EXPECT_EQ('W'_l.resolve(ResolveMethod::ZEROS), '0'_b);
+    EXPECT_EQ('L'_l.resolve(ResolveMethod::ZEROS), '0'_b);
+    EXPECT_EQ('H'_l.resolve(ResolveMethod::ZEROS), '1'_b);
+    EXPECT_EQ('-'_l.resolve(ResolveMethod::ZEROS), '0'_b);
 
     // Test ONES resolution
-    EXPECT_EQ('U'_l.resolve(ResolveMethod::ONES), '1'_l);
-    EXPECT_EQ('X'_l.resolve(ResolveMethod::ONES), '1'_l);
-    EXPECT_EQ('0'_l.resolve(ResolveMethod::ONES), '0'_l);
-    EXPECT_EQ('1'_l.resolve(ResolveMethod::ONES), '1'_l);
-    EXPECT_EQ('Z'_l.resolve(ResolveMethod::ONES), '1'_l);
-    EXPECT_EQ('W'_l.resolve(ResolveMethod::ONES), '1'_l);
-    EXPECT_EQ('L'_l.resolve(ResolveMethod::ONES), '0'_l);
-    EXPECT_EQ('H'_l.resolve(ResolveMethod::ONES), '1'_l);
-    EXPECT_EQ('-'_l.resolve(ResolveMethod::ONES), '1'_l);
+    EXPECT_EQ('U'_l.resolve(ResolveMethod::ONES), '1'_b);
+    EXPECT_EQ('X'_l.resolve(ResolveMethod::ONES), '1'_b);
+    EXPECT_EQ('0'_l.resolve(ResolveMethod::ONES), '0'_b);
+    EXPECT_EQ('1'_l.resolve(ResolveMethod::ONES), '1'_b);
+    EXPECT_EQ('Z'_l.resolve(ResolveMethod::ONES), '1'_b);
+    EXPECT_EQ('W'_l.resolve(ResolveMethod::ONES), '1'_b);
+    EXPECT_EQ('L'_l.resolve(ResolveMethod::ONES), '0'_b);
+    EXPECT_EQ('H'_l.resolve(ResolveMethod::ONES), '1'_b);
+    EXPECT_EQ('-'_l.resolve(ResolveMethod::ONES), '1'_b);
 
     // Test RANDOM resolution
     auto resolved_u = 'U'_l.resolve(ResolveMethod::RANDOM);
-    EXPECT_TRUE(resolved_u == '0'_l || resolved_u == '1'_l);
+    EXPECT_TRUE(resolved_u == '0'_b || resolved_u == '1'_b);
 
     auto resolved_x = 'X'_l.resolve(ResolveMethod::RANDOM);
-    EXPECT_TRUE(resolved_x == '0'_l || resolved_x == '1'_l);
+    EXPECT_TRUE(resolved_x == '0'_b || resolved_x == '1'_b);
 
-    EXPECT_EQ('0'_l.resolve(ResolveMethod::RANDOM), '0'_l);
-    EXPECT_EQ('1'_l.resolve(ResolveMethod::RANDOM), '1'_l);
+    EXPECT_EQ('0'_l.resolve(ResolveMethod::RANDOM), '0'_b);
+    EXPECT_EQ('1'_l.resolve(ResolveMethod::RANDOM), '1'_b);
 
     auto resolved_z = 'Z'_l.resolve(ResolveMethod::RANDOM);
-    EXPECT_TRUE(resolved_z == '0'_l || resolved_z == '1'_l);
+    EXPECT_TRUE(resolved_z == '0'_b || resolved_z == '1'_b);
 
     auto resolved_w = 'W'_l.resolve(ResolveMethod::RANDOM);
-    EXPECT_TRUE(resolved_w == '0'_l || resolved_w == '1'_l);
+    EXPECT_TRUE(resolved_w == '0'_b || resolved_w == '1'_b);
 
-    EXPECT_EQ('L'_l.resolve(ResolveMethod::RANDOM), '0'_l);
-    EXPECT_EQ('H'_l.resolve(ResolveMethod::RANDOM), '1'_l);
+    EXPECT_EQ('L'_l.resolve(ResolveMethod::RANDOM), '0'_b);
+    EXPECT_EQ('H'_l.resolve(ResolveMethod::RANDOM), '1'_b);
 
     auto resolved_dc = '-'_l.resolve(ResolveMethod::RANDOM);
-    EXPECT_TRUE(resolved_dc == '0'_l || resolved_dc == '1'_l);
+    EXPECT_TRUE(resolved_dc == '0'_b || resolved_dc == '1'_b);
 
-    // Test ERROR resolution
-    EXPECT_EQ('0'_l.resolve(ResolveMethod::ERROR), '0'_l);
-    EXPECT_EQ('1'_l.resolve(ResolveMethod::ERROR), '1'_l);
+    // Test ERROR resolution: ERROR is the strict tier -- only 0/1 pass.
+    // L and H now throw too (previous behavior incorrectly accepted them).
+    EXPECT_EQ('0'_l.resolve(ResolveMethod::ERROR), '0'_b);
+    EXPECT_EQ('1'_l.resolve(ResolveMethod::ERROR), '1'_b);
     EXPECT_THROW((void)'U'_l.resolve(ResolveMethod::ERROR), std::invalid_argument);
     EXPECT_THROW((void)'X'_l.resolve(ResolveMethod::ERROR), std::invalid_argument);
     EXPECT_THROW((void)'Z'_l.resolve(ResolveMethod::ERROR), std::invalid_argument);
@@ -292,16 +349,14 @@ TEST(TestLogic, LogicResolve) {
     EXPECT_THROW((void)'H'_l.resolve(ResolveMethod::ERROR), std::invalid_argument);
     EXPECT_THROW((void)'-'_l.resolve(ResolveMethod::ERROR), std::invalid_argument);
 
-    // Out-of-range ResolveMethod hits the outer `default:` arm.
+    // Out-of-range ResolveMethod hits the fallthrough throw.
     EXPECT_THROW(
         (void)'0'_l.resolve(static_cast<ResolveMethod>(99)), std::invalid_argument
     );
 }
 
 TEST(TestBit, BitResolve) {
-    // Every Bit value is resolvable, so resolve() is a no-op regardless of
-    // method -- including ERROR (which throws on Logic for non-binary values)
-    // and out-of-range method values.
+    // Every Bit value is resolvable under every method; resolve() is a no-op.
     EXPECT_EQ('0'_b.resolve(ResolveMethod::ERROR), '0'_b);
     EXPECT_EQ('1'_b.resolve(ResolveMethod::ERROR), '1'_b);
 

--- a/tests/cpp/test_logic_array.cpp
+++ b/tests/cpp/test_logic_array.cpp
@@ -337,10 +337,18 @@ TEST(TestLogicArray, ResolveOnes) {
     EXPECT_EQ(to_string(b), "011110111");
 }
 
-TEST(TestLogicArray, ResolveWeak) {
-    auto a = to_logic_array("01XZULWH-");
+TEST(TestLogicArray, ResolveWeakAcceptsResolvable) {
+    // WEAK passes 0/1/L/H -> 0/1/0/1 and throws on the rest. The input must
+    // contain only resolvable-under-WEAK values for the call to succeed.
+    auto a = to_logic_array("01LH");
     auto b = a.resolve(ResolveMethod::WEAK);
-    EXPECT_EQ(to_string(b), "01XZU0X1-");
+    EXPECT_EQ(to_string(b), "0101");
+}
+
+TEST(TestLogicArray, ResolveWeakThrowsOnMetavalue) {
+    // Even a single non-resolvable value makes the whole array throw.
+    auto a = to_logic_array("01X");
+    EXPECT_THROW(a.resolve(ResolveMethod::WEAK), std::invalid_argument);
 }
 
 TEST(TestLogicArray, ResolveError) {
@@ -354,13 +362,21 @@ TEST(TestLogicArray, ResolveErrorPass) {
     EXPECT_EQ(to_string(b), "01");
 }
 
+TEST(TestLogicArray, ResolveErrorThrowsOnWeakStrengths) {
+    // ERROR is the strict tier -- L and H aren't accepted even though they're
+    // representable as 0/1 (use WEAK for that).
+    EXPECT_THROW(to_logic_array("0L").resolve(ResolveMethod::ERROR), std::invalid_argument);
+    EXPECT_THROW(to_logic_array("1H").resolve(ResolveMethod::ERROR), std::invalid_argument);
+}
+
 TEST(TestLogicArray, ResolveStaticReturnsStaticArray) {
     auto a = "01XZ"_l;  // static LogicArray<Range{3, DOWNTO, 0}>
     auto b = a.resolve(ResolveMethod::ZEROS);
     // Static-bound input -> static-bound output of matching range. This is the
     // payoff of memberizing resolve on the specializations: the result type
-    // preserves Self's static range when available.
-    static_assert(std::is_same_v<decltype(b), LogicArray<Range{3, Direction::DOWNTO, 0}>>);
+    // preserves Self's static range when available, and resolve always returns
+    // a Bit-valued container.
+    static_assert(std::is_same_v<decltype(b), BitArray<Range{3, Direction::DOWNTO, 0}>>);
     EXPECT_EQ(to_string(b), "0100");
 }
 
@@ -385,7 +401,7 @@ TEST(TestLogicArray, DynSliceResolveReturnsVector) {
     auto a = to_logic_array("01XZ");
     auto s = a[{3, 0}];
     auto r = s.resolve(ResolveMethod::ZEROS);
-    static_assert(std::is_same_v<decltype(r), Vector<Logic>>);
+    static_assert(std::is_same_v<decltype(r), BitVector>);
     EXPECT_EQ(to_string(r), "0100");
 }
 
@@ -393,7 +409,7 @@ TEST(TestLogicArray, StaticSliceResolveReturnsStaticArray) {
     auto a = "01XZ"_l;  // LogicArray<Range{3, DOWNTO, 0}>
     auto s = a.slice<Range{2, Direction::DOWNTO, 1}>();
     auto r = s.resolve(ResolveMethod::ZEROS);
-    static_assert(std::is_same_v<decltype(r), LogicArray<Range{2, Direction::DOWNTO, 1}>>);
+    static_assert(std::is_same_v<decltype(r), BitArray<Range{2, Direction::DOWNTO, 1}>>);
     EXPECT_EQ(to_string(r), "10");  // X->0, 1->1; slice was {X, 1} in storage order
 }
 


### PR DESCRIPTION
This matches an upstream change where WEAK now throws on U, W, X, Z, and -, and resolve() returns a Bit, which is guaranteed to be non-failing convert to int or bool. Additionally a global default resolver and a getter and setter were added. resolve() was allowed to take to argument to default to the global default resolver, and is_resolvable now respects the global default resolver. Additionally, is_resolvable was given the ability to take a resolver argument.

Since we added int and bool conversion to Bit, this seemed the best way to utilize those casts.

Also is makes is_resolvable() and resolve() actually work together where is_resolvable() means that an equivalent resolve() call won't fail.

This was the inspiration for https://github.com/cocotb/cocotb/pull/5614.