### PR TITLE
Split coconext and add dependency on libgpi

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -14,14 +14,71 @@ target_include_directories(coconext PUBLIC
 target_compile_features(coconext PUBLIC cxx_std_20)
 set_target_properties(coconext PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 
-# On macOS the install name is @rpath-relative so a preloaded image
-# satisfies the dependency by install-name match rather than by search path.
-# Looks like RPATH, is actually not.
+# Needed for MacOS.
 set_target_properties(coconext PROPERTIES
     MACOSX_RPATH TRUE
     INSTALL_NAME_DIR "@rpath")
 
-install(TARGETS coconext
+# -- libgpi --------------------------------------------------------------------
+#
+# This is some CMake to pull in libgpi since cocotb doesn't provide a CMake
+# package yet.
+
+# Use cocotb_tools.config to get libgpi binary dir and include dir
+execute_process(
+    COMMAND ${Python_EXECUTABLE} -c
+        "from cocotb_tools.config import libs_dir, share_dir; print(libs_dir); print(share_dir / 'include')"
+    OUTPUT_VARIABLE _coconext_cocotb_paths
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    COMMAND_ERROR_IS_FATAL ANY)
+string(REPLACE "\n" ";" _coconext_cocotb_paths "${_coconext_cocotb_paths}")
+list(GET _coconext_cocotb_paths 0 COCOTB_LIBS_DIR)
+list(GET _coconext_cocotb_paths 1 COCOTB_INCLUDE_DIR)
+
+# Create a CMake target for libgpi. cocotb installs libgpi as .so on every platform except Windows (including MacOS).
+if(WIN32)
+    set(_coconext_libgpi_suffix ".dll")
+else()
+    set(_coconext_libgpi_suffix ".so")
+endif()
+add_library(cocotb_gpi SHARED IMPORTED)
+set_target_properties(cocotb_gpi PROPERTIES
+    IMPORTED_LOCATION "${COCOTB_LIBS_DIR}/libgpi${_coconext_libgpi_suffix}"
+    INTERFACE_INCLUDE_DIRECTORIES "${COCOTB_INCLUDE_DIR}")
+
+# -- libcoconext_gpi -----------------------------------------------------------
+#
+# For parts of the library that have a dependency on libgpi and a running
+# simulation, e.g. handles and GPI triggers.
+
+add_library(coconext_gpi SHARED
+    src/sim_objects.cpp
+)
+set_target_properties(coconext_gpi PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+target_link_libraries(coconext_gpi
+    PRIVATE
+        cocotb_gpi
+    PUBLIC
+        coconext)
+
+# Needed for MacOS.
+set_target_properties(coconext_gpi PROPERTIES
+    MACOSX_RPATH TRUE
+    INSTALL_NAME_DIR "@rpath")
+
+# RPATH to the current dir to pick up libcoconext.
+if(APPLE)
+    set(_coconext_origin "@loader_path")
+else()
+    set(_coconext_origin "$ORIGIN")
+endif()
+set_target_properties(coconext_gpi PROPERTIES
+    INSTALL_RPATH "${_coconext_origin}"
+    BUILD_RPATH "${_coconext_origin}")
+
+# -- install -------------------------------------------------------------------
+
+install(TARGETS coconext coconext_gpi
     EXPORT coconextTargets
     LIBRARY DESTINATION coconext/lib
     RUNTIME DESTINATION coconext/lib

--- a/cpp/include/coconext/sim_objects.hpp
+++ b/cpp/include/coconext/sim_objects.hpp
@@ -1,0 +1,10 @@
+#ifndef COCONEXT_SIM_OBJECTS_HPP
+#define COCONEXT_SIM_OBJECTS_HPP
+
+namespace coconext::sim_objects {
+
+bool has_registered_impl() noexcept;
+
+}  // namespace coconext::sim_objects
+
+#endif  // COCONEXT_SIM_OBJECTS_HPP

--- a/cpp/src/sim_objects.cpp
+++ b/cpp/src/sim_objects.cpp
@@ -1,0 +1,8 @@
+#include <coconext/sim_objects.hpp>
+#include <gpi.h>
+
+namespace coconext::sim_objects {
+
+bool has_registered_impl() noexcept { return ::gpi_has_registered_impl(); }
+
+}  // namespace coconext::sim_objects

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 requires = [
     "scikit-build-core >=0.4.3",
     "nanobind >=1.3.2",
+    "cocotb @ git+https://github.com/cocotb/cocotb.git",
 ]
 build-backend = "scikit_build_core.build"
 

--- a/python/coconext/__init__.py
+++ b/python/coconext/__init__.py
@@ -10,25 +10,6 @@ __version__ = "0.3.dev"
 
 
 def _preload_libcoconext() -> None:
-    """Make ``libcoconext`` resolvable for the ``_pycoconext`` extension.
-
-    ``_pycoconext`` has a ``NEEDED libcoconext`` dependency but carries no
-    RPATH (by design -- see cpp/CMakeLists.txt). Rather than teaching the
-    loader where to search, we ensure the library is already loaded before the
-    extension is imported, matching cocotb's loading model.
-
-    On Linux/macOS the library is ``dlopen``-ed with ``RTLD_GLOBAL`` so the
-    extension's dependency resolves against the in-memory image -- and, just as
-    importantly, so the process-wide globals coconext owns (the RNG today,
-    handle/scheduler state once GPI lands) are a single shared instance visible
-    to every later consumer. On Windows the containing directory is added to
-    the DLL search path instead.
-
-    The library lives at ``<dir of _pycoconext>/coconext/lib/`` in both wheel
-    and editable installs, so we anchor on the extension's resolved location
-    rather than this package's ``__file__`` (which points at the source tree in
-    editable mode).
-    """
     import importlib.util
     import sys
     from pathlib import Path
@@ -48,19 +29,29 @@ def _preload_libcoconext() -> None:
 
     import ctypes
 
-    leaf = "libcoconext.dylib" if sys.platform == "darwin" else "libcoconext.so"
-    anchored = lib_dir / leaf
-    if anchored.exists():
-        # Wheel layout: the library ships next to the extension.
-        ctypes.CDLL(str(anchored), mode=ctypes.RTLD_GLOBAL)
+    from cocotb_tools.config import libs_dir as _cocotb_libs_dir
+
+    is_darwin = sys.platform == "darwin"
+    ext = ".dylib" if is_darwin else ".so"
+
+    # libgpi is always suffixed with .so
+    ctypes.CDLL(str(_cocotb_libs_dir / "libgpi.so"), mode=ctypes.RTLD_GLOBAL)
+
+    anchored_core = lib_dir / f"libcoconext{ext}"
+    anchored_sim = lib_dir / f"libcoconext_gpi{ext}"
+    if anchored_core.exists():
+        # Wheel layout: the libraries ship next to the extension.
+        ctypes.CDLL(str(anchored_core), mode=ctypes.RTLD_GLOBAL)
+        ctypes.CDLL(str(anchored_sim), mode=ctypes.RTLD_GLOBAL)
     else:
-        # Editable / alternative layouts: the library isn't co-located. Try
-        # using the bare name so sharing still holds when the loader can find
-        # it.
-        try:
-            ctypes.CDLL(leaf, mode=ctypes.RTLD_GLOBAL)
-        except OSError:
-            pass
+        # Editable / alternative layouts: the libraries aren't co-located.
+        # Use bare names to let the dynamic linker find them if they have
+        # already been loaded (e.g. via GPI_USERS).
+        for leaf in (f"libcoconext{ext}", f"libcoconext_gpi{ext}"):
+            try:
+                ctypes.CDLL(leaf, mode=ctypes.RTLD_GLOBAL)
+            except OSError:
+                pass
 
 
 _preload_libcoconext()


### PR DESCRIPTION
We split libcoconext into two: one that's pure C++ with no deps and another that depends on libgpi. The difference is dynamic linking requirements and who is allowed to load the libraries.

libcoconext.so, the pure C++ library with no deps, can be loaded by anyone. libcoconext_sim.so depends on libgpi.so, so can only be loaded by a running simulation (or presumably someone with enough of an interest to source the dependency themselves).

Finally it adds a stub for sim_objects, coconext's corollary to handles, with a token libgpi usage to ensure it works.