### PR TITLE
`resolve()` touch ups

### DIFF
--- a/cpp/include/coconext/types/logic.hpp
+++ b/cpp/include/coconext/types/logic.hpp
@@ -18,6 +18,8 @@ enum class ResolveMethod {
     RANDOM,
 };
 
+class Bit;
+
 class Logic {
   public:
     enum class value_type : uint8_t {
@@ -39,7 +41,7 @@ class Logic {
 
     bool is_resolvable(ResolveMethod method) const noexcept;
 
-    Logic resolve(ResolveMethod method) const;
+    Bit resolve(ResolveMethod method) const;
 
   private:
     value_type value_ = _0;
@@ -232,6 +234,8 @@ constexpr int to_int(Logic const& value) {
         );
     }
 }
+
+constexpr int to_int(Bit const& value) noexcept { return value.value() == Bit::_0 ? 0 : 1; }
 
 constexpr Logic operator|(Logic const& lhs, Logic const& rhs) noexcept {
     using enum Logic::value_type;

--- a/cpp/include/coconext/types/logic.hpp
+++ b/cpp/include/coconext/types/logic.hpp
@@ -4,6 +4,7 @@
 #include <coconext/types/concepts.hpp>
 #include <cstdint>
 #include <format>
+#include <optional>
 #include <stdexcept>
 #include <string_view>
 #include <type_traits>
@@ -39,9 +40,12 @@ class Logic {
     constexpr Logic(value_type value) noexcept : value_(value) {}
     constexpr value_type value() const noexcept { return value_; }
 
-    bool is_resolvable(ResolveMethod method) const noexcept;
-
-    Bit resolve(ResolveMethod method) const;
+    // Resolve under `method`. Returns nullopt iff the value is not resolvable
+    // under `method` -- ERROR accepts only 0/1; WEAK additionally accepts L/H;
+    // ZEROS, ONES, RANDOM accept anything. This unifies the old separate
+    // is_resolvable/resolve pair: `r.has_value()` answers the predicate,
+    // `r.value()` extracts the Bit.
+    std::optional<Bit> resolve(ResolveMethod method) const noexcept;
 
   private:
     value_type value_ = _0;
@@ -59,9 +63,10 @@ class Bit {
     constexpr Bit(value_type value) noexcept : value_(value) {}
     constexpr value_type value() const noexcept { return value_; }
 
-    constexpr bool is_resolvable(ResolveMethod) const noexcept { return true; }
-
-    constexpr Bit resolve(ResolveMethod) const noexcept { return *this; }
+    // Every Bit is resolvable under every method, so the optional is always
+    // engaged. Kept for uniformity with Logic::resolve so generic code over
+    // LogicType can treat both the same way.
+    constexpr std::optional<Bit> resolve(ResolveMethod) const noexcept { return *this; }
 
     // Implicit conversion from Bit to Logic mimics subtype upcasting.
     constexpr operator Logic() const noexcept {

--- a/cpp/include/coconext/types/logic.hpp
+++ b/cpp/include/coconext/types/logic.hpp
@@ -37,9 +37,7 @@ class Logic {
     constexpr Logic(value_type value) noexcept : value_(value) {}
     constexpr value_type value() const noexcept { return value_; }
 
-    constexpr bool is_resolvable() const noexcept {
-        return value_ == _0 || value_ == _1 || value_ == L || value_ == H;
-    }
+    bool is_resolvable(ResolveMethod method) const noexcept;
 
     Logic resolve(ResolveMethod method) const;
 
@@ -59,7 +57,7 @@ class Bit {
     constexpr Bit(value_type value) noexcept : value_(value) {}
     constexpr value_type value() const noexcept { return value_; }
 
-    constexpr bool is_resolvable() const noexcept { return true; }
+    constexpr bool is_resolvable(ResolveMethod) const noexcept { return true; }
 
     constexpr Bit resolve(ResolveMethod) const noexcept { return *this; }
 

--- a/cpp/include/coconext/types/logic.hpp
+++ b/cpp/include/coconext/types/logic.hpp
@@ -47,6 +47,9 @@ class Logic {
     // `r.value()` extracts the Bit.
     std::optional<Bit> resolve(ResolveMethod method) const noexcept;
 
+    // Default to WEAK.
+    std::optional<Bit> resolve() const noexcept;
+
   private:
     value_type value_ = _0;
 };
@@ -67,6 +70,7 @@ class Bit {
     // engaged. Kept for uniformity with Logic::resolve so generic code over
     // LogicType can treat both the same way.
     constexpr std::optional<Bit> resolve(ResolveMethod) const noexcept { return *this; }
+    constexpr std::optional<Bit> resolve() const noexcept { return *this; }
 
     // Implicit conversion from Bit to Logic mimics subtype upcasting.
     constexpr operator Logic() const noexcept {
@@ -84,6 +88,12 @@ class Bit {
   private:
     value_type value_ = _0;
 };
+
+// Out-of-line: needs the Bit definition above to instantiate
+// std::optional<Bit>.
+inline std::optional<Bit> Logic::resolve() const noexcept {
+    return resolve(ResolveMethod::WEAK);
+}
 
 constexpr bool operator==(Logic const& lhs, Logic const& rhs) noexcept {
     return lhs.value() == rhs.value();

--- a/cpp/include/coconext/types/logic_array.hpp
+++ b/cpp/include/coconext/types/logic_array.hpp
@@ -94,6 +94,8 @@ template <typename Self>
 struct LogicArrayMixin {
 
     auto resolve(ResolveMethod method) const;
+    // Default to WEAK.
+    auto resolve() const { return resolve(ResolveMethod::WEAK); }
 
     // Reductions: fold over the array with the corresponding bitwise op.
     // Empty arrays return the operation's identity (1 for AND, 0 for OR/XOR),

--- a/cpp/include/coconext/types/logic_array.hpp
+++ b/cpp/include/coconext/types/logic_array.hpp
@@ -9,6 +9,7 @@
 #include <cstddef>
 #include <format>
 #include <limits>
+#include <optional>
 #include <ranges>
 #include <stdexcept>
 #include <string>
@@ -85,27 +86,12 @@ class Vector<Bit>;
 
 namespace detail {
 
-template <Range R>
-class Array<Bit, R>;
-
-// CRTP mixin providing the Logic/Bit-specific query and resolution members.
-// Inherited by the Logic/Bit specializations of Array, Vector, StaticArraySlice,
-// and ArraySlice below. The non-Logic/Bit primaries do NOT inherit this,
-// so `Array<int, R>::is_resolvable(method)` and friends don't exist.
+// CRTP mixin providing the Logic/Bit-specific resolve member. Inherited by
+// the Logic/Bit specializations of Array, Vector, StaticArraySlice, and
+// ArraySlice below. The non-Logic/Bit primaries do NOT inherit this, so
+// `Array<int, R>::resolve(method)` and friends don't exist.
 template <typename Self>
 struct LogicArrayMixin {
-    bool is_resolvable(ResolveMethod method) const noexcept {
-        auto const& self = *static_cast<Self const*>(this);
-        using Elem = std::ranges::range_value_t<Self>;
-        if constexpr (std::same_as<Elem, Bit>) {
-            // Every Bit is resolvable under every method; skip the walk.
-            return true;
-        } else {
-            return std::ranges::all_of(self, [method](auto const& v) {
-                return v.is_resolvable(method);
-            });
-        }
-    }
 
     auto resolve(ResolveMethod method) const;
 
@@ -150,9 +136,9 @@ struct LogicArrayMixin {
 //
 // These specializations make `Array<Logic, R>`, `Array<Bit, R>`,
 // `Vector<Logic>`, `Vector<Bit>`, and slices over Logic/Bit owners
-// inherit `LogicArrayMixin`, gaining `is_resolvable(method)` and `resolve(method)`
-// as members. The primary templates remain unchanged for non-Logic element
-// types -- e.g., `Array<int, R>` has no `is_resolvable(method)`.
+// inherit `LogicArrayMixin`, gaining `resolve(method)` as a member. The
+// primary templates remain unchanged for non-Logic element types -- e.g.,
+// `Array<int, R>` has no `resolve(method)`.
 
 namespace detail {
 
@@ -248,16 +234,28 @@ template <typename Self>
 auto LogicArrayMixin<Self>::resolve(ResolveMethod method) const {
     auto const& self = *static_cast<Self const*>(this);
     if constexpr (StaticRangedSequence<Self>) {
-        ::coconext::types::detail::Array<Bit, Self::static_range> result{};
-        std::ranges::transform(self, result.begin(), [method](auto const& v) {
-            return v.resolve(method);
-        });
+        std::optional<::coconext::types::detail::Array<Bit, Self::static_range>> result{
+            std::in_place
+        };
+        auto out = result->begin();
+        for (auto const& v : self) {
+            auto r = v.resolve(method);
+            if (!r) {
+                return decltype(result){std::nullopt};
+            }
+            *out++ = *r;
+        }
         return result;
     } else {
-        ::coconext::types::Vector<Bit> result(self.range());
-        std::ranges::transform(self, result.begin(), [method](auto const& v) {
-            return v.resolve(method);
-        });
+        std::optional<::coconext::types::Vector<Bit>> result{std::in_place, self.range()};
+        auto out = result->begin();
+        for (auto const& v : self) {
+            auto r = v.resolve(method);
+            if (!r) {
+                return decltype(result){std::nullopt};
+            }
+            *out++ = *r;
+        }
         return result;
     }
 }
@@ -757,31 +755,6 @@ inline Vector<Logic> to_logic_array(std::string_view s) {
 
 inline Vector<Bit> to_bit_array(std::string_view s) {
     return detail::parse_logic_string<Bit>(s, [](char c) { return to_bit(c); });
-}
-
-// Convert a range of Logic to a Vector<Bit>. Throws if any element is not
-// 0/1/L/H (i.e. every element must be resolvable). Constrained to sized_range
-// so the result can be sized up-front from std::ranges::size in O(1) and the
-// resolvability check can be fused with the fill into a single pass.
-template <std::ranges::sized_range R>
-    requires std::same_as<std::ranges::range_value_t<R>, Logic>
-Vector<Bit> to_bit_array(R const& range) {
-    auto const sz = std::ranges::size(range);
-    if (sz > static_cast<size_t>(std::numeric_limits<Range::value_type>::max())) {
-        throw std::length_error("range too long for Range::value_type");
-    }
-    auto const n = static_cast<Range::value_type>(sz);
-    Vector<Bit> result(Range{n - 1, Direction::DOWNTO, 0});
-    auto out = result.begin();
-    for (Logic const& v : range) {
-        if (!v.is_resolvable(ResolveMethod::WEAK)) {
-            throw std::invalid_argument(
-                "Cannot convert non-resolvable Logic values to BitArray"
-            );
-        }
-        *out++ = to_int(v) ? Bit::_1 : Bit::_0;
-    }
-    return result;
 }
 
 // -- String-literal UDL ----------------------------------------------------

--- a/cpp/include/coconext/types/logic_array.hpp
+++ b/cpp/include/coconext/types/logic_array.hpp
@@ -81,18 +81,18 @@ constexpr Range make_logic_static_range() {
 // CRTP mixin providing the Logic/Bit-specific query and resolution members.
 // Inherited by the Logic/Bit specializations of Array, Vector, StaticArraySlice,
 // and ArraySlice below. The non-Logic/Bit primaries do NOT inherit this,
-// so `Array<int, R>::is_resolvable()` and friends don't exist.
+// so `Array<int, R>::is_resolvable(method)` and friends don't exist.
 template <typename Self>
 struct LogicArrayMixin {
-    bool is_resolvable() const noexcept {
+    bool is_resolvable(ResolveMethod method) const noexcept {
         auto const& self = *static_cast<Self const*>(this);
         using Elem = std::ranges::range_value_t<Self>;
         if constexpr (std::same_as<Elem, Bit>) {
-            // Every Bit is resolvable; skip the walk.
+            // Every Bit is resolvable under every method; skip the walk.
             return true;
         } else {
-            return std::ranges::all_of(self, [](auto const& v) {
-                return v.is_resolvable();
+            return std::ranges::all_of(self, [method](auto const& v) {
+                return v.is_resolvable(method);
             });
         }
     }
@@ -160,9 +160,9 @@ struct LogicArrayMixin {
 //
 // These specializations make `Array<Logic, R>`, `Array<Bit, R>`,
 // `Vector<Logic>`, `Vector<Bit>`, and slices over Logic/Bit owners
-// inherit `LogicArrayMixin`, gaining `is_resolvable()` and `resolve(method)`
+// inherit `LogicArrayMixin`, gaining `is_resolvable(method)` and `resolve(method)`
 // as members. The primary templates remain unchanged for non-Logic element
-// types -- e.g., `Array<int, R>` has no `is_resolvable()`.
+// types -- e.g., `Array<int, R>` has no `is_resolvable(method)`.
 
 namespace detail {
 
@@ -762,7 +762,7 @@ Vector<Bit> to_bit_array(R const& range) {
     Vector<Bit> result(Range{n - 1, Direction::DOWNTO, 0});
     auto out = result.begin();
     for (Logic const& v : range) {
-        if (!v.is_resolvable()) {
+        if (!v.is_resolvable(ResolveMethod::WEAK)) {
             throw std::invalid_argument(
                 "Cannot convert non-resolvable Logic values to BitArray"
             );

--- a/cpp/include/coconext/types/logic_array.hpp
+++ b/cpp/include/coconext/types/logic_array.hpp
@@ -78,6 +78,16 @@ constexpr Range make_logic_static_range() {
     }
 }
 
+}  // namespace detail
+
+template <>
+class Vector<Bit>;
+
+namespace detail {
+
+template <Range R>
+class Array<Bit, R>;
+
 // CRTP mixin providing the Logic/Bit-specific query and resolution members.
 // Inherited by the Logic/Bit specializations of Array, Vector, StaticArraySlice,
 // and ArraySlice below. The non-Logic/Bit primaries do NOT inherit this,
@@ -97,27 +107,7 @@ struct LogicArrayMixin {
         }
     }
 
-    // Element-wise resolve. Returns a static `Array<Elem, R>` when Self has a
-    // compile-time range, a heap-allocated `Vector<Elem>` otherwise. The
-    // returned array preserves Self's range (an owner returns the same shape;
-    // a slice returns an owner sized like the slice's range).
-    auto resolve(ResolveMethod method) const {
-        auto const& self = *static_cast<Self const*>(this);
-        using Elem = std::ranges::range_value_t<Self>;
-        if constexpr (StaticRangedSequence<Self>) {
-            ::coconext::types::Array<Elem, Self::static_range> result{};
-            std::ranges::transform(self, result.begin(), [method](auto const& v) {
-                return v.resolve(method);
-            });
-            return result;
-        } else {
-            ::coconext::types::Vector<Elem> result(self.range());
-            std::ranges::transform(self, result.begin(), [method](auto const& v) {
-                return v.resolve(method);
-            });
-            return result;
-        }
-    }
+    auto resolve(ResolveMethod method) const;
 
     // Reductions: fold over the array with the corresponding bitwise op.
     // Empty arrays return the operation's identity (1 for AND, 0 for OR/XOR),
@@ -251,6 +241,28 @@ class StaticArraySlice<ArrayT, R>
     using detail::StaticArraySliceImpl<ArrayT, R>::StaticArraySliceImpl;
     using detail::StaticArraySliceImpl<ArrayT, R>::operator=;
 };
+
+namespace detail {
+
+template <typename Self>
+auto LogicArrayMixin<Self>::resolve(ResolveMethod method) const {
+    auto const& self = *static_cast<Self const*>(this);
+    if constexpr (StaticRangedSequence<Self>) {
+        ::coconext::types::detail::Array<Bit, Self::static_range> result{};
+        std::ranges::transform(self, result.begin(), [method](auto const& v) {
+            return v.resolve(method);
+        });
+        return result;
+    } else {
+        ::coconext::types::Vector<Bit> result(self.range());
+        std::ranges::transform(self, result.begin(), [method](auto const& v) {
+            return v.resolve(method);
+        });
+        return result;
+    }
+}
+
+}  // namespace detail
 
 using LogicVector = Vector<Logic>;
 using BitVector = Vector<Bit>;

--- a/cpp/src/logic.cpp
+++ b/cpp/src/logic.cpp
@@ -8,6 +8,20 @@ using namespace coconext::types;
 
 namespace coconext::types {
 
+bool Logic::is_resolvable(ResolveMethod method) const noexcept {
+    switch (method) {
+    case ResolveMethod::ERROR:
+        return value_ == _0 || value_ == _1;
+    case ResolveMethod::WEAK:
+        return value_ == _0 || value_ == _1 || value_ == L || value_ == H;
+    case ResolveMethod::ZEROS:
+    case ResolveMethod::ONES:
+    case ResolveMethod::RANDOM:
+        return true;
+    }
+    return false;
+}
+
 Logic Logic::resolve(ResolveMethod method) const {
     switch (method) {
     case ResolveMethod::ERROR:

--- a/cpp/src/logic.cpp
+++ b/cpp/src/logic.cpp
@@ -1,6 +1,7 @@
 #include <coconext/types/logic.hpp>
 #include <random>
 #include <stdexcept>
+#include <string>
 
 #include "./random.hpp"
 
@@ -22,70 +23,72 @@ bool Logic::is_resolvable(ResolveMethod method) const noexcept {
     return false;
 }
 
-Logic Logic::resolve(ResolveMethod method) const {
+Bit Logic::resolve(ResolveMethod method) const {
     switch (method) {
     case ResolveMethod::ERROR:
         switch (value_) {
         case _0:
+            return Bit::_0;
         case _1:
-            return *this;
+            return Bit::_1;
         default:
-            throw std::invalid_argument("Logic value is not resolvable");
+            throw std::invalid_argument(
+                "Logic value '" + std::string(to_string(*this))
+                + "' is not resolvable under ERROR"
+            );
         }
     case ResolveMethod::WEAK:
         switch (value_) {
         case _0:
-        case _1:
-            return *this;
         case L:
-            return _0;
+            return Bit::_0;
+        case _1:
         case H:
-            return _1;
+            return Bit::_1;
         default:
-            throw std::invalid_argument("Logic value is not resolvable under WEAK");
+            throw std::invalid_argument(
+                "Logic value '" + std::string(to_string(*this))
+                + "' is not resolvable under WEAK"
+            );
         }
     case ResolveMethod::ZEROS:
         switch (value_) {
         case _0:
-        case _1:
-            return *this;
         case L:
-            return _0;
+            return Bit::_0;
+        case _1:
         case H:
-            return _1;
+            return Bit::_1;
         default:
-            return _0;
+            return Bit::_0;
         }
     case ResolveMethod::ONES:
         switch (value_) {
         case _0:
-        case _1:
-            return *this;
         case L:
-            return _0;
+            return Bit::_0;
+        case _1:
         case H:
-            return _1;
+            return Bit::_1;
         default:
-            return _1;
+            return Bit::_1;
         }
     case ResolveMethod::RANDOM: {
         switch (value_) {
         case _0:
-        case _1:
-            return *this;
         case L:
-            return _0;
+            return Bit::_0;
+        case _1:
         case H:
-            return _1;
+            return Bit::_1;
         default: {
             auto& rng = get_rng();
-            return (rng() % 2 == 0) ? _0 : _1;
+            return (rng() % 2 == 0) ? Bit::_0 : Bit::_1;
         }
         }
     }
-    default:
-        throw std::invalid_argument("Unknown resolve method");
     }
+    throw std::invalid_argument("Unknown resolve method");
 }
 
 }  // namespace coconext::types

--- a/cpp/src/logic.cpp
+++ b/cpp/src/logic.cpp
@@ -27,10 +27,8 @@ Logic Logic::resolve(ResolveMethod method) const {
             return _0;
         case H:
             return _1;
-        case W:
-            return X;
         default:
-            return *this;
+            throw std::invalid_argument("Logic value is not resolvable under WEAK");
         }
     case ResolveMethod::ZEROS:
         switch (value_) {

--- a/cpp/src/logic.cpp
+++ b/cpp/src/logic.cpp
@@ -1,7 +1,6 @@
 #include <coconext/types/logic.hpp>
+#include <optional>
 #include <random>
-#include <stdexcept>
-#include <string>
 
 #include "./random.hpp"
 
@@ -9,71 +8,51 @@ using namespace coconext::types;
 
 namespace coconext::types {
 
-bool Logic::is_resolvable(ResolveMethod method) const noexcept {
+std::optional<Bit> Logic::resolve(ResolveMethod method) const noexcept {
     switch (method) {
     case ResolveMethod::ERROR:
-        return value_ == _0 || value_ == _1;
+        switch (value_) {
+        case _0:
+            return Bit::_0;
+        case _1:
+            return Bit::_1;
+        default:
+            return std::nullopt;
+        }
     case ResolveMethod::WEAK:
-        return value_ == _0 || value_ == _1 || value_ == L || value_ == H;
+        switch (value_) {
+        case _0:
+        case L:
+            return Bit::_0;
+        case _1:
+        case H:
+            return Bit::_1;
+        default:
+            return std::nullopt;
+        }
     case ResolveMethod::ZEROS:
+        switch (value_) {
+        case _0:
+        case L:
+            return Bit::_0;
+        case _1:
+        case H:
+            return Bit::_1;
+        default:
+            return Bit::_0;
+        }
     case ResolveMethod::ONES:
+        switch (value_) {
+        case _0:
+        case L:
+            return Bit::_0;
+        case _1:
+        case H:
+            return Bit::_1;
+        default:
+            return Bit::_1;
+        }
     case ResolveMethod::RANDOM:
-        return true;
-    }
-    return false;
-}
-
-Bit Logic::resolve(ResolveMethod method) const {
-    switch (method) {
-    case ResolveMethod::ERROR:
-        switch (value_) {
-        case _0:
-            return Bit::_0;
-        case _1:
-            return Bit::_1;
-        default:
-            throw std::invalid_argument(
-                "Logic value '" + std::string(to_string(*this))
-                + "' is not resolvable under ERROR"
-            );
-        }
-    case ResolveMethod::WEAK:
-        switch (value_) {
-        case _0:
-        case L:
-            return Bit::_0;
-        case _1:
-        case H:
-            return Bit::_1;
-        default:
-            throw std::invalid_argument(
-                "Logic value '" + std::string(to_string(*this))
-                + "' is not resolvable under WEAK"
-            );
-        }
-    case ResolveMethod::ZEROS:
-        switch (value_) {
-        case _0:
-        case L:
-            return Bit::_0;
-        case _1:
-        case H:
-            return Bit::_1;
-        default:
-            return Bit::_0;
-        }
-    case ResolveMethod::ONES:
-        switch (value_) {
-        case _0:
-        case L:
-            return Bit::_0;
-        case _1:
-        case H:
-            return Bit::_1;
-        default:
-            return Bit::_1;
-        }
-    case ResolveMethod::RANDOM: {
         switch (value_) {
         case _0:
         case L:
@@ -87,8 +66,7 @@ Bit Logic::resolve(ResolveMethod method) const {
         }
         }
     }
-    }
-    throw std::invalid_argument("Unknown resolve method");
+    return std::nullopt;
 }
 
 }  // namespace coconext::types

--- a/nanobind/src/types/bind_logic.cpp
+++ b/nanobind/src/types/bind_logic.cpp
@@ -128,16 +128,17 @@ void register_logic(nb::module_& m) {
         )
         .def_prop_ro(
             "is_resolvable",
-            [](Logic const& self) { return self.is_resolvable(ResolveMethod::WEAK); }
+            [](Logic const& self) { return self.resolve(ResolveMethod::WEAK).has_value(); }
         )
         .def(
             "resolve",
             [](Logic const& self, std::string_view method) {
                 auto m = string_to_resolve_method(method);
                 // Compat shim: pre-branch C++ WEAK mapped L/H -> 0/1, W -> X,
-                // and left other metavalues unchanged. Post-branch C++ throws
-                // on metavalues under WEAK. Reproduce the old mapping here so
-                // upstream Python (and its integration tests) don't break.
+                // and left other metavalues unchanged. Post-branch C++ returns
+                // nullopt on metavalues under WEAK. Reproduce the old mapping
+                // here so upstream Python (and its integration tests) don't
+                // break.
                 if (m == ResolveMethod::WEAK) {
                     switch (self.value()) {
                     case Logic::_0:
@@ -153,13 +154,13 @@ void register_logic(nb::module_& m) {
                         return self;
                     }
                 }
-                return Logic(self.resolve(m));
-            }
-        )
-        .def(
-            "resolve",
-            [](Logic const& self, ResolveMethod method) {
-                return Logic(self.resolve(method));
+                auto r = self.resolve(m);
+                if (!r) {
+                    throw std::invalid_argument(
+                        "Logic value is not resolvable under the given method"
+                    );
+                }
+                return Logic(*r);
             }
         )
         .def("__copy__", [](Logic const& self) { return Logic(self); })
@@ -253,17 +254,14 @@ void register_logic(nb::module_& m) {
         .def(
             "__invert__", [](Bit const& self) { return ~self; }, nb::is_operator()
         )
-        .def_prop_ro(
-            "is_resolvable",
-            [](Bit const& self) { return self.is_resolvable(ResolveMethod::WEAK); }
-        )
+        .def_prop_ro("is_resolvable", [](Bit const&) { return true; })
         .def(
             "resolve",
             [](Bit const& self, std::string_view method) {
-                return self.resolve(string_to_resolve_method(method));
+                (void)string_to_resolve_method(method);
+                return self;
             }
         )
-        .def("resolve", &Bit::resolve)
         .def("__copy__", [](Bit const& self) { return Bit(self); })
         .def("__deepcopy__", [](Bit const& self, nb::dict /* memo */) {
             return Bit(self);

--- a/nanobind/src/types/bind_logic.cpp
+++ b/nanobind/src/types/bind_logic.cpp
@@ -130,7 +130,27 @@ void register_logic(nb::module_& m) {
         .def(
             "resolve",
             [](Logic const& self, std::string_view method) {
-                return self.resolve(string_to_resolve_method(method));
+                auto m = string_to_resolve_method(method);
+                // Compat shim: pre-branch C++ WEAK mapped L/H -> 0/1, W -> X,
+                // and left other metavalues unchanged. Post-branch C++ throws
+                // on metavalues under WEAK. Reproduce the old mapping here so
+                // upstream Python (and its integration tests) don't break.
+                if (m == ResolveMethod::WEAK) {
+                    switch (self.value()) {
+                    case Logic::_0:
+                    case Logic::_1:
+                        return self;
+                    case Logic::L:
+                        return Logic(Logic::_0);
+                    case Logic::H:
+                        return Logic(Logic::_1);
+                    case Logic::W:
+                        return Logic(Logic::X);
+                    default:
+                        return self;
+                    }
+                }
+                return self.resolve(m);
             }
         )
         .def("resolve", &Logic::resolve)

--- a/nanobind/src/types/bind_logic.cpp
+++ b/nanobind/src/types/bind_logic.cpp
@@ -55,7 +55,7 @@ void register_logic(nb::module_& m) {
             [](Logic* self, long long value) { new (self) Logic(to_logic(value)); }
         )
         .def("__str__", [](Logic const& self) { return to_string(self); })
-        .def("__index__", &to_int)
+        .def("__index__", [](Logic const& self) { return to_int(self); })
         .def("__bool__", [](Logic const& self) { return to_int(self) != 0; })
         .def(
             "__repr__",
@@ -153,10 +153,15 @@ void register_logic(nb::module_& m) {
                         return self;
                     }
                 }
-                return self.resolve(m);
+                return Logic(self.resolve(m));
             }
         )
-        .def("resolve", &Logic::resolve)
+        .def(
+            "resolve",
+            [](Logic const& self, ResolveMethod method) {
+                return Logic(self.resolve(method));
+            }
+        )
         .def("__copy__", [](Logic const& self) { return Logic(self); })
         .def("__deepcopy__", [](Logic const& self, nb::dict /* memo */) {
             return Logic(self);
@@ -173,7 +178,7 @@ void register_logic(nb::module_& m) {
         )
         .def("__init__", [](Bit* self, long long value) { new (self) Bit(to_bit(value)); })
         .def("__str__", [](Bit const& self) { return to_string(self); })
-        .def("__index__", &to_int)
+        .def("__index__", [](Bit const& self) { return to_int(self); })
         .def("__bool__", [](Bit const& self) { return to_int(self) != 0; })
         .def(
             "__repr__",

--- a/nanobind/src/types/bind_logic.cpp
+++ b/nanobind/src/types/bind_logic.cpp
@@ -126,7 +126,10 @@ void register_logic(nb::module_& m) {
         .def(
             "__invert__", [](Logic const& self) { return ~self; }, nb::is_operator()
         )
-        .def_prop_ro("is_resolvable", &Logic::is_resolvable)
+        .def_prop_ro(
+            "is_resolvable",
+            [](Logic const& self) { return self.is_resolvable(ResolveMethod::WEAK); }
+        )
         .def(
             "resolve",
             [](Logic const& self, std::string_view method) {
@@ -245,7 +248,10 @@ void register_logic(nb::module_& m) {
         .def(
             "__invert__", [](Bit const& self) { return ~self; }, nb::is_operator()
         )
-        .def_prop_ro("is_resolvable", &Bit::is_resolvable)
+        .def_prop_ro(
+            "is_resolvable",
+            [](Bit const& self) { return self.is_resolvable(ResolveMethod::WEAK); }
+        )
         .def(
             "resolve",
             [](Bit const& self, std::string_view method) {

--- a/tests/cpp/test_logic.cpp
+++ b/tests/cpp/test_logic.cpp
@@ -226,16 +226,17 @@ TEST(TestBit, BitInvert) {
 
 // Test Logic resolve with different methods
 TEST(TestLogic, LogicResolve) {
-    // Test WEAK resolution
-    EXPECT_EQ('U'_l.resolve(ResolveMethod::WEAK), 'U'_l);
-    EXPECT_EQ('X'_l.resolve(ResolveMethod::WEAK), 'X'_l);
+    // Test WEAK resolution: 0/1 pass through; L/H map to 0/1; everything else
+    // throws (the "not resolvable under WEAK" tier matches L/H plus 0/1).
     EXPECT_EQ('0'_l.resolve(ResolveMethod::WEAK), '0'_l);
     EXPECT_EQ('1'_l.resolve(ResolveMethod::WEAK), '1'_l);
-    EXPECT_EQ('Z'_l.resolve(ResolveMethod::WEAK), 'Z'_l);
-    EXPECT_EQ('W'_l.resolve(ResolveMethod::WEAK), 'X'_l);
     EXPECT_EQ('L'_l.resolve(ResolveMethod::WEAK), '0'_l);
     EXPECT_EQ('H'_l.resolve(ResolveMethod::WEAK), '1'_l);
-    EXPECT_EQ('-'_l.resolve(ResolveMethod::WEAK), '-'_l);
+    EXPECT_THROW((void)'U'_l.resolve(ResolveMethod::WEAK), std::invalid_argument);
+    EXPECT_THROW((void)'X'_l.resolve(ResolveMethod::WEAK), std::invalid_argument);
+    EXPECT_THROW((void)'Z'_l.resolve(ResolveMethod::WEAK), std::invalid_argument);
+    EXPECT_THROW((void)'W'_l.resolve(ResolveMethod::WEAK), std::invalid_argument);
+    EXPECT_THROW((void)'-'_l.resolve(ResolveMethod::WEAK), std::invalid_argument);
 
     // Test ZEROS resolution
     EXPECT_EQ('U'_l.resolve(ResolveMethod::ZEROS), '0'_l);

--- a/tests/cpp/test_logic.cpp
+++ b/tests/cpp/test_logic.cpp
@@ -95,55 +95,55 @@ TEST(TestBit, BitConversions) {
 // Test Logic bool conversions
 TEST(TestLogic, LogicBoolConversions) {
     // Convertible to true
-    EXPECT_EQ('1'_l.is_resolvable(ResolveMethod::WEAK), true);
-    EXPECT_EQ('H'_l.is_resolvable(ResolveMethod::WEAK), true);
+    EXPECT_EQ('1'_l.resolve(ResolveMethod::WEAK).has_value(), true);
+    EXPECT_EQ('H'_l.resolve(ResolveMethod::WEAK).has_value(), true);
 
     // Convertible to false
-    EXPECT_EQ('0'_l.is_resolvable(ResolveMethod::WEAK), true);
-    EXPECT_EQ('L'_l.is_resolvable(ResolveMethod::WEAK), true);
+    EXPECT_EQ('0'_l.resolve(ResolveMethod::WEAK).has_value(), true);
+    EXPECT_EQ('L'_l.resolve(ResolveMethod::WEAK).has_value(), true);
 
     // Non-convertible values
-    EXPECT_EQ('X'_l.is_resolvable(ResolveMethod::WEAK), false);
-    EXPECT_EQ('Z'_l.is_resolvable(ResolveMethod::WEAK), false);
-    EXPECT_EQ('U'_l.is_resolvable(ResolveMethod::WEAK), false);
-    EXPECT_EQ('W'_l.is_resolvable(ResolveMethod::WEAK), false);
-    EXPECT_EQ('-'_l.is_resolvable(ResolveMethod::WEAK), false);
+    EXPECT_EQ('X'_l.resolve(ResolveMethod::WEAK).has_value(), false);
+    EXPECT_EQ('Z'_l.resolve(ResolveMethod::WEAK).has_value(), false);
+    EXPECT_EQ('U'_l.resolve(ResolveMethod::WEAK).has_value(), false);
+    EXPECT_EQ('W'_l.resolve(ResolveMethod::WEAK).has_value(), false);
+    EXPECT_EQ('-'_l.resolve(ResolveMethod::WEAK).has_value(), false);
 }
 
 TEST(TestBit, BitBoolConversions) {
-    EXPECT_EQ('0'_b.is_resolvable(ResolveMethod::WEAK), true);
-    EXPECT_EQ('1'_b.is_resolvable(ResolveMethod::WEAK), true);
+    EXPECT_EQ('0'_b.resolve(ResolveMethod::WEAK).has_value(), true);
+    EXPECT_EQ('1'_b.resolve(ResolveMethod::WEAK).has_value(), true);
 }
 
-TEST(TestLogic, LogicIsResolvableUnderEachMethod) {
+TEST(TestLogic, LogicResolvabilityUnderEachMethod) {
     // ERROR: only 0/1 are resolvable.
-    EXPECT_TRUE('0'_l.is_resolvable(ResolveMethod::ERROR));
-    EXPECT_TRUE('1'_l.is_resolvable(ResolveMethod::ERROR));
-    EXPECT_FALSE('L'_l.is_resolvable(ResolveMethod::ERROR));
-    EXPECT_FALSE('H'_l.is_resolvable(ResolveMethod::ERROR));
-    EXPECT_FALSE('X'_l.is_resolvable(ResolveMethod::ERROR));
-    EXPECT_FALSE('Z'_l.is_resolvable(ResolveMethod::ERROR));
-    EXPECT_FALSE('U'_l.is_resolvable(ResolveMethod::ERROR));
-    EXPECT_FALSE('W'_l.is_resolvable(ResolveMethod::ERROR));
-    EXPECT_FALSE('-'_l.is_resolvable(ResolveMethod::ERROR));
+    EXPECT_TRUE('0'_l.resolve(ResolveMethod::ERROR).has_value());
+    EXPECT_TRUE('1'_l.resolve(ResolveMethod::ERROR).has_value());
+    EXPECT_FALSE('L'_l.resolve(ResolveMethod::ERROR).has_value());
+    EXPECT_FALSE('H'_l.resolve(ResolveMethod::ERROR).has_value());
+    EXPECT_FALSE('X'_l.resolve(ResolveMethod::ERROR).has_value());
+    EXPECT_FALSE('Z'_l.resolve(ResolveMethod::ERROR).has_value());
+    EXPECT_FALSE('U'_l.resolve(ResolveMethod::ERROR).has_value());
+    EXPECT_FALSE('W'_l.resolve(ResolveMethod::ERROR).has_value());
+    EXPECT_FALSE('-'_l.resolve(ResolveMethod::ERROR).has_value());
 
     // WEAK: 0/1/L/H pass; metavalues (incl. W) do not.
-    EXPECT_TRUE('0'_l.is_resolvable(ResolveMethod::WEAK));
-    EXPECT_TRUE('1'_l.is_resolvable(ResolveMethod::WEAK));
-    EXPECT_TRUE('L'_l.is_resolvable(ResolveMethod::WEAK));
-    EXPECT_TRUE('H'_l.is_resolvable(ResolveMethod::WEAK));
-    EXPECT_FALSE('X'_l.is_resolvable(ResolveMethod::WEAK));
-    EXPECT_FALSE('Z'_l.is_resolvable(ResolveMethod::WEAK));
-    EXPECT_FALSE('U'_l.is_resolvable(ResolveMethod::WEAK));
-    EXPECT_FALSE('W'_l.is_resolvable(ResolveMethod::WEAK));
-    EXPECT_FALSE('-'_l.is_resolvable(ResolveMethod::WEAK));
+    EXPECT_TRUE('0'_l.resolve(ResolveMethod::WEAK).has_value());
+    EXPECT_TRUE('1'_l.resolve(ResolveMethod::WEAK).has_value());
+    EXPECT_TRUE('L'_l.resolve(ResolveMethod::WEAK).has_value());
+    EXPECT_TRUE('H'_l.resolve(ResolveMethod::WEAK).has_value());
+    EXPECT_FALSE('X'_l.resolve(ResolveMethod::WEAK).has_value());
+    EXPECT_FALSE('Z'_l.resolve(ResolveMethod::WEAK).has_value());
+    EXPECT_FALSE('U'_l.resolve(ResolveMethod::WEAK).has_value());
+    EXPECT_FALSE('W'_l.resolve(ResolveMethod::WEAK).has_value());
+    EXPECT_FALSE('-'_l.resolve(ResolveMethod::WEAK).has_value());
 
     // ZEROS / ONES / RANDOM: always resolvable (no value can throw).
     for (auto m : {ResolveMethod::ZEROS, ResolveMethod::ONES, ResolveMethod::RANDOM}) {
-        EXPECT_TRUE('0'_l.is_resolvable(m));
-        EXPECT_TRUE('X'_l.is_resolvable(m));
-        EXPECT_TRUE('U'_l.is_resolvable(m));
-        EXPECT_TRUE('-'_l.is_resolvable(m));
+        EXPECT_TRUE('0'_l.resolve(m).has_value());
+        EXPECT_TRUE('X'_l.resolve(m).has_value());
+        EXPECT_TRUE('U'_l.resolve(m).has_value());
+        EXPECT_TRUE('-'_l.resolve(m).has_value());
     }
 }
 
@@ -259,16 +259,17 @@ TEST(TestBit, BitInvert) {
 // Test Logic resolve with different methods
 TEST(TestLogic, LogicResolve) {
     // Test WEAK resolution: 0/1 pass through; L/H map to 0/1; everything else
-    // throws (the "not resolvable under WEAK" tier matches L/H plus 0/1).
+    // returns nullopt (the "not resolvable under WEAK" tier matches L/H plus
+    // 0/1). optional<Bit> compares equal to Bit when engaged.
     EXPECT_EQ('0'_l.resolve(ResolveMethod::WEAK), '0'_b);
     EXPECT_EQ('1'_l.resolve(ResolveMethod::WEAK), '1'_b);
     EXPECT_EQ('L'_l.resolve(ResolveMethod::WEAK), '0'_b);
     EXPECT_EQ('H'_l.resolve(ResolveMethod::WEAK), '1'_b);
-    EXPECT_THROW((void)'U'_l.resolve(ResolveMethod::WEAK), std::invalid_argument);
-    EXPECT_THROW((void)'X'_l.resolve(ResolveMethod::WEAK), std::invalid_argument);
-    EXPECT_THROW((void)'Z'_l.resolve(ResolveMethod::WEAK), std::invalid_argument);
-    EXPECT_THROW((void)'W'_l.resolve(ResolveMethod::WEAK), std::invalid_argument);
-    EXPECT_THROW((void)'-'_l.resolve(ResolveMethod::WEAK), std::invalid_argument);
+    EXPECT_EQ('U'_l.resolve(ResolveMethod::WEAK), std::nullopt);
+    EXPECT_EQ('X'_l.resolve(ResolveMethod::WEAK), std::nullopt);
+    EXPECT_EQ('Z'_l.resolve(ResolveMethod::WEAK), std::nullopt);
+    EXPECT_EQ('W'_l.resolve(ResolveMethod::WEAK), std::nullopt);
+    EXPECT_EQ('-'_l.resolve(ResolveMethod::WEAK), std::nullopt);
 
     // Test ZEROS resolution
     EXPECT_EQ('U'_l.resolve(ResolveMethod::ZEROS), '0'_b);
@@ -317,24 +318,23 @@ TEST(TestLogic, LogicResolve) {
     // Test ERROR resolution
     EXPECT_EQ('0'_l.resolve(ResolveMethod::ERROR), '0'_b);
     EXPECT_EQ('1'_l.resolve(ResolveMethod::ERROR), '1'_b);
-    EXPECT_THROW((void)'U'_l.resolve(ResolveMethod::ERROR), std::invalid_argument);
-    EXPECT_THROW((void)'X'_l.resolve(ResolveMethod::ERROR), std::invalid_argument);
-    EXPECT_THROW((void)'Z'_l.resolve(ResolveMethod::ERROR), std::invalid_argument);
-    EXPECT_THROW((void)'W'_l.resolve(ResolveMethod::ERROR), std::invalid_argument);
-    EXPECT_THROW((void)'L'_l.resolve(ResolveMethod::ERROR), std::invalid_argument);
-    EXPECT_THROW((void)'H'_l.resolve(ResolveMethod::ERROR), std::invalid_argument);
-    EXPECT_THROW((void)'-'_l.resolve(ResolveMethod::ERROR), std::invalid_argument);
+    EXPECT_EQ('U'_l.resolve(ResolveMethod::ERROR), std::nullopt);
+    EXPECT_EQ('X'_l.resolve(ResolveMethod::ERROR), std::nullopt);
+    EXPECT_EQ('Z'_l.resolve(ResolveMethod::ERROR), std::nullopt);
+    EXPECT_EQ('W'_l.resolve(ResolveMethod::ERROR), std::nullopt);
+    EXPECT_EQ('L'_l.resolve(ResolveMethod::ERROR), std::nullopt);
+    EXPECT_EQ('H'_l.resolve(ResolveMethod::ERROR), std::nullopt);
+    EXPECT_EQ('-'_l.resolve(ResolveMethod::ERROR), std::nullopt);
 
-    // Out-of-range ResolveMethod hits the outer `default:` arm.
-    EXPECT_THROW(
-        (void)'0'_l.resolve(static_cast<ResolveMethod>(99)), std::invalid_argument
-    );
+    // Out-of-range ResolveMethod hits the outer fall-through arm and returns
+    // nullopt (the unified API doesn't throw on bad methods either).
+    EXPECT_EQ('0'_l.resolve(static_cast<ResolveMethod>(99)), std::nullopt);
 }
 
 TEST(TestBit, BitResolve) {
-    // Every Bit value is resolvable, so resolve() is a no-op regardless of
-    // method -- including ERROR (which throws on Logic for non-binary values)
-    // and out-of-range method values.
+    // Every Bit value is resolvable, so resolve() always returns an engaged
+    // optional equal to the input -- including ERROR (which is nullopt on
+    // Logic for non-binary values) and out-of-range method values.
     EXPECT_EQ('0'_b.resolve(ResolveMethod::ERROR), '0'_b);
     EXPECT_EQ('1'_b.resolve(ResolveMethod::ERROR), '1'_b);
 
@@ -374,23 +374,23 @@ TEST(TestLogic, RuntimeIntAndBitConversions) {
     EXPECT_EQ(bits[1].resolve(ResolveMethod::ZEROS), '1'_b);
 }
 
-// Test Logic is_resolvable
+// Test Logic resolvability via resolve(...).has_value()
 TEST(TestLogic, LogicIsResolvable) {
-    EXPECT_TRUE('0'_l.is_resolvable(ResolveMethod::WEAK));
-    EXPECT_TRUE('1'_l.is_resolvable(ResolveMethod::WEAK));
-    EXPECT_TRUE('L'_l.is_resolvable(ResolveMethod::WEAK));
-    EXPECT_TRUE('H'_l.is_resolvable(ResolveMethod::WEAK));
+    EXPECT_TRUE('0'_l.resolve(ResolveMethod::WEAK).has_value());
+    EXPECT_TRUE('1'_l.resolve(ResolveMethod::WEAK).has_value());
+    EXPECT_TRUE('L'_l.resolve(ResolveMethod::WEAK).has_value());
+    EXPECT_TRUE('H'_l.resolve(ResolveMethod::WEAK).has_value());
 
-    EXPECT_FALSE('U'_l.is_resolvable(ResolveMethod::WEAK));
-    EXPECT_FALSE('X'_l.is_resolvable(ResolveMethod::WEAK));
-    EXPECT_FALSE('Z'_l.is_resolvable(ResolveMethod::WEAK));
-    EXPECT_FALSE('W'_l.is_resolvable(ResolveMethod::WEAK));
-    EXPECT_FALSE('-'_l.is_resolvable(ResolveMethod::WEAK));
+    EXPECT_FALSE('U'_l.resolve(ResolveMethod::WEAK).has_value());
+    EXPECT_FALSE('X'_l.resolve(ResolveMethod::WEAK).has_value());
+    EXPECT_FALSE('Z'_l.resolve(ResolveMethod::WEAK).has_value());
+    EXPECT_FALSE('W'_l.resolve(ResolveMethod::WEAK).has_value());
+    EXPECT_FALSE('-'_l.resolve(ResolveMethod::WEAK).has_value());
 }
 
 TEST(TestBit, BitIsResolvable) {
-    EXPECT_TRUE('0'_b.is_resolvable(ResolveMethod::WEAK));
-    EXPECT_TRUE('1'_b.is_resolvable(ResolveMethod::WEAK));
+    EXPECT_TRUE('0'_b.resolve(ResolveMethod::WEAK).has_value());
+    EXPECT_TRUE('1'_b.resolve(ResolveMethod::WEAK).has_value());
 }
 
 TEST(TestLogic, LogicIsHashable) {

--- a/tests/cpp/test_logic.cpp
+++ b/tests/cpp/test_logic.cpp
@@ -95,24 +95,56 @@ TEST(TestBit, BitConversions) {
 // Test Logic bool conversions
 TEST(TestLogic, LogicBoolConversions) {
     // Convertible to true
-    EXPECT_EQ('1'_l.is_resolvable(), true);
-    EXPECT_EQ('H'_l.is_resolvable(), true);
+    EXPECT_EQ('1'_l.is_resolvable(ResolveMethod::WEAK), true);
+    EXPECT_EQ('H'_l.is_resolvable(ResolveMethod::WEAK), true);
 
     // Convertible to false
-    EXPECT_EQ('0'_l.is_resolvable(), true);
-    EXPECT_EQ('L'_l.is_resolvable(), true);
+    EXPECT_EQ('0'_l.is_resolvable(ResolveMethod::WEAK), true);
+    EXPECT_EQ('L'_l.is_resolvable(ResolveMethod::WEAK), true);
 
     // Non-convertible values
-    EXPECT_EQ('X'_l.is_resolvable(), false);
-    EXPECT_EQ('Z'_l.is_resolvable(), false);
-    EXPECT_EQ('U'_l.is_resolvable(), false);
-    EXPECT_EQ('W'_l.is_resolvable(), false);
-    EXPECT_EQ('-'_l.is_resolvable(), false);
+    EXPECT_EQ('X'_l.is_resolvable(ResolveMethod::WEAK), false);
+    EXPECT_EQ('Z'_l.is_resolvable(ResolveMethod::WEAK), false);
+    EXPECT_EQ('U'_l.is_resolvable(ResolveMethod::WEAK), false);
+    EXPECT_EQ('W'_l.is_resolvable(ResolveMethod::WEAK), false);
+    EXPECT_EQ('-'_l.is_resolvable(ResolveMethod::WEAK), false);
 }
 
 TEST(TestBit, BitBoolConversions) {
-    EXPECT_EQ('0'_b.is_resolvable(), true);
-    EXPECT_EQ('1'_b.is_resolvable(), true);
+    EXPECT_EQ('0'_b.is_resolvable(ResolveMethod::WEAK), true);
+    EXPECT_EQ('1'_b.is_resolvable(ResolveMethod::WEAK), true);
+}
+
+TEST(TestLogic, LogicIsResolvableUnderEachMethod) {
+    // ERROR: only 0/1 are resolvable.
+    EXPECT_TRUE('0'_l.is_resolvable(ResolveMethod::ERROR));
+    EXPECT_TRUE('1'_l.is_resolvable(ResolveMethod::ERROR));
+    EXPECT_FALSE('L'_l.is_resolvable(ResolveMethod::ERROR));
+    EXPECT_FALSE('H'_l.is_resolvable(ResolveMethod::ERROR));
+    EXPECT_FALSE('X'_l.is_resolvable(ResolveMethod::ERROR));
+    EXPECT_FALSE('Z'_l.is_resolvable(ResolveMethod::ERROR));
+    EXPECT_FALSE('U'_l.is_resolvable(ResolveMethod::ERROR));
+    EXPECT_FALSE('W'_l.is_resolvable(ResolveMethod::ERROR));
+    EXPECT_FALSE('-'_l.is_resolvable(ResolveMethod::ERROR));
+
+    // WEAK: 0/1/L/H pass; metavalues (incl. W) do not.
+    EXPECT_TRUE('0'_l.is_resolvable(ResolveMethod::WEAK));
+    EXPECT_TRUE('1'_l.is_resolvable(ResolveMethod::WEAK));
+    EXPECT_TRUE('L'_l.is_resolvable(ResolveMethod::WEAK));
+    EXPECT_TRUE('H'_l.is_resolvable(ResolveMethod::WEAK));
+    EXPECT_FALSE('X'_l.is_resolvable(ResolveMethod::WEAK));
+    EXPECT_FALSE('Z'_l.is_resolvable(ResolveMethod::WEAK));
+    EXPECT_FALSE('U'_l.is_resolvable(ResolveMethod::WEAK));
+    EXPECT_FALSE('W'_l.is_resolvable(ResolveMethod::WEAK));
+    EXPECT_FALSE('-'_l.is_resolvable(ResolveMethod::WEAK));
+
+    // ZEROS / ONES / RANDOM: always resolvable (no value can throw).
+    for (auto m : {ResolveMethod::ZEROS, ResolveMethod::ONES, ResolveMethod::RANDOM}) {
+        EXPECT_TRUE('0'_l.is_resolvable(m));
+        EXPECT_TRUE('X'_l.is_resolvable(m));
+        EXPECT_TRUE('U'_l.is_resolvable(m));
+        EXPECT_TRUE('-'_l.is_resolvable(m));
+    }
 }
 
 // Test Logic string conversions
@@ -344,21 +376,21 @@ TEST(TestLogic, RuntimeIntAndBitConversions) {
 
 // Test Logic is_resolvable
 TEST(TestLogic, LogicIsResolvable) {
-    EXPECT_TRUE('0'_l.is_resolvable());
-    EXPECT_TRUE('1'_l.is_resolvable());
-    EXPECT_TRUE('L'_l.is_resolvable());
-    EXPECT_TRUE('H'_l.is_resolvable());
+    EXPECT_TRUE('0'_l.is_resolvable(ResolveMethod::WEAK));
+    EXPECT_TRUE('1'_l.is_resolvable(ResolveMethod::WEAK));
+    EXPECT_TRUE('L'_l.is_resolvable(ResolveMethod::WEAK));
+    EXPECT_TRUE('H'_l.is_resolvable(ResolveMethod::WEAK));
 
-    EXPECT_FALSE('U'_l.is_resolvable());
-    EXPECT_FALSE('X'_l.is_resolvable());
-    EXPECT_FALSE('Z'_l.is_resolvable());
-    EXPECT_FALSE('W'_l.is_resolvable());
-    EXPECT_FALSE('-'_l.is_resolvable());
+    EXPECT_FALSE('U'_l.is_resolvable(ResolveMethod::WEAK));
+    EXPECT_FALSE('X'_l.is_resolvable(ResolveMethod::WEAK));
+    EXPECT_FALSE('Z'_l.is_resolvable(ResolveMethod::WEAK));
+    EXPECT_FALSE('W'_l.is_resolvable(ResolveMethod::WEAK));
+    EXPECT_FALSE('-'_l.is_resolvable(ResolveMethod::WEAK));
 }
 
 TEST(TestBit, BitIsResolvable) {
-    EXPECT_TRUE('0'_b.is_resolvable());
-    EXPECT_TRUE('1'_b.is_resolvable());
+    EXPECT_TRUE('0'_b.is_resolvable(ResolveMethod::WEAK));
+    EXPECT_TRUE('1'_b.is_resolvable(ResolveMethod::WEAK));
 }
 
 TEST(TestLogic, LogicIsHashable) {

--- a/tests/cpp/test_logic.cpp
+++ b/tests/cpp/test_logic.cpp
@@ -356,6 +356,26 @@ TEST(TestBit, BitResolve) {
     EXPECT_EQ('1'_b.resolve(static_cast<ResolveMethod>(99)), '1'_b);
 }
 
+// No-arg resolve() defaults to WEAK -- mirroring the LogicArrayMixin shortcut
+// so user code can write `r.resolve()` for the common synthesizable-values
+// case.
+TEST(TestLogic, LogicResolveNoArgDefaultsToWeak) {
+    EXPECT_EQ('0'_l.resolve(), '0'_b);
+    EXPECT_EQ('1'_l.resolve(), '1'_b);
+    EXPECT_EQ('L'_l.resolve(), '0'_b);
+    EXPECT_EQ('H'_l.resolve(), '1'_b);
+    EXPECT_EQ('X'_l.resolve(), std::nullopt);
+    EXPECT_EQ('U'_l.resolve(), std::nullopt);
+    EXPECT_EQ('Z'_l.resolve(), std::nullopt);
+    EXPECT_EQ('W'_l.resolve(), std::nullopt);
+    EXPECT_EQ('-'_l.resolve(), std::nullopt);
+}
+
+TEST(TestBit, BitResolveNoArgAlwaysEngaged) {
+    EXPECT_EQ('0'_b.resolve(), '0'_b);
+    EXPECT_EQ('1'_b.resolve(), '1'_b);
+}
+
 // Stores values in std::vector to force runtime evaluation of conversions.
 // These can be evaluated at compile time and reduce observed coverage.
 TEST(TestLogic, RuntimeIntAndBitConversions) {

--- a/tests/cpp/test_logic.cpp
+++ b/tests/cpp/test_logic.cpp
@@ -260,10 +260,10 @@ TEST(TestBit, BitInvert) {
 TEST(TestLogic, LogicResolve) {
     // Test WEAK resolution: 0/1 pass through; L/H map to 0/1; everything else
     // throws (the "not resolvable under WEAK" tier matches L/H plus 0/1).
-    EXPECT_EQ('0'_l.resolve(ResolveMethod::WEAK), '0'_l);
-    EXPECT_EQ('1'_l.resolve(ResolveMethod::WEAK), '1'_l);
-    EXPECT_EQ('L'_l.resolve(ResolveMethod::WEAK), '0'_l);
-    EXPECT_EQ('H'_l.resolve(ResolveMethod::WEAK), '1'_l);
+    EXPECT_EQ('0'_l.resolve(ResolveMethod::WEAK), '0'_b);
+    EXPECT_EQ('1'_l.resolve(ResolveMethod::WEAK), '1'_b);
+    EXPECT_EQ('L'_l.resolve(ResolveMethod::WEAK), '0'_b);
+    EXPECT_EQ('H'_l.resolve(ResolveMethod::WEAK), '1'_b);
     EXPECT_THROW((void)'U'_l.resolve(ResolveMethod::WEAK), std::invalid_argument);
     EXPECT_THROW((void)'X'_l.resolve(ResolveMethod::WEAK), std::invalid_argument);
     EXPECT_THROW((void)'Z'_l.resolve(ResolveMethod::WEAK), std::invalid_argument);
@@ -271,52 +271,52 @@ TEST(TestLogic, LogicResolve) {
     EXPECT_THROW((void)'-'_l.resolve(ResolveMethod::WEAK), std::invalid_argument);
 
     // Test ZEROS resolution
-    EXPECT_EQ('U'_l.resolve(ResolveMethod::ZEROS), '0'_l);
-    EXPECT_EQ('X'_l.resolve(ResolveMethod::ZEROS), '0'_l);
-    EXPECT_EQ('0'_l.resolve(ResolveMethod::ZEROS), '0'_l);
-    EXPECT_EQ('1'_l.resolve(ResolveMethod::ZEROS), '1'_l);
-    EXPECT_EQ('Z'_l.resolve(ResolveMethod::ZEROS), '0'_l);
-    EXPECT_EQ('W'_l.resolve(ResolveMethod::ZEROS), '0'_l);
-    EXPECT_EQ('L'_l.resolve(ResolveMethod::ZEROS), '0'_l);
-    EXPECT_EQ('H'_l.resolve(ResolveMethod::ZEROS), '1'_l);
-    EXPECT_EQ('-'_l.resolve(ResolveMethod::ZEROS), '0'_l);
+    EXPECT_EQ('U'_l.resolve(ResolveMethod::ZEROS), '0'_b);
+    EXPECT_EQ('X'_l.resolve(ResolveMethod::ZEROS), '0'_b);
+    EXPECT_EQ('0'_l.resolve(ResolveMethod::ZEROS), '0'_b);
+    EXPECT_EQ('1'_l.resolve(ResolveMethod::ZEROS), '1'_b);
+    EXPECT_EQ('Z'_l.resolve(ResolveMethod::ZEROS), '0'_b);
+    EXPECT_EQ('W'_l.resolve(ResolveMethod::ZEROS), '0'_b);
+    EXPECT_EQ('L'_l.resolve(ResolveMethod::ZEROS), '0'_b);
+    EXPECT_EQ('H'_l.resolve(ResolveMethod::ZEROS), '1'_b);
+    EXPECT_EQ('-'_l.resolve(ResolveMethod::ZEROS), '0'_b);
 
     // Test ONES resolution
-    EXPECT_EQ('U'_l.resolve(ResolveMethod::ONES), '1'_l);
-    EXPECT_EQ('X'_l.resolve(ResolveMethod::ONES), '1'_l);
-    EXPECT_EQ('0'_l.resolve(ResolveMethod::ONES), '0'_l);
-    EXPECT_EQ('1'_l.resolve(ResolveMethod::ONES), '1'_l);
-    EXPECT_EQ('Z'_l.resolve(ResolveMethod::ONES), '1'_l);
-    EXPECT_EQ('W'_l.resolve(ResolveMethod::ONES), '1'_l);
-    EXPECT_EQ('L'_l.resolve(ResolveMethod::ONES), '0'_l);
-    EXPECT_EQ('H'_l.resolve(ResolveMethod::ONES), '1'_l);
-    EXPECT_EQ('-'_l.resolve(ResolveMethod::ONES), '1'_l);
+    EXPECT_EQ('U'_l.resolve(ResolveMethod::ONES), '1'_b);
+    EXPECT_EQ('X'_l.resolve(ResolveMethod::ONES), '1'_b);
+    EXPECT_EQ('0'_l.resolve(ResolveMethod::ONES), '0'_b);
+    EXPECT_EQ('1'_l.resolve(ResolveMethod::ONES), '1'_b);
+    EXPECT_EQ('Z'_l.resolve(ResolveMethod::ONES), '1'_b);
+    EXPECT_EQ('W'_l.resolve(ResolveMethod::ONES), '1'_b);
+    EXPECT_EQ('L'_l.resolve(ResolveMethod::ONES), '0'_b);
+    EXPECT_EQ('H'_l.resolve(ResolveMethod::ONES), '1'_b);
+    EXPECT_EQ('-'_l.resolve(ResolveMethod::ONES), '1'_b);
 
     // Test RANDOM resolution
     auto resolved_u = 'U'_l.resolve(ResolveMethod::RANDOM);
-    EXPECT_TRUE(resolved_u == '0'_l || resolved_u == '1'_l);
+    EXPECT_TRUE(resolved_u == '0'_b || resolved_u == '1'_b);
 
     auto resolved_x = 'X'_l.resolve(ResolveMethod::RANDOM);
-    EXPECT_TRUE(resolved_x == '0'_l || resolved_x == '1'_l);
+    EXPECT_TRUE(resolved_x == '0'_b || resolved_x == '1'_b);
 
-    EXPECT_EQ('0'_l.resolve(ResolveMethod::RANDOM), '0'_l);
-    EXPECT_EQ('1'_l.resolve(ResolveMethod::RANDOM), '1'_l);
+    EXPECT_EQ('0'_l.resolve(ResolveMethod::RANDOM), '0'_b);
+    EXPECT_EQ('1'_l.resolve(ResolveMethod::RANDOM), '1'_b);
 
     auto resolved_z = 'Z'_l.resolve(ResolveMethod::RANDOM);
-    EXPECT_TRUE(resolved_z == '0'_l || resolved_z == '1'_l);
+    EXPECT_TRUE(resolved_z == '0'_b || resolved_z == '1'_b);
 
     auto resolved_w = 'W'_l.resolve(ResolveMethod::RANDOM);
-    EXPECT_TRUE(resolved_w == '0'_l || resolved_w == '1'_l);
+    EXPECT_TRUE(resolved_w == '0'_b || resolved_w == '1'_b);
 
-    EXPECT_EQ('L'_l.resolve(ResolveMethod::RANDOM), '0'_l);
-    EXPECT_EQ('H'_l.resolve(ResolveMethod::RANDOM), '1'_l);
+    EXPECT_EQ('L'_l.resolve(ResolveMethod::RANDOM), '0'_b);
+    EXPECT_EQ('H'_l.resolve(ResolveMethod::RANDOM), '1'_b);
 
     auto resolved_dc = '-'_l.resolve(ResolveMethod::RANDOM);
-    EXPECT_TRUE(resolved_dc == '0'_l || resolved_dc == '1'_l);
+    EXPECT_TRUE(resolved_dc == '0'_b || resolved_dc == '1'_b);
 
     // Test ERROR resolution
-    EXPECT_EQ('0'_l.resolve(ResolveMethod::ERROR), '0'_l);
-    EXPECT_EQ('1'_l.resolve(ResolveMethod::ERROR), '1'_l);
+    EXPECT_EQ('0'_l.resolve(ResolveMethod::ERROR), '0'_b);
+    EXPECT_EQ('1'_l.resolve(ResolveMethod::ERROR), '1'_b);
     EXPECT_THROW((void)'U'_l.resolve(ResolveMethod::ERROR), std::invalid_argument);
     EXPECT_THROW((void)'X'_l.resolve(ResolveMethod::ERROR), std::invalid_argument);
     EXPECT_THROW((void)'Z'_l.resolve(ResolveMethod::ERROR), std::invalid_argument);

--- a/tests/cpp/test_logic_array.cpp
+++ b/tests/cpp/test_logic_array.cpp
@@ -377,6 +377,18 @@ TEST(TestLogicArray, ResolveStaticReturnsStaticArray) {
     EXPECT_EQ(to_string(*b), "0100");
 }
 
+// No-arg resolve() defaults to WEAK -- engages iff every element is 0/1/L/H,
+// matching the scalar Logic::resolve() shortcut.
+TEST(TestLogicArray, ResolveNoArgDefaultsToWeak) {
+    auto resolvable = to_logic_array("01LH");
+    auto a = resolvable.resolve();
+    ASSERT_TRUE(a.has_value());
+    EXPECT_EQ(to_string(*a), "0101");
+
+    auto mixed = to_logic_array("01X");
+    EXPECT_FALSE(mixed.resolve().has_value());
+}
+
 // -- Slice resolvability ---------------------------------------------------
 //
 // The constrained partial specs of StaticArraySlice and ArraySlice inherit the

--- a/tests/cpp/test_logic_array.cpp
+++ b/tests/cpp/test_logic_array.cpp
@@ -307,20 +307,20 @@ TEST(TestLogicArray, ToStringEmpty) {
 
 TEST(TestLogicArray, IsResolvableTrue) {
     auto a = to_logic_array("01LH");
-    EXPECT_TRUE(a.is_resolvable());
+    EXPECT_TRUE(a.is_resolvable(ResolveMethod::WEAK));
 }
 
 TEST(TestLogicArray, IsResolvableFalse) {
-    EXPECT_FALSE(to_logic_array("01X0").is_resolvable());
-    EXPECT_FALSE(to_logic_array("Z").is_resolvable());
-    EXPECT_FALSE(to_logic_array("U").is_resolvable());
-    EXPECT_FALSE(to_logic_array("W").is_resolvable());
-    EXPECT_FALSE(to_logic_array("-").is_resolvable());
+    EXPECT_FALSE(to_logic_array("01X0").is_resolvable(ResolveMethod::WEAK));
+    EXPECT_FALSE(to_logic_array("Z").is_resolvable(ResolveMethod::WEAK));
+    EXPECT_FALSE(to_logic_array("U").is_resolvable(ResolveMethod::WEAK));
+    EXPECT_FALSE(to_logic_array("W").is_resolvable(ResolveMethod::WEAK));
+    EXPECT_FALSE(to_logic_array("-").is_resolvable(ResolveMethod::WEAK));
 }
 
 TEST(TestLogicArray, IsResolvableEmpty) {
     auto a = to_logic_array("");
-    EXPECT_TRUE(a.is_resolvable());
+    EXPECT_TRUE(a.is_resolvable(ResolveMethod::WEAK));
 }
 
 // -- resolve on arrays ------------------------------------------------------
@@ -376,7 +376,7 @@ TEST(TestLogicArray, ResolveStaticReturnsStaticArray) {
 //
 // The constrained partial specs of StaticArraySlice and ArraySlice inherit the
 // LogicArrayMixin too, so slices of LogicArray/BitArray/LogicVector/etc
-// have is_resolvable() and resolve(method) members. Sub-slicing preserves
+// have is_resolvable(method) and resolve(method) members. Sub-slicing preserves
 // the mixin via outer-name resolution in the slice impl.
 
 TEST(TestLogicArray, DynSliceIsResolvable) {
@@ -384,9 +384,9 @@ TEST(TestLogicArray, DynSliceIsResolvable) {
     // a[2]='0', a[1]='1', a[0]='X'.
     auto a = to_logic_array("01X");
     auto s_full = a[{2, 0}];
-    EXPECT_FALSE(s_full.is_resolvable());  // covers the X at a[0]
+    EXPECT_FALSE(s_full.is_resolvable(ResolveMethod::WEAK));  // covers the X at a[0]
     auto s_excl_x = a[{2, 1}];
-    EXPECT_TRUE(s_excl_x.is_resolvable());  // covers '0' and '1' only
+    EXPECT_TRUE(s_excl_x.is_resolvable(ResolveMethod::WEAK));  // covers '0' and '1' only
 }
 
 TEST(TestLogicArray, DynSliceResolveReturnsVector) {
@@ -406,15 +406,15 @@ TEST(TestLogicArray, StaticSliceResolveReturnsStaticArray) {
 }
 
 TEST(TestLogicArray, StaticSliceIsResolvable) {
-    // Exercises StaticArraySlice<LogicArray<R>, R2>::is_resolvable() -- the constrained
-    // partial spec from logic_array.hpp. Without this test a regression that drops
-    // the mixin from the static slice spec would only be caught when user code
-    // calls .is_resolvable() on a sliced LogicArray and fails to compile.
+    // Exercises StaticArraySlice<LogicArray<R>, R2>::is_resolvable(method) -- the
+    // constrained partial spec from logic_array.hpp. Without this test a regression that
+    // drops the mixin from the static slice spec would only be caught when user code calls
+    // .is_resolvable(method) on a sliced LogicArray and fails to compile.
     auto a = "01XZ"_l;  // a[3]='0', a[2]='1', a[1]='X', a[0]='Z'
     auto s_with_x = a.slice<Range{2, Direction::DOWNTO, 1}>();
-    EXPECT_FALSE(s_with_x.is_resolvable());  // contains '1' and 'X'
+    EXPECT_FALSE(s_with_x.is_resolvable(ResolveMethod::WEAK));  // contains '1' and 'X'
     auto s_clean = a.slice<Range{3, Direction::DOWNTO, 2}>();
-    EXPECT_TRUE(s_clean.is_resolvable());  // '0' and '1'
+    EXPECT_TRUE(s_clean.is_resolvable(ResolveMethod::WEAK));  // '0' and '1'
 }
 
 TEST(TestLogicArray, ConstOwnerDynSliceHasMixin) {
@@ -430,7 +430,7 @@ TEST(TestLogicArray, ConstOwnerDynSliceHasMixin) {
         std::same_as<decltype(s), ArraySlice<Vector<Logic> const>>,
         "const Logic owner must produce ArraySlice<const Vector<Logic>>"
     );
-    EXPECT_TRUE(s.is_resolvable());  // all elements are 0/1/L/H
+    EXPECT_TRUE(s.is_resolvable(ResolveMethod::WEAK));  // all elements are 0/1/L/H
     auto r = s.resolve(ResolveMethod::WEAK);
     EXPECT_EQ(to_string(r), "0101");  // L->0, H->1
 }
@@ -439,10 +439,10 @@ TEST(TestLogicArray, SubSlicePreservesMixin) {
     auto a = to_logic_array("01XZ");
     auto s = a[{3, 0}];
     auto sub = s[{2, 1}];  // sub-slice via ArraySliceImpl::operator[]
-    // The sub-slice still has is_resolvable() -- the impl returns
+    // The sub-slice still has is_resolvable(method) -- the impl returns
     // ArraySlice<ArrayT> by outer name, which resolves to the constrained
     // partial spec when the element type is Logic.
-    EXPECT_FALSE(sub.is_resolvable());
+    EXPECT_FALSE(sub.is_resolvable(ResolveMethod::WEAK));
 }
 
 // -- index / rindex on Logic/Bit arrays -----------------------------------
@@ -1218,9 +1218,9 @@ TEST(TestBitArray, ToStringStaticBit) {
 
 TEST(TestBitArray, IsResolvableAlwaysTrue) {
     auto a = to_bit_array("0110");
-    EXPECT_TRUE(a.is_resolvable());
+    EXPECT_TRUE(a.is_resolvable(ResolveMethod::WEAK));
     auto empty = to_bit_array("");
-    EXPECT_TRUE(empty.is_resolvable());
+    EXPECT_TRUE(empty.is_resolvable(ResolveMethod::WEAK));
 }
 
 // -- resolve on BitArray ---------------------------------------------------

--- a/tests/cpp/test_logic_array.cpp
+++ b/tests/cpp/test_logic_array.cpp
@@ -367,8 +367,9 @@ TEST(TestLogicArray, ResolveStaticReturnsStaticArray) {
     auto b = a.resolve(ResolveMethod::ZEROS);
     // Static-bound input -> static-bound output of matching range. This is the
     // payoff of memberizing resolve on the specializations: the result type
-    // preserves Self's static range when available.
-    static_assert(std::is_same_v<decltype(b), LogicArray<Range{3, Direction::DOWNTO, 0}>>);
+    // preserves Self's static range when available, and resolve always returns
+    // a Bit-valued container.
+    static_assert(std::is_same_v<decltype(b), BitArray<Range{3, Direction::DOWNTO, 0}>>);
     EXPECT_EQ(to_string(b), "0100");
 }
 
@@ -393,7 +394,7 @@ TEST(TestLogicArray, DynSliceResolveReturnsVector) {
     auto a = to_logic_array("01XZ");
     auto s = a[{3, 0}];
     auto r = s.resolve(ResolveMethod::ZEROS);
-    static_assert(std::is_same_v<decltype(r), Vector<Logic>>);
+    static_assert(std::is_same_v<decltype(r), BitVector>);
     EXPECT_EQ(to_string(r), "0100");
 }
 
@@ -401,7 +402,7 @@ TEST(TestLogicArray, StaticSliceResolveReturnsStaticArray) {
     auto a = "01XZ"_l;  // LogicArray<Range{3, DOWNTO, 0}>
     auto s = a.slice<Range{2, Direction::DOWNTO, 1}>();
     auto r = s.resolve(ResolveMethod::ZEROS);
-    static_assert(std::is_same_v<decltype(r), LogicArray<Range{2, Direction::DOWNTO, 1}>>);
+    static_assert(std::is_same_v<decltype(r), BitArray<Range{2, Direction::DOWNTO, 1}>>);
     EXPECT_EQ(to_string(r), "10");  // X->0, 1->1; slice was {X, 1} in storage order
 }
 

--- a/tests/cpp/test_logic_array.cpp
+++ b/tests/cpp/test_logic_array.cpp
@@ -337,10 +337,18 @@ TEST(TestLogicArray, ResolveOnes) {
     EXPECT_EQ(to_string(b), "011110111");
 }
 
-TEST(TestLogicArray, ResolveWeak) {
-    auto a = to_logic_array("01XZULWH-");
+TEST(TestLogicArray, ResolveWeakAcceptsResolvable) {
+    // WEAK passes 0/1/L/H -> 0/1/0/1 and throws on the rest. The input must
+    // contain only resolvable-under-WEAK values for the call to succeed.
+    auto a = to_logic_array("01LH");
     auto b = a.resolve(ResolveMethod::WEAK);
-    EXPECT_EQ(to_string(b), "01XZU0X1-");
+    EXPECT_EQ(to_string(b), "0101");
+}
+
+TEST(TestLogicArray, ResolveWeakThrowsOnMetavalue) {
+    // Even a single non-resolvable value makes the whole array throw.
+    auto a = to_logic_array("01X");
+    EXPECT_THROW(a.resolve(ResolveMethod::WEAK), std::invalid_argument);
 }
 
 TEST(TestLogicArray, ResolveError) {

--- a/tests/cpp/test_logic_array.cpp
+++ b/tests/cpp/test_logic_array.cpp
@@ -303,24 +303,24 @@ TEST(TestLogicArray, ToStringEmpty) {
     EXPECT_EQ(to_string(a), "");
 }
 
-// -- is_resolvable on arrays ------------------------------------------------
+// -- resolvability query on arrays ------------------------------------------
 
-TEST(TestLogicArray, IsResolvableTrue) {
+TEST(TestLogicArray, ResolveEngagedOnResolvable) {
     auto a = to_logic_array("01LH");
-    EXPECT_TRUE(a.is_resolvable(ResolveMethod::WEAK));
+    EXPECT_TRUE(a.resolve(ResolveMethod::WEAK).has_value());
 }
 
-TEST(TestLogicArray, IsResolvableFalse) {
-    EXPECT_FALSE(to_logic_array("01X0").is_resolvable(ResolveMethod::WEAK));
-    EXPECT_FALSE(to_logic_array("Z").is_resolvable(ResolveMethod::WEAK));
-    EXPECT_FALSE(to_logic_array("U").is_resolvable(ResolveMethod::WEAK));
-    EXPECT_FALSE(to_logic_array("W").is_resolvable(ResolveMethod::WEAK));
-    EXPECT_FALSE(to_logic_array("-").is_resolvable(ResolveMethod::WEAK));
+TEST(TestLogicArray, ResolveNulloptOnMetavalue) {
+    EXPECT_FALSE(to_logic_array("01X0").resolve(ResolveMethod::WEAK).has_value());
+    EXPECT_FALSE(to_logic_array("Z").resolve(ResolveMethod::WEAK).has_value());
+    EXPECT_FALSE(to_logic_array("U").resolve(ResolveMethod::WEAK).has_value());
+    EXPECT_FALSE(to_logic_array("W").resolve(ResolveMethod::WEAK).has_value());
+    EXPECT_FALSE(to_logic_array("-").resolve(ResolveMethod::WEAK).has_value());
 }
 
-TEST(TestLogicArray, IsResolvableEmpty) {
+TEST(TestLogicArray, ResolveEngagedOnEmpty) {
     auto a = to_logic_array("");
-    EXPECT_TRUE(a.is_resolvable(ResolveMethod::WEAK));
+    EXPECT_TRUE(a.resolve(ResolveMethod::WEAK).has_value());
 }
 
 // -- resolve on arrays ------------------------------------------------------
@@ -328,38 +328,40 @@ TEST(TestLogicArray, IsResolvableEmpty) {
 TEST(TestLogicArray, ResolveZeros) {
     auto a = to_logic_array("01XZULWH-");
     auto b = a.resolve(ResolveMethod::ZEROS);
-    EXPECT_EQ(to_string(b), "010000010");
+    EXPECT_EQ(to_string(*b), "010000010");
 }
 
 TEST(TestLogicArray, ResolveOnes) {
     auto a = to_logic_array("01XZULWH-");
     auto b = a.resolve(ResolveMethod::ONES);
-    EXPECT_EQ(to_string(b), "011110111");
+    EXPECT_EQ(to_string(*b), "011110111");
 }
 
 TEST(TestLogicArray, ResolveWeakAcceptsResolvable) {
-    // WEAK passes 0/1/L/H -> 0/1/0/1 and throws on the rest. The input must
-    // contain only resolvable-under-WEAK values for the call to succeed.
+    // WEAK passes 0/1/L/H -> 0/1/0/1 and returns nullopt on the rest. The
+    // input must contain only resolvable-under-WEAK values for the result to
+    // be engaged.
     auto a = to_logic_array("01LH");
     auto b = a.resolve(ResolveMethod::WEAK);
-    EXPECT_EQ(to_string(b), "0101");
+    EXPECT_EQ(to_string(*b), "0101");
 }
 
-TEST(TestLogicArray, ResolveWeakThrowsOnMetavalue) {
-    // Even a single non-resolvable value makes the whole array throw.
+TEST(TestLogicArray, ResolveWeakReturnsNulloptOnMetavalue) {
+    // Even a single non-resolvable value makes the whole array's resolve
+    // return nullopt (build-then-drop).
     auto a = to_logic_array("01X");
-    EXPECT_THROW(a.resolve(ResolveMethod::WEAK), std::invalid_argument);
+    EXPECT_FALSE(a.resolve(ResolveMethod::WEAK).has_value());
 }
 
 TEST(TestLogicArray, ResolveError) {
     auto a = to_logic_array("01X");
-    EXPECT_THROW(a.resolve(ResolveMethod::ERROR), std::invalid_argument);
+    EXPECT_FALSE(a.resolve(ResolveMethod::ERROR).has_value());
 }
 
 TEST(TestLogicArray, ResolveErrorPass) {
     auto a = to_logic_array("01");
     auto b = a.resolve(ResolveMethod::ERROR);
-    EXPECT_EQ(to_string(b), "01");
+    EXPECT_EQ(to_string(*b), "01");
 }
 
 TEST(TestLogicArray, ResolveStaticReturnsStaticArray) {
@@ -368,16 +370,18 @@ TEST(TestLogicArray, ResolveStaticReturnsStaticArray) {
     // Static-bound input -> static-bound output of matching range. This is the
     // payoff of memberizing resolve on the specializations: the result type
     // preserves Self's static range when available, and resolve always returns
-    // a Bit-valued container.
-    static_assert(std::is_same_v<decltype(b), BitArray<Range{3, Direction::DOWNTO, 0}>>);
-    EXPECT_EQ(to_string(b), "0100");
+    // an optional Bit-valued container.
+    static_assert(
+        std::is_same_v<decltype(b), std::optional<BitArray<Range{3, Direction::DOWNTO, 0}>>>
+    );
+    EXPECT_EQ(to_string(*b), "0100");
 }
 
 // -- Slice resolvability ---------------------------------------------------
 //
 // The constrained partial specs of StaticArraySlice and ArraySlice inherit the
 // LogicArrayMixin too, so slices of LogicArray/BitArray/LogicVector/etc
-// have is_resolvable(method) and resolve(method) members. Sub-slicing preserves
+// have resolve(method) members returning std::optional. Sub-slicing preserves
 // the mixin via outer-name resolution in the slice impl.
 
 TEST(TestLogicArray, DynSliceIsResolvable) {
@@ -385,37 +389,44 @@ TEST(TestLogicArray, DynSliceIsResolvable) {
     // a[2]='0', a[1]='1', a[0]='X'.
     auto a = to_logic_array("01X");
     auto s_full = a[{2, 0}];
-    EXPECT_FALSE(s_full.is_resolvable(ResolveMethod::WEAK));  // covers the X at a[0]
+    EXPECT_FALSE(s_full.resolve(ResolveMethod::WEAK).has_value());  // covers the X at a[0]
     auto s_excl_x = a[{2, 1}];
-    EXPECT_TRUE(s_excl_x.is_resolvable(ResolveMethod::WEAK));  // covers '0' and '1' only
+    EXPECT_TRUE(
+        s_excl_x.resolve(ResolveMethod::WEAK).has_value()
+    );  // covers '0' and '1' only
 }
 
 TEST(TestLogicArray, DynSliceResolveReturnsVector) {
     auto a = to_logic_array("01XZ");
     auto s = a[{3, 0}];
     auto r = s.resolve(ResolveMethod::ZEROS);
-    static_assert(std::is_same_v<decltype(r), BitVector>);
-    EXPECT_EQ(to_string(r), "0100");
+    static_assert(std::is_same_v<decltype(r), std::optional<BitVector>>);
+    EXPECT_EQ(to_string(*r), "0100");
 }
 
 TEST(TestLogicArray, StaticSliceResolveReturnsStaticArray) {
     auto a = "01XZ"_l;  // LogicArray<Range{3, DOWNTO, 0}>
     auto s = a.slice<Range{2, Direction::DOWNTO, 1}>();
     auto r = s.resolve(ResolveMethod::ZEROS);
-    static_assert(std::is_same_v<decltype(r), BitArray<Range{2, Direction::DOWNTO, 1}>>);
-    EXPECT_EQ(to_string(r), "10");  // X->0, 1->1; slice was {X, 1} in storage order
+    static_assert(
+        std::is_same_v<decltype(r), std::optional<BitArray<Range{2, Direction::DOWNTO, 1}>>>
+    );
+    EXPECT_EQ(to_string(*r), "10");  // X->0, 1->1; slice was {X, 1} in storage order
 }
 
 TEST(TestLogicArray, StaticSliceIsResolvable) {
-    // Exercises StaticArraySlice<LogicArray<R>, R2>::is_resolvable(method) -- the
-    // constrained partial spec from logic_array.hpp. Without this test a regression that
-    // drops the mixin from the static slice spec would only be caught when user code calls
-    // .is_resolvable(method) on a sliced LogicArray and fails to compile.
+    // Exercises StaticArraySlice<LogicArray<R>, R2>::resolve(method) -- the
+    // constrained partial spec from logic_array.hpp. Without this test a
+    // regression that drops the mixin from the static slice spec would only be
+    // caught when user code calls .resolve(method).has_value() on a sliced
+    // LogicArray and fails to compile.
     auto a = "01XZ"_l;  // a[3]='0', a[2]='1', a[1]='X', a[0]='Z'
     auto s_with_x = a.slice<Range{2, Direction::DOWNTO, 1}>();
-    EXPECT_FALSE(s_with_x.is_resolvable(ResolveMethod::WEAK));  // contains '1' and 'X'
+    EXPECT_FALSE(
+        s_with_x.resolve(ResolveMethod::WEAK).has_value()
+    );  // contains '1' and 'X'
     auto s_clean = a.slice<Range{3, Direction::DOWNTO, 2}>();
-    EXPECT_TRUE(s_clean.is_resolvable(ResolveMethod::WEAK));  // '0' and '1'
+    EXPECT_TRUE(s_clean.resolve(ResolveMethod::WEAK).has_value());  // '0' and '1'
 }
 
 TEST(TestLogicArray, ConstOwnerDynSliceHasMixin) {
@@ -431,19 +442,19 @@ TEST(TestLogicArray, ConstOwnerDynSliceHasMixin) {
         std::same_as<decltype(s), ArraySlice<Vector<Logic> const>>,
         "const Logic owner must produce ArraySlice<const Vector<Logic>>"
     );
-    EXPECT_TRUE(s.is_resolvable(ResolveMethod::WEAK));  // all elements are 0/1/L/H
+    EXPECT_TRUE(s.resolve(ResolveMethod::WEAK).has_value());  // all elements are 0/1/L/H
     auto r = s.resolve(ResolveMethod::WEAK);
-    EXPECT_EQ(to_string(r), "0101");  // L->0, H->1
+    EXPECT_EQ(to_string(*r), "0101");  // L->0, H->1
 }
 
 TEST(TestLogicArray, SubSlicePreservesMixin) {
     auto a = to_logic_array("01XZ");
     auto s = a[{3, 0}];
     auto sub = s[{2, 1}];  // sub-slice via ArraySliceImpl::operator[]
-    // The sub-slice still has is_resolvable(method) -- the impl returns
+    // The sub-slice still has resolve(method) -- the impl returns
     // ArraySlice<ArrayT> by outer name, which resolves to the constrained
     // partial spec when the element type is Logic.
-    EXPECT_FALSE(sub.is_resolvable(ResolveMethod::WEAK));
+    EXPECT_FALSE(sub.resolve(ResolveMethod::WEAK).has_value());
 }
 
 // -- index / rindex on Logic/Bit arrays -----------------------------------
@@ -1155,54 +1166,6 @@ TEST(TestBitArray, ToBitArrayInvalidChar) {
     EXPECT_THROW(to_bit_array("2"), std::invalid_argument);
 }
 
-// -- to_bit_array from range of Logic --------------------------------------
-
-TEST(TestBitArray, ToBitArrayFromLogicRange) {
-    auto a = to_logic_array("01LH");
-    auto b = to_bit_array(a);
-    static_assert(std::is_same_v<decltype(b), BitVector>);
-    EXPECT_EQ(b.range(), Range(3, Direction::DOWNTO, 0));
-    EXPECT_EQ(b[3], '0'_b);
-    EXPECT_EQ(b[2], '1'_b);
-    EXPECT_EQ(b[1], '0'_b);
-    EXPECT_EQ(b[0], '1'_b);
-}
-
-TEST(TestBitArray, ToBitArrayFromLogicRangeNonResolvable) {
-    EXPECT_THROW(to_bit_array(to_logic_array("X")), std::invalid_argument);
-    EXPECT_THROW(to_bit_array(to_logic_array("Z")), std::invalid_argument);
-    EXPECT_THROW(to_bit_array(to_logic_array("U")), std::invalid_argument);
-    EXPECT_THROW(to_bit_array(to_logic_array("W")), std::invalid_argument);
-    EXPECT_THROW(to_bit_array(to_logic_array("-")), std::invalid_argument);
-}
-
-TEST(TestBitArray, ToBitArrayFromStdVector) {
-    // Exercises the sized_range overload with a non-coconext range. std::vector
-    // is the canonical non-coconext sized range; this verifies the constraint
-    // accepts it and the single-pass fused walk yields the same result as the
-    // coconext-array form above.
-    std::vector<Logic> const v{'0'_l, '1'_l, 'L'_l, 'H'_l};
-    auto b = to_bit_array(v);
-    static_assert(std::is_same_v<decltype(b), BitVector>);
-    EXPECT_EQ(b.range(), Range(3, Direction::DOWNTO, 0));
-    EXPECT_EQ(b[3], '0'_b);
-    EXPECT_EQ(b[2], '1'_b);
-    EXPECT_EQ(b[1], '0'_b);  // L -> 0
-    EXPECT_EQ(b[0], '1'_b);  // H -> 1
-}
-
-TEST(TestBitArray, ToBitArrayFromStdVectorNonResolvable) {
-    std::vector<Logic> const v{'0'_l, '1'_l, 'X'_l};
-    EXPECT_THROW(to_bit_array(v), std::invalid_argument);
-}
-
-TEST(TestBitArray, ToBitArrayFromStaticLogicArray) {
-    auto a = "01LH"_l;
-    auto b = to_bit_array(a);
-    static_assert(std::is_same_v<decltype(b), BitVector>);
-    EXPECT_EQ(to_string(b), "0101");
-}
-
 // -- to_string on BitArray -------------------------------------------------
 
 TEST(TestBitArray, ToStringBit) {
@@ -1215,20 +1178,22 @@ TEST(TestBitArray, ToStringStaticBit) {
     EXPECT_EQ(to_string(a), "0101");
 }
 
-// -- is_resolvable on BitArray ---------------------------------------------
+// -- resolve on BitArray (always engaged) ----------------------------------
 
-TEST(TestBitArray, IsResolvableAlwaysTrue) {
+TEST(TestBitArray, ResolveAlwaysEngaged) {
     auto a = to_bit_array("0110");
-    EXPECT_TRUE(a.is_resolvable(ResolveMethod::WEAK));
+    EXPECT_TRUE(a.resolve(ResolveMethod::WEAK).has_value());
     auto empty = to_bit_array("");
-    EXPECT_TRUE(empty.is_resolvable(ResolveMethod::WEAK));
+    EXPECT_TRUE(empty.resolve(ResolveMethod::WEAK).has_value());
 }
 
 // -- resolve on BitArray ---------------------------------------------------
 
 TEST(TestBitArray, ResolveBitIsIdentity) {
     auto a = to_bit_array("0110");
-    static_assert(std::is_same_v<decltype(a.resolve(ResolveMethod::ZEROS)), BitVector>);
+    static_assert(
+        std::is_same_v<decltype(a.resolve(ResolveMethod::ZEROS)), std::optional<BitVector>>
+    );
     for (auto method :
          {ResolveMethod::ZEROS,
           ResolveMethod::ONES,
@@ -1236,7 +1201,7 @@ TEST(TestBitArray, ResolveBitIsIdentity) {
           ResolveMethod::ERROR,
           ResolveMethod::RANDOM})
     {
-        EXPECT_EQ(to_string(a.resolve(method)), "0110");
+        EXPECT_EQ(to_string(*a.resolve(method)), "0110");
     }
 }
 


### PR DESCRIPTION
Supersedes #283.

I decided that we are going to handle metavlue resolving in the handles and not on the datatypes themselves since that makes for some truly strange semantics. But I did keep some good ideas from the old PR:

* `WEAK` resolve method now throws on metavlues.
* `Logic.is_resolvable` and `LogicArray.is_resolvable` now take a resolve method.
* `Logic.resolve` and `LogicArray.resolve` now return a `Bit` and `BitArray`, respectively.

Python is left unchanged to make this mergeable now.