### PR TITLE
ABI version checking against compiled user tests 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,15 @@ DEV_BUILD_DEP_GROUP ?= dev
 
 CXX_STANDARD ?= 20
 
+GIT_HASH := $(shell git describe --always --dirty --exclude '*')
+
 .PHONY: dev_build
 dev_build:
 	uv sync --no-default-groups --group=$(DEV_BUILD_DEP_GROUP) --no-install-project
 
 	# Build the package with debugging and coverage flags.
 	CCACHE_DISABLE=1 \
-	CXXFLAGS="$$CXXFLAGS --coverage -g -Og" \
+	CXXFLAGS="$$CXXFLAGS --coverage -g -Og -DCOCONEXT_ABI_VERSION=\"\\\"$(GIT_HASH)\\\"\"" \
 	CFLAGS="$$CFLAGS --coverage -g -Og" \
 	LDFLAGS="$$LDFLAGS --coverage" \
 	CMAKE_CXX_STANDARD=$(CXX_STANDARD) \

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -3,6 +3,10 @@ add_library(coconext SHARED
     src/random.cpp
 )
 
+target_compile_definitions(coconext PUBLIC
+    COCONEXT_ABI_VERSION=\"${SKBUILD_PROJECT_VERSION}\"
+)
+
 option(COCONEXT_USE_APINT "Use LLVM APInt backend" OFF)
 if(COCONEXT_USE_APINT)
     target_compile_definitions(coconext PUBLIC COCONEXT_USE_APINT)

--- a/nanobind/src/bind.cpp
+++ b/nanobind/src/bind.cpp
@@ -8,4 +8,5 @@ void register_range(nb::module_& m);
 NB_MODULE(_pycoconext, m) {
     register_logic(m);
     register_range(m);
+    // bubble up a boolean from user code
 }

--- a/python/coconext_tools/config.py
+++ b/python/coconext_tools/config.py
@@ -40,6 +40,19 @@ def _get_parser() -> argparse.ArgumentParser:
     return parser
 
 
+# import ctypes
+# import coconext
+
+# def load_user_cpp_library(coconext_cpp):
+#     abi_mismatc = coconext.check_abi_version()
+
+#     if abi_mismatch:
+#         raise RuntimeError(
+#             f"ABI Mismatch! You compiled your tests with coconext v{user_abi}, "
+#             f"but you are running coconext v{current_abi}. Please recompile your tests."
+#         )
+
+
 def main() -> None:  # noqa: D103
     parser = _get_parser()
     args = parser.parse_args()


### PR DESCRIPTION
@ktbarrett This is blocked on some things
-  It cannot be tested unitll user test support is added, or cant it be?
- We are going to have python in the loop even for pure cpp user tests? https://github.com/ktbarrett/coconext/issues/304#issuecomment-4886046862  