### PR TITLE
Be more strict about equality and remove std::formatter template/trait hell for Arrays

### DIFF
--- a/cpp/include/coconext/types/array.hpp
+++ b/cpp/include/coconext/types/array.hpp
@@ -18,6 +18,7 @@
 #include <string>
 #include <tuple>
 #include <type_traits>
+#include <typeinfo>
 
 namespace coconext::types {
 
@@ -191,12 +192,9 @@ class Array : public ArrayImpl<T, R> {
     using ArrayImpl<T, R>::operator=;
 };
 
-template <typename T, Range R1, Range R2>
+template <typename T, Range R>
     requires std::equality_comparable<T>
-constexpr bool operator==(Array<T, R1> const& lhs, Array<T, R2> const& rhs) noexcept {
-    if constexpr (R1 != R2) {
-        return false;
-    }
+constexpr bool operator==(Array<T, R> const& lhs, Array<T, R> const& rhs) noexcept {
     return std::equal(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
 }
 
@@ -298,7 +296,7 @@ using Array = detail::Array<T, detail::make_static_range<Args...>()>;
 template <typename T, coconext::types::Range R>
 struct std::hash<coconext::types::detail::Array<T, R>> {
     size_t operator()(coconext::types::detail::Array<T, R> const& arr) const noexcept {
-        size_t seed = 0;
+        size_t seed = typeid(coconext::types::detail::Array<T, R>).hash_code();
         for (auto const& elem : arr) {
             seed = coconext::types::detail::hash_combine(seed, elem);
         }

--- a/cpp/include/coconext/types/array.hpp
+++ b/cpp/include/coconext/types/array.hpp
@@ -309,4 +309,25 @@ struct std::hash<coconext::types::detail::Array<T, R>> {
     }
 };
 
+// Formatter for Array<T, R>. The Logic/Bit specializations in logic_array.hpp
+// are more-specialized partial specs and win by C++'s partial-ordering rules
+// when both headers are visible.
+template <typename T, coconext::types::Range R>
+    requires coconext::types::detail::Formattable<T>
+struct std::formatter<coconext::types::detail::Array<T, R>> {
+    constexpr auto parse(std::format_parse_context& ctx) {
+        auto it = ctx.begin();
+        if (it != ctx.end() && *it != '}') {
+            throw std::format_error("Array formatter takes no format spec");
+        }
+        return it;
+    }
+
+    auto format(
+        coconext::types::detail::Array<T, R> const& arr, std::format_context& ctx
+    ) const {
+        return coconext::types::detail::format_array("Array", arr, ctx.out());
+    }
+};
+
 #endif  // COCONEXT_ARRAY_HPP

--- a/cpp/include/coconext/types/array.hpp
+++ b/cpp/include/coconext/types/array.hpp
@@ -200,9 +200,6 @@ constexpr bool operator==(Array<T, R1> const& lhs, Array<T, R2> const& rhs) noex
     return std::equal(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
 }
 
-template <typename T, Range R>
-struct is_array<Array<T, R>> : std::true_type {};
-
 static_assert(RangedSequence<Array<int, Range{0, Direction::TO, 7}>>);
 static_assert(RangedSequence<Array<int, Range{0, Direction::TO, 7}> const>);
 static_assert(RangedSequence<ArraySlice<Array<int, Range{0, Direction::TO, 7}>>>);

--- a/cpp/include/coconext/types/array_base.hpp
+++ b/cpp/include/coconext/types/array_base.hpp
@@ -443,14 +443,14 @@ struct is_array<ArraySlice<ArrayT>> : std::true_type {};
 template <typename ArrayT, Range R>
 struct is_array<StaticArraySlice<ArrayT, R>> : std::true_type {};
 
-// -- Formatter ----------------------------------------------------------------
-
-// Walks a RangedSequence, emitting "[range]{elem, elem, ...}" via the formatter
-// for each element type. Used by the generic Array/Slice formatter.
+// Emit "<prefix>[range]{e0, e1, ...}". Used by the per-type std::formatter
+// specializations for Array/Vector/ArraySlice/StaticArraySlice on non-logic
+// element types. Logic/Bit arrays use a quoted-bit-string body instead; see
+// logic_array.hpp.
 template <RangedSequence ArrayT, typename OutIt>
     requires Formattable<std::ranges::range_value_t<ArrayT>>
-OutIt format_array(ArrayT const& arr, OutIt out) {
-    out = std::format_to(out, "{}{{", arr.range());
+OutIt format_array(std::string_view prefix, ArrayT const& arr, OutIt out) {
+    out = std::format_to(out, "{}{}{{", prefix, arr.range());
     bool first = true;
     for (auto const& elem : arr) {
         if (!first) {
@@ -467,25 +467,33 @@ OutIt format_array(ArrayT const& arr, OutIt out) {
 
 }  // namespace coconext::types
 
-// One generic formatter for every array type that opts into is_array. The
-// LogicType-constrained version in logic_array.hpp subsumes this one for
-// arrays of Logic/Bit (via constraint conjunction) and produces the terse
-// "Logic[range]{0, 1, X}" form instead.
-template <typename T>
-    requires coconext::types::ArrayType<T>
-          && coconext::types::detail::Formattable<std::ranges::range_value_t<T>>
-struct std::formatter<T> {
-    constexpr auto parse(std::format_parse_context& ctx) {
-        auto it = ctx.begin();
-        if (it != ctx.end() && *it != '}') {
-            throw std::format_error("ArrayType formatter takes no format spec");
-        }
-        return it;
+// Formatters for ArraySlice and StaticArraySlice. Both print with the
+// "ArraySlice" prefix; the static-vs-runtime distinction isn't useful to a
+// reader of the printed output. The Logic/Bit specializations in
+// logic_array.hpp are more-specialized partial specs and win when both
+// headers are visible.
+#define COCONEXT_DEFINE_ARRAY_SLICE_FORMATTER(...)                                         \
+    struct std::formatter<__VA_ARGS__> {                                                   \
+        constexpr auto parse(std::format_parse_context& ctx) {                             \
+            auto it = ctx.begin();                                                         \
+            if (it != ctx.end() && *it != '}') {                                           \
+                throw std::format_error("ArraySlice formatter takes no format spec");      \
+            }                                                                              \
+            return it;                                                                     \
+        }                                                                                  \
+        auto format(__VA_ARGS__ const& s, std::format_context& ctx) const {                \
+            return coconext::types::detail::format_array("ArraySlice", s, ctx.out());      \
+        }                                                                                  \
     }
 
-    auto format(T const& arr, std::format_context& ctx) const {
-        return coconext::types::detail::format_array(arr, ctx.out());
-    }
-};
+template <typename ArrayT>
+    requires coconext::types::detail::Formattable<std::ranges::range_value_t<ArrayT>>
+COCONEXT_DEFINE_ARRAY_SLICE_FORMATTER(coconext::types::ArraySlice<ArrayT>);
+
+template <typename ArrayT, coconext::types::Range R>
+    requires coconext::types::detail::Formattable<std::ranges::range_value_t<ArrayT>>
+COCONEXT_DEFINE_ARRAY_SLICE_FORMATTER(coconext::types::StaticArraySlice<ArrayT, R>);
+
+#undef COCONEXT_DEFINE_ARRAY_SLICE_FORMATTER
 
 #endif  // COCONEXT_ARRAY_BASE_HPP

--- a/cpp/include/coconext/types/array_base.hpp
+++ b/cpp/include/coconext/types/array_base.hpp
@@ -24,10 +24,6 @@ namespace detail {
 template <typename R>
 concept sized_input_range = std::ranges::sized_range<R> && std::ranges::input_range<R>;
 
-// Opt-in trait for array types.
-template <typename T>
-struct is_array : std::false_type {};
-
 // Helper to force a value into a constant-expression context.
 template <auto V>
 struct require_constant {};
@@ -54,12 +50,6 @@ template <typename T, typename Elem = void>
 concept StaticRangedSequence = RangedSequence<T, Elem> && requires {
     typename detail::require_constant<std::remove_cvref_t<T>::static_range>;
 };
-
-// Any type that opts into the array machinery via is_array. Element-type
-// constraints (formattability, etc.) live on the consumers that need them,
-// not on this concept.
-template <typename T>
-concept ArrayType = detail::is_array<std::remove_cvref_t<T>>::value;
 
 // -- Slice types --------------------------------------------------------------
 
@@ -436,12 +426,6 @@ class StaticArraySlice : public detail::StaticArraySliceImpl<ArrayT, R> {
 };
 
 namespace detail {
-
-template <typename ArrayT>
-struct is_array<ArraySlice<ArrayT>> : std::true_type {};
-
-template <typename ArrayT, Range R>
-struct is_array<StaticArraySlice<ArrayT, R>> : std::true_type {};
 
 // Emit "<prefix>[range]{e0, e1, ...}". Used by the per-type std::formatter
 // specializations for Array/Vector/ArraySlice/StaticArraySlice on non-logic

--- a/cpp/include/coconext/types/logic_array.hpp
+++ b/cpp/include/coconext/types/logic_array.hpp
@@ -210,7 +210,7 @@ using BitArray = detail::Array<Bit, detail::make_logic_static_range<Args...>()>;
 
 template <typename T>
 concept LogicArrayType =
-    ArrayType<T> && LogicType<std::ranges::range_value_t<std::remove_cvref_t<T>>>;
+    RangedSequence<T> && LogicType<std::ranges::range_value_t<std::remove_cvref_t<T>>>;
 
 // -- Bitwise array operations -----------------------------------------------
 

--- a/cpp/include/coconext/types/logic_array.hpp
+++ b/cpp/include/coconext/types/logic_array.hpp
@@ -612,15 +612,6 @@ auto operator~(T const& arr) {
 
 namespace detail {
 
-template <LogicType T>
-constexpr std::string_view logic_type_name() {
-    if constexpr (std::same_as<T, Logic>) {
-        return "Logic";
-    } else {
-        return "Bit";
-    }
-}
-
 template <typename ElemT, typename CharToElem>
 Vector<ElemT> parse_logic_string(std::string_view s, CharToElem char_to_elem) {
     size_t count = 0;
@@ -654,17 +645,15 @@ constexpr size_t count_non_underscore() {
     return n;
 }
 
+// Emit '<prefix>[range]{"<bit-string>"}' for Logic/Bit-element arrays.
 template <RangedSequence ArrayT, typename OutIt>
-OutIt format_typed_array(std::string_view type_name, ArrayT const& arr, OutIt out) {
-    out = std::format_to(out, "{}{}{{", type_name, arr.range());
-    bool first = true;
+    requires LogicType<std::ranges::range_value_t<ArrayT>>
+OutIt format_logic_array(std::string_view prefix, ArrayT const& arr, OutIt out) {
+    out = std::format_to(out, "{}{}{{\"", prefix, arr.range());
     for (auto const& elem : arr) {
-        if (!first) {
-            out = std::format_to(out, ", ");
-        }
-        out = std::format_to(out, "{}", to_string(elem));
-        first = false;
+        *out++ = to_char(elem);
     }
+    *out++ = '"';
     *out++ = '}';
     return out;
 }
@@ -730,34 +719,83 @@ constexpr auto operator""_b() {
 
 }  // namespace coconext::types
 
-// One LogicType-constrained formatter for every array type that opts into
-// is_array (Vector, Array, ArraySlice, StaticArraySlice). The constraint is a
-// conjunction of the generic ArrayType constraint plus a LogicType check on
-// the element type, so it subsumes the generic std::formatter<ArrayType T> in
-// array_base.hpp via C++20 partial specialization ordering with constraints.
-// Result: arrays of Logic/Bit print as "Logic[range]{0, 1, X}" instead of
-// "[range]{Logic{0}, Logic{1}, Logic{X}}".
-template <typename T>
-    requires coconext::types::ArrayType<T>
-          && coconext::types::detail::Formattable<std::ranges::range_value_t<T>>
-          && coconext::types::LogicType<std::ranges::range_value_t<T>>
-struct std::formatter<T> {
-    constexpr auto parse(std::format_parse_context& ctx) {
-        auto it = ctx.begin();
-        if (it != ctx.end() && *it != '}') {
-            throw std::format_error("ArrayType<Logic/Bit> formatter takes no format spec");
-        }
-        return it;
+// Per-type formatters for Logic/Bit-element arrays. These are more-specialized
+// partial specializations of std::formatter than the corresponding non-logic
+// formatters in array.hpp / vector.hpp / array_base.hpp, so they win by C++20
+// partial-ordering rules when both headers are visible.
+//
+// Output format: `<Prefix>[range]{"<bit-string>"}`. The prefix encodes the
+// type kind (Array / Vector / ArraySlice) and the element type (Logic / Bit).
+
+#define COCONEXT_DEFINE_LOGIC_ARRAY_FORMATTER(PREFIX, ...)                                 \
+    struct std::formatter<__VA_ARGS__> {                                                   \
+        constexpr auto parse(std::format_parse_context& ctx) {                             \
+            auto it = ctx.begin();                                                         \
+            if (it != ctx.end() && *it != '}') {                                           \
+                throw std::format_error(PREFIX " formatter takes no format spec");         \
+            }                                                                              \
+            return it;                                                                     \
+        }                                                                                  \
+        auto format(__VA_ARGS__ const& v, std::format_context& ctx) const {                \
+            return coconext::types::detail::format_logic_array(PREFIX, v, ctx.out());      \
+        }                                                                                  \
     }
 
-    auto format(T const& arr, std::format_context& ctx) const {
-        return coconext::types::detail::format_typed_array(
-            coconext::types::detail::logic_type_name<std::ranges::range_value_t<T>>(),
-            arr,
-            ctx.out()
-        );
-    }
-};
+template <coconext::types::Range R>
+COCONEXT_DEFINE_LOGIC_ARRAY_FORMATTER(
+    "LogicArray", coconext::types::detail::Array<coconext::types::Logic, R>
+);
+
+template <coconext::types::Range R>
+COCONEXT_DEFINE_LOGIC_ARRAY_FORMATTER(
+    "BitArray", coconext::types::detail::Array<coconext::types::Bit, R>
+);
+
+template <>
+COCONEXT_DEFINE_LOGIC_ARRAY_FORMATTER(
+    "LogicVector", coconext::types::Vector<coconext::types::Logic>
+);
+
+template <>
+COCONEXT_DEFINE_LOGIC_ARRAY_FORMATTER(
+    "BitVector", coconext::types::Vector<coconext::types::Bit>
+);
+
+template <typename ArrayT>
+    requires coconext::types::detail::Formattable<std::ranges::range_value_t<ArrayT>>
+          && std::same_as<
+                 std::remove_cv_t<std::ranges::range_value_t<ArrayT>>,
+                 coconext::types::Logic>
+COCONEXT_DEFINE_LOGIC_ARRAY_FORMATTER(
+    "LogicArraySlice", coconext::types::ArraySlice<ArrayT>
+);
+
+template <typename ArrayT>
+    requires coconext::types::detail::Formattable<std::ranges::range_value_t<ArrayT>>
+          && std::same_as<
+                 std::remove_cv_t<std::ranges::range_value_t<ArrayT>>,
+                 coconext::types::Bit>
+COCONEXT_DEFINE_LOGIC_ARRAY_FORMATTER("BitArraySlice", coconext::types::ArraySlice<ArrayT>);
+
+template <typename ArrayT, coconext::types::Range R>
+    requires coconext::types::detail::Formattable<std::ranges::range_value_t<ArrayT>>
+          && std::same_as<
+                 std::remove_cv_t<std::ranges::range_value_t<ArrayT>>,
+                 coconext::types::Logic>
+COCONEXT_DEFINE_LOGIC_ARRAY_FORMATTER(
+    "LogicArraySlice", coconext::types::StaticArraySlice<ArrayT, R>
+);
+
+template <typename ArrayT, coconext::types::Range R>
+    requires coconext::types::detail::Formattable<std::ranges::range_value_t<ArrayT>>
+          && std::same_as<
+                 std::remove_cv_t<std::ranges::range_value_t<ArrayT>>,
+                 coconext::types::Bit>
+COCONEXT_DEFINE_LOGIC_ARRAY_FORMATTER(
+    "BitArraySlice", coconext::types::StaticArraySlice<ArrayT, R>
+);
+
+#undef COCONEXT_DEFINE_LOGIC_ARRAY_FORMATTER
 
 #undef COCONEXT_DYN_LOGIC_ARRAY_CONSTEXPR
 

--- a/cpp/include/coconext/types/vector.hpp
+++ b/cpp/include/coconext/types/vector.hpp
@@ -249,14 +249,6 @@ constexpr bool operator==(Vector<ValueT> const& lhs, Vector<ValueT> const& rhs) 
     return true;
 }
 
-namespace detail {
-
-// Opt into array-specific features such as formatting.
-template <typename T>
-struct is_array<Vector<T>> : std::true_type {};
-
-}  // namespace detail
-
 static_assert(RangedSequence<Vector<int>>);
 static_assert(RangedSequence<Vector<int> const>);
 static_assert(RangedSequence<ArraySlice<Vector<int>>>);

--- a/cpp/include/coconext/types/vector.hpp
+++ b/cpp/include/coconext/types/vector.hpp
@@ -291,6 +291,24 @@ struct std::hash<coconext::types::Vector<T>> {
     }
 };
 
+// Formatter for Vector<T>. The Logic/Bit specializations in logic_array.hpp
+// are more-specialized partial specs and win when both headers are visible.
+template <typename T>
+    requires coconext::types::detail::Formattable<T>
+struct std::formatter<coconext::types::Vector<T>> {
+    constexpr auto parse(std::format_parse_context& ctx) {
+        auto it = ctx.begin();
+        if (it != ctx.end() && *it != '}') {
+            throw std::format_error("Vector formatter takes no format spec");
+        }
+        return it;
+    }
+
+    auto format(coconext::types::Vector<T> const& arr, std::format_context& ctx) const {
+        return coconext::types::detail::format_array("Vector", arr, ctx.out());
+    }
+};
+
 #undef COCONEXT_VECTOR_CONSTEXPR
 
 #endif  // COCONEXT_VECTOR_HPP

--- a/cpp/include/coconext/types/vector.hpp
+++ b/cpp/include/coconext/types/vector.hpp
@@ -16,6 +16,7 @@
 #include <stdexcept>
 #include <string>
 #include <type_traits>
+#include <typeinfo>
 
 // std::unique_ptr's constexpr support landed in C++23 (P2273R3); under C++20
 // the constexpr keyword on Vector's members is still legal but evaluating
@@ -275,7 +276,10 @@ static_assert(
 template <typename T>
 struct std::hash<coconext::types::Vector<T>> {
     size_t operator()(coconext::types::Vector<T> const& arr) const noexcept {
-        size_t seed = hash<coconext::types::Range>{}(arr.range());
+        size_t seed = typeid(coconext::types::Vector<T>).hash_code();
+        seed = coconext::types::detail::hash_mix(
+            seed, hash<coconext::types::Range>{}(arr.range())
+        );
         for (auto const& elem : arr) {
             seed = coconext::types::detail::hash_combine(seed, elem);
         }

--- a/tests/cpp/test_array.cpp
+++ b/tests/cpp/test_array.cpp
@@ -534,6 +534,17 @@ TEST(TestVector, UnorderedSetDeduplicatesEmptyArrays) {
     EXPECT_EQ(s.size(), 1U);
 }
 
+TEST(TestVector, HashDistinctAcrossElementType) {
+    // Element- and range-equivalent values of Vector<int> and Vector<long>
+    // are distinct types with no cross-type equality; their hashes must
+    // differ.
+    Vector<int> a({1, 2, 3});
+    Vector<long> b({1L, 2L, 3L});
+    auto ha = std::hash<Vector<int>>{}(a);
+    auto hb = std::hash<Vector<long>>{}(b);
+    EXPECT_NE(ha, hb);
+}
+
 // -- Copy semantics ---------------------------------------------------------
 
 TEST(TestVector, Copy) {

--- a/tests/cpp/test_array.cpp
+++ b/tests/cpp/test_array.cpp
@@ -575,40 +575,40 @@ TEST(TestVector, MoveAssignReplacesRange) {
 
 TEST(TestVector, FormatterInt) {
     Vector<int> a({1, 2, 3});
-    EXPECT_EQ(std::format("{}", a), "[0 to 2]{1, 2, 3}");
+    EXPECT_EQ(std::format("{}", a), "Vector[0 to 2]{1, 2, 3}");
 }
 
 TEST(TestVector, FormatterEmpty) {
     Vector<int> a({});
-    EXPECT_EQ(std::format("{}", a), "[0 to -1]{}");
+    EXPECT_EQ(std::format("{}", a), "Vector[0 to -1]{}");
 }
 
 TEST(TestVector, FormatterLogic) {
     Vector<Logic> a({'0'_l, '1'_l, 'X'_l});
-    EXPECT_EQ(std::format("{}", a), "Logic[2 downto 0]{0, 1, X}");
+    EXPECT_EQ(std::format("{}", a), "LogicVector[2 downto 0]{\"01X\"}");
 }
 
 TEST(TestVector, FormatterBit) {
     Vector<Bit> a({'0'_b, '1'_b, '0'_b, '1'_b});
-    EXPECT_EQ(std::format("{}", a), "Bit[3 downto 0]{0, 1, 0, 1}");
+    EXPECT_EQ(std::format("{}", a), "BitVector[3 downto 0]{\"0101\"}");
 }
 
 TEST(TestVector, FormatterLogicSlice) {
     Vector<Logic> a({'0'_l, '1'_l, 'X'_l, 'Z'_l});
     auto s = a[Range(2, 1)];
-    EXPECT_EQ(std::format("{}", s), "Logic[2 downto 1]{1, X}");
+    EXPECT_EQ(std::format("{}", s), "LogicArraySlice[2 downto 1]{\"1X\"}");
 }
 
 TEST(TestVector, FormatterLogicConstSlice) {
     Vector<Logic> const a({'0'_l, '1'_l, 'X'_l, 'Z'_l});
     auto s = a[Range(2, 1)];
-    EXPECT_EQ(std::format("{}", s), "Logic[2 downto 1]{1, X}");
+    EXPECT_EQ(std::format("{}", s), "LogicArraySlice[2 downto 1]{\"1X\"}");
 }
 
 TEST(TestVector, FormatterBitSlice) {
     Vector<Bit> a({'0'_b, '1'_b, '0'_b, '1'_b});
     auto s = a[Range(2, 1)];
-    EXPECT_EQ(std::format("{}", s), "Bit[2 downto 1]{1, 0}");
+    EXPECT_EQ(std::format("{}", s), "BitArraySlice[2 downto 1]{\"10\"}");
 }
 
 // -- Static slice of Vector (compile-time-bounded view) -----------------

--- a/tests/cpp/test_logic_array.cpp
+++ b/tests/cpp/test_logic_array.cpp
@@ -962,17 +962,16 @@ TEST(TestLogicArray, UdlLogicAllUnderscores) {
 }
 
 TEST(TestLogicArray, FormatterStatic) {
-    // The LogicType-constrained std::formatter spec in logic_array.hpp must
-    // pick up static LogicArray, not just LogicVector (the latter is covered
-    // in test_array.cpp). Verifies the partial spec matches at the static
-    // owner type and produces the "Logic[range]{...}" form.
+    // Per-type std::formatter spec for Array<Logic, R> in logic_array.hpp
+    // must wins over the generic Array formatter. Verifies the spec produces
+    // the "LogicArray[range]{"..."}" form.
     auto a = "01XZ"_l;  // LogicArray<Range{3, DOWNTO, 0}>
-    EXPECT_EQ(std::format("{}", a), "Logic[3 downto 0]{0, 1, X, Z}");
+    EXPECT_EQ(std::format("{}", a), "LogicArray[3 downto 0]{\"01XZ\"}");
 }
 
 TEST(TestBitArray, FormatterStatic) {
     auto a = "0101"_b;  // BitArray<Range{3, DOWNTO, 0}>
-    EXPECT_EQ(std::format("{}", a), "Bit[3 downto 0]{0, 1, 0, 1}");
+    EXPECT_EQ(std::format("{}", a), "BitArray[3 downto 0]{\"0101\"}");
 }
 
 TEST(TestLogicArray, UdlBitwiseOps) {

--- a/tests/cpp/test_static_array.cpp
+++ b/tests/cpp/test_static_array.cpp
@@ -255,6 +255,27 @@ TEST(TestStaticArray, UnorderedSetByValue) {
     EXPECT_EQ(s.size(), 1u);
 }
 
+TEST(TestStaticArray, HashDistinctAcrossElementType) {
+    // Element-equivalent values of Array<int, R> and Array<long, R> are
+    // distinct types with no cross-type equality; their hashes must differ
+    // so a downstream type added to the family doesn't inherit a collision.
+    Array<int, Range{0, Direction::TO, 2}> a({1, 2, 3});
+    Array<long, Range{0, Direction::TO, 2}> b({1L, 2L, 3L});
+    auto ha = std::hash<decltype(a)>{}(a);
+    auto hb = std::hash<decltype(b)>{}(b);
+    EXPECT_NE(ha, hb);
+}
+
+TEST(TestStaticArray, HashDistinctAcrossRange) {
+    // Different static ranges instantiate different types; their hashes
+    // must differ even when the element sequence matches.
+    Array<int, Range{0, Direction::TO, 2}> a({1, 2, 3});
+    Array<int, Range{2, Direction::DOWNTO, 0}> b({1, 2, 3});
+    auto ha = std::hash<decltype(a)>{}(a);
+    auto hb = std::hash<decltype(b)>{}(b);
+    EXPECT_NE(ha, hb);
+}
+
 // -- Formatter --------------------------------------------------------------
 
 TEST(TestStaticArray, FormatterInt) {

--- a/tests/cpp/test_static_array.cpp
+++ b/tests/cpp/test_static_array.cpp
@@ -259,46 +259,46 @@ TEST(TestStaticArray, UnorderedSetByValue) {
 
 TEST(TestStaticArray, FormatterInt) {
     Array<int, Range{0, Direction::TO, 2}> a({1, 2, 3});
-    EXPECT_EQ(std::format("{}", a), "[0 to 2]{1, 2, 3}");
+    EXPECT_EQ(std::format("{}", a), "Array[0 to 2]{1, 2, 3}");
 }
 
 TEST(TestStaticArray, FormatterEmpty) {
     Array<int, Range{0, Direction::TO, -1}> a;
-    EXPECT_EQ(std::format("{}", a), "[0 to -1]{}");
+    EXPECT_EQ(std::format("{}", a), "Array[0 to -1]{}");
 }
 
 TEST(TestStaticArray, FormatterLogic) {
     Array<Logic, Range{0, Direction::TO, 2}> a({'0'_l, '1'_l, 'X'_l});
-    EXPECT_EQ(std::format("{}", a), "Logic[0 to 2]{0, 1, X}");
+    EXPECT_EQ(std::format("{}", a), "LogicArray[0 to 2]{\"01X\"}");
 }
 
 TEST(TestStaticArray, FormatterBit) {
     Array<Bit, Range{0, Direction::TO, 3}> a({'0'_b, '1'_b, '0'_b, '1'_b});
-    EXPECT_EQ(std::format("{}", a), "Bit[0 to 3]{0, 1, 0, 1}");
+    EXPECT_EQ(std::format("{}", a), "BitArray[0 to 3]{\"0101\"}");
 }
 
 TEST(TestStaticArray, FormatterLogicRuntimeSlice) {
     Array<Logic, Range{0, Direction::TO, 3}> a({'0'_l, '1'_l, 'X'_l, 'Z'_l});
     auto s = a[Range{1, 2}];
-    EXPECT_EQ(std::format("{}", s), "Logic[1 to 2]{1, X}");
+    EXPECT_EQ(std::format("{}", s), "LogicArraySlice[1 to 2]{\"1X\"}");
 }
 
 TEST(TestStaticArray, FormatterLogicRuntimeSliceConst) {
     Array<Logic, Range{0, Direction::TO, 3}> const a({'0'_l, '1'_l, 'X'_l, 'Z'_l});
     auto s = a[Range{1, 2}];
-    EXPECT_EQ(std::format("{}", s), "Logic[1 to 2]{1, X}");
+    EXPECT_EQ(std::format("{}", s), "LogicArraySlice[1 to 2]{\"1X\"}");
 }
 
 TEST(TestStaticArray, FormatterBitRuntimeSlice) {
     Array<Bit, Range{0, Direction::TO, 3}> a({'0'_b, '1'_b, '0'_b, '1'_b});
     auto s = a[Range{1, 2}];
-    EXPECT_EQ(std::format("{}", s), "Bit[1 to 2]{1, 0}");
+    EXPECT_EQ(std::format("{}", s), "BitArraySlice[1 to 2]{\"10\"}");
 }
 
 TEST(TestStaticArray, FormatterBitRuntimeSliceConst) {
     Array<Bit, Range{0, Direction::TO, 3}> const a({'0'_b, '1'_b, '0'_b, '1'_b});
     auto s = a[Range{1, 2}];
-    EXPECT_EQ(std::format("{}", s), "Bit[1 to 2]{1, 0}");
+    EXPECT_EQ(std::format("{}", s), "BitArraySlice[1 to 2]{\"10\"}");
 }
 
 // -- Static sub-slice (compile-time-bounded) -------------------------------


### PR DESCRIPTION
The is_array trait and ArrayType concept are now only used for formatter implementation. Now that we are being more specific with the formatting, this makes less sense. Also it will eventually cause issues with Unsigned and Signed being formatted like they are BitArray subtypes instead of as integers. It was just going to be a pain so we removed it.

Next we remove cross-type equality for Array-like types as this becomes subtley broken when Unsigned and Signed are added, where they will compare and hash equal to BitArray. So also added seeding the hash with the typeid which is recommended by the standard committee (hence the bespoke `typeid(...).hash_code()` thing).