### PR TITLE
Finish API docs on Logic, Bit, Range, Array, Vector, RangedSequence, LogicArray, and pretty much everything else

### DIFF
--- a/cpp/include/coconext/types.hpp
+++ b/cpp/include/coconext/types.hpp
@@ -3,7 +3,6 @@
 
 // NOLINTBEGIN(unused-includes)
 #include "./types/array.hpp"
-#include "./types/array_base.hpp"
 #include "./types/concepts.hpp"
 #include "./types/direction.hpp"
 #include "./types/int.hpp"

--- a/cpp/include/coconext/types/array.hpp
+++ b/cpp/include/coconext/types/array.hpp
@@ -12,7 +12,6 @@
 #include <initializer_list>
 #include <iterator>
 #include <limits>
-#include <optional>
 #include <ranges>
 #include <stdexcept>
 #include <string>
@@ -76,24 +75,25 @@ class ArrayImpl {
         std::ranges::copy(obj, data_.begin());
     }
 
-    // The range, exposed two ways: `static_range` for type-level access
-    // (`T::static_range`, used by the StaticRangedSequence concept), and a
-    // plain constexpr `range()` member matching Vector's instance accessor
-    // so generic code can write `obj.range()` uniformly across both.
     static constexpr Range static_range = R;
-    constexpr Range range() const noexcept { return static_range; }
-    constexpr size_t size() const noexcept { return static_range.length(); }
+    static constexpr Range range() noexcept { return static_range; }
+    static constexpr size_t size() noexcept { return static_range.length(); }
 
-    constexpr reference operator[](index_type idx) { return access_(*this, idx); }
+    constexpr reference operator[](index_type idx) {
+        auto offset = offset_of(R, idx);
+        if (!offset.has_value()) {
+            throw std::out_of_range("Index out of bounds");
+        }
+        return data_[offset.value()];
+    }
     constexpr const_reference operator[](index_type idx) const {
-        return access_(*this, idx);
+        auto offset = offset_of(R, idx);
+        if (!offset.has_value()) {
+            throw std::out_of_range("Index out of bounds");
+        }
+        return data_[offset.value()];
     }
 
-    // Slices are constructed with the outer `Array<T, R>` (or const variant)
-    // as the owner. `this` is an ArrayImpl*, but the outer Array derives from
-    // it, so static_cast safely lands on the most-derived type at every
-    // instantiation -- and routes through the Logic/Bit slice partial spec
-    // when applicable.
     constexpr ArraySlice<Array<T, R>> operator[](Range r) {
         detail::subsequence_check(R, r);
         return ArraySlice<Array<T, R>>(static_cast<Array<T, R>*>(this), r);
@@ -146,12 +146,12 @@ class ArrayImpl {
 
     template <index_type I>
     constexpr reference index() {
-        static_assert(find(R, I) != R.end(), "index is out of range");
+        static_assert(contains(R, I), "index is out of range");
         return (*this)[I];
     }
     template <index_type I>
     constexpr const_reference index() const {
-        static_assert(find(R, I) != R.end(), "index is out of range");
+        static_assert(contains(R, I), "index is out of range");
         return (*this)[I];
     }
 
@@ -165,26 +165,12 @@ class ArrayImpl {
     constexpr auto rend() const noexcept { return data_.rend(); }
 
   private:
-    template <typename Self>
-    static constexpr auto& access_(Self& self, index_type idx) {
-        if constexpr (R.direction == Direction::TO) {
-            if (idx < R.left || idx > R.right) {
-                throw std::out_of_range("Index out of bounds");
-            }
-            return *(self.begin() + (idx - R.left));
-        } else {
-            if (idx > R.left || idx < R.right) {
-                throw std::out_of_range("Index out of bounds");
-            }
-            return *(self.begin() + (R.left - idx));
-        }
-    }
-
     std::array<value_type, R.length()> data_;
 };
 
-// Local-allocated, compile-time-bounded array indexed according to its Range.
-// This is the canonical "Array" implementation. It's stuck in detail since `Array`
+// Local-allocated, compile-time-bounded, type-generic array indexed according to its Range.
+// This is the canonical "Array" implementation. Stuck here so coconext::types::Array can be
+// the variadic template.
 template <typename T, Range R>
 class Array : public ArrayImpl<T, R> {
   public:
@@ -304,9 +290,6 @@ struct std::hash<coconext::types::detail::Array<T, R>> {
     }
 };
 
-// Formatter for Array<T, R>. The Logic/Bit specializations in logic_array.hpp
-// are more-specialized partial specs and win by C++'s partial-ordering rules
-// when both headers are visible.
 template <typename T, coconext::types::Range R>
     requires coconext::types::detail::Formattable<T>
 struct std::formatter<coconext::types::detail::Array<T, R>> {

--- a/cpp/include/coconext/types/array_base.hpp
+++ b/cpp/include/coconext/types/array_base.hpp
@@ -34,10 +34,7 @@ struct require_constant {};
 // optional `Elem` template parameter constrains the element type: `Elem = void`
 // (the default) matches any element type; a concrete type requires the element
 // to match exactly. So `RangedSequence T` matches any ranged sequence,
-// `RangedSequence<Logic> T` matches only ranged sequences of Logic. Concepts
-// can't be passed as template arguments in C++20, so element-concept
-// constraints (e.g. "any LogicType element") still need a composed concept or
-// a separate requires clause.
+// `RangedSequence<Logic> T` matches only ranged sequences of Logic.
 template <typename T, typename Elem = void>
 concept RangedSequence = std::ranges::random_access_range<T> && requires(T const& t) {
     { t.range() } -> std::convertible_to<Range>;
@@ -61,19 +58,8 @@ constexpr void subsequence_check(Range parent, Range child) {
     }
 }
 
-// Convert a 0-based offset into the data buffer (iteration order) to the
-// corresponding HDL coordinate for the given range's direction.
-constexpr Range::value_type offset_to_hdl_coord(
-    Range r, size_t offset_from_begin
-) noexcept {
-    auto const off = static_cast<Range::value_type>(offset_from_begin);
-    return r.direction == Direction::TO ? r.left + off : r.left - off;
-}
-
 }  // namespace detail
 
-// First HDL coordinate (from the left in iteration order) whose element equals
-// `v`, or nullopt if not found.
 template <RangedSequence S>
 constexpr std::optional<Range::value_type> index_of(
     S const& s, std::ranges::range_value_t<S> const& v
@@ -82,13 +68,9 @@ constexpr std::optional<Range::value_type> index_of(
     if (it == s.end()) {
         return std::nullopt;
     }
-    return detail::offset_to_hdl_coord(
-        s.range(), static_cast<size_t>(std::ranges::distance(s.begin(), it))
-    );
+    return s.range()[static_cast<size_t>(std::ranges::distance(s.begin(), it))];
 }
 
-// First HDL coordinate from the right (i.e. the last matching element in
-// iteration order), or nullopt if not found.
 template <RangedSequence S>
 constexpr std::optional<Range::value_type> rindex_of(
     S const& s, std::ranges::range_value_t<S> const& v
@@ -97,8 +79,9 @@ constexpr std::optional<Range::value_type> rindex_of(
     if (rit == s.rend()) {
         return std::nullopt;
     }
-    auto const off_from_end = static_cast<size_t>(std::distance(s.rbegin(), rit));
-    return detail::offset_to_hdl_coord(s.range(), s.range().length() - 1 - off_from_end);
+    return s.range()
+        [s.range().length() - 1
+         - static_cast<size_t>(std::ranges::distance(s.rbegin(), rit))];
 }
 
 template <typename ArrayT>
@@ -125,24 +108,18 @@ class ArraySliceImpl {
     constexpr ArraySliceImpl(ArraySliceImpl const&) = default;
     constexpr ArraySliceImpl(ArraySliceImpl&&) = default;
     constexpr ArraySliceImpl(ArrayT* arr, Range range) noexcept
-        : arr_(arr), range_(range), begin_(compute_begin(arr, range)) {}
+        : arr_(arr), range_(range) {}
 
     constexpr Range const& range() const noexcept { return range_; }
     constexpr size_t size() const noexcept { return range_.length(); }
 
     // Element access bounds-checks against this slice's range_, not the owner's range.
     constexpr reference operator[](index_type idx) const {
-        if (range_.direction == Direction::TO) {
-            if (idx < range_.left || idx > range_.right) {
-                throw std::out_of_range("Index out of bounds");
-            }
-            return *(begin_ + (idx - range_.left));
-        } else {
-            if (idx > range_.left || idx < range_.right) {
-                throw std::out_of_range("Index out of bounds");
-            }
-            return *(begin_ + (range_.left - idx));
+        auto const offset = offset_of(range_, idx);
+        if (!offset.has_value()) {
+            throw std::out_of_range("Index out of bounds");
         }
+        return *(begin() + offset.value());
     }
 
     // Slicing a slice flattens to a new ArraySlice of the same underlying array.
@@ -222,32 +199,24 @@ class ArraySliceImpl {
         return *this;
     }
 
-    constexpr iterator begin() const noexcept { return begin_; }
-    constexpr iterator end() const noexcept { return begin_ + range_.length(); }
+    constexpr iterator begin() const noexcept {
+        if (range_.length() == 0) {
+            return arr_->begin();
+        }
+        return arr_->begin() + offset_of(arr_->range(), range_.left).value();
+    }
+    constexpr iterator end() const noexcept {
+        if (range_.length() == 0) {
+            return arr_->begin();
+        }
+        return arr_->begin() + offset_of(arr_->range(), range_.right).value() + 1;
+    }
     constexpr auto rbegin() const noexcept { return std::reverse_iterator(end()); }
     constexpr auto rend() const noexcept { return std::reverse_iterator(begin()); }
 
   private:
-    // Cache the begin pointer. This is just one stack pointer for a temporary object, and
-    // it saves recomputing the offset on every element access.
-    static constexpr iterator compute_begin(ArrayT* arr, Range range) noexcept {
-        // Null slices may carry bounds outside the parent's range (the
-        // validity rule allows that). Pin them to the parent's begin so
-        // begin()/end() form a well-formed empty iterator pair.
-        if (range.length() == 0) {
-            return arr->begin();
-        }
-        auto start = find(arr->range(), range.left);
-        assert(
-            start != arr->range().end()
-            && "slice range not a sub-range of the owner's range"
-        );
-        return arr->begin() + std::distance(arr->range().begin(), start);
-    }
-
     ArrayT* arr_;
     Range range_;
-    iterator begin_;
 };
 
 template <typename ArrayT, Range R>
@@ -264,26 +233,16 @@ class StaticArraySliceImpl {
     constexpr StaticArraySliceImpl(StaticArraySliceImpl&&) = default;
     constexpr explicit StaticArraySliceImpl(ArrayT* arr) noexcept : arr_(arr) {}
 
-    // The range, exposed two ways: `static_range` for type-level access
-    // (`T::static_range`, used by the StaticRangedSequence concept), and a
-    // plain constexpr `range()` member matching ArraySlice's instance
-    // accessor so generic code can write `obj.range()` uniformly across both.
     static constexpr Range static_range = R;
-    constexpr Range range() const noexcept { return static_range; }
-    constexpr size_t size() const noexcept { return static_range.length(); }
+    static constexpr Range range() noexcept { return static_range; }
+    static constexpr size_t size() noexcept { return static_range.length(); }
 
     constexpr reference operator[](index_type idx) const {
-        if constexpr (R.direction == Direction::TO) {
-            if (idx < R.left || idx > R.right) {
-                throw std::out_of_range("Index out of bounds");
-            }
-            return *(begin() + (idx - R.left));
-        } else {
-            if (idx > R.left || idx < R.right) {
-                throw std::out_of_range("Index out of bounds");
-            }
-            return *(begin() + (R.left - idx));
+        auto const offset = offset_of(R, idx);
+        if (!offset.has_value()) {
+            throw std::out_of_range("Index out of bounds");
         }
+        return *(begin() + offset.value());
     }
 
     template <Range R2>
@@ -297,7 +256,7 @@ class StaticArraySliceImpl {
 
     template <index_type I>
     constexpr reference index() const {
-        static_assert(find(R, I) != R.end(), "index is out of range");
+        static_assert(contains(R, I), "index is out of range");
         return (*this)[I];
     }
 
@@ -309,8 +268,6 @@ class StaticArraySliceImpl {
     constexpr ArraySlice<ArrayT> operator[](
         Range::value_type left, Range::value_type right
     ) const {
-        // StaticArraySliceImpl has a compile-time range R, not a runtime range_ member,
-        // so the direction comes from the template parameter.
         return (*this)[Range{left, R.direction, right}];
     }
     constexpr ArraySlice<ArrayT> operator[](
@@ -364,32 +321,27 @@ class StaticArraySliceImpl {
     }
 
     constexpr iterator begin() const noexcept {
-        // We don't cache the begin pointer here since we can conditionally leverage the
-        // compile-time range to fold the offset to a constant.
-
-        // Null slices may carry bounds outside the parent's range (the
-        // validity rule allows that). Pin them to the parent's begin so
-        // begin()/end() form a well-formed empty iterator pair.
         if constexpr (R.length() == 0) {
             return arr_->begin();
         } else if constexpr (StaticRangedSequence<ArrayT>) {
-            // Parent's range is a compile-time constant; fold the offset to
-            // a constant instead of recomputing it via find()/distance().
             constexpr auto parent = std::remove_cvref_t<ArrayT>::static_range;
-            constexpr auto offset = parent.direction == Direction::TO
-                                      ? R.left - parent.left
-                                      : parent.left - R.left;
+            constexpr auto offset = offset_of(parent, R.left).value();
             return arr_->begin() + offset;
         } else {
-            auto start = find(arr_->range(), R.left);
-            assert(
-                start != arr_->range().end()
-                && "slice range not a sub-range of the owner's range"
-            );
-            return arr_->begin() + std::distance(arr_->range().begin(), start);
+            return arr_->begin() + offset_of(arr_->range(), R.left).value();
         }
     }
-    constexpr iterator end() const noexcept { return begin() + R.length(); }
+    constexpr iterator end() const noexcept {
+        if constexpr (R.length() == 0) {
+            return arr_->begin();
+        } else if constexpr (StaticRangedSequence<ArrayT>) {
+            constexpr auto parent = std::remove_cvref_t<ArrayT>::static_range;
+            constexpr auto offset = offset_of(parent, R.right).value();
+            return arr_->begin() + offset + 1;
+        } else {
+            return arr_->begin() + offset_of(arr_->range(), R.right).value() + 1;
+        }
+    }
     constexpr auto rbegin() const noexcept { return std::reverse_iterator(end()); }
     constexpr auto rend() const noexcept { return std::reverse_iterator(begin()); }
 
@@ -427,10 +379,6 @@ class StaticArraySlice : public detail::StaticArraySliceImpl<ArrayT, R> {
 
 namespace detail {
 
-// Emit "<prefix>[range]{e0, e1, ...}". Used by the per-type std::formatter
-// specializations for Array/Vector/ArraySlice/StaticArraySlice on non-logic
-// element types. Logic/Bit arrays use a quoted-bit-string body instead; see
-// logic_array.hpp.
 template <RangedSequence ArrayT, typename OutIt>
     requires Formattable<std::ranges::range_value_t<ArrayT>>
 OutIt format_array(std::string_view prefix, ArrayT const& arr, OutIt out) {
@@ -451,11 +399,6 @@ OutIt format_array(std::string_view prefix, ArrayT const& arr, OutIt out) {
 
 }  // namespace coconext::types
 
-// Formatters for ArraySlice and StaticArraySlice. Both print with the
-// "ArraySlice" prefix; the static-vs-runtime distinction isn't useful to a
-// reader of the printed output. The Logic/Bit specializations in
-// logic_array.hpp are more-specialized partial specs and win when both
-// headers are visible.
 #define COCONEXT_DEFINE_ARRAY_SLICE_FORMATTER(...)                                         \
     struct std::formatter<__VA_ARGS__> {                                                   \
         constexpr auto parse(std::format_parse_context& ctx) {                             \

--- a/cpp/include/coconext/types/concepts.hpp
+++ b/cpp/include/coconext/types/concepts.hpp
@@ -60,9 +60,7 @@ concept Hashable = requires(T a) {
     { std::hash<T>{}(a) } -> std::convertible_to<std::size_t>;
 };
 
-// C++20 substitute for std::formattable (C++23). Strong enough to discriminate
-// types with a usable std::formatter specialization from those that fall back
-// to the disabled primary template.
+// C++20 substitute for std::formattable (C++23).
 template <typename T>
 concept Formattable = std::semiregular<std::formatter<std::remove_cvref_t<T>, char>>;
 

--- a/cpp/include/coconext/types/hash.hpp
+++ b/cpp/include/coconext/types/hash.hpp
@@ -6,6 +6,8 @@
 
 namespace coconext::types::detail {
 
+// Inspired by boost::hash_combine
+
 constexpr size_t hash_mix(size_t seed, size_t value) noexcept {
     return seed ^ (value + 0x9e3779b97f4a7c15ULL + (seed << 6) + (seed >> 2));
 }

--- a/cpp/include/coconext/types/logic.hpp
+++ b/cpp/include/coconext/types/logic.hpp
@@ -6,6 +6,7 @@
 #include <format>
 #include <optional>
 #include <stdexcept>
+#include <string>
 #include <string_view>
 #include <type_traits>
 
@@ -38,16 +39,101 @@ class Logic {
 
     constexpr Logic() noexcept = default;
     constexpr Logic(value_type value) noexcept : value_(value) {}
+
+    template <Character C>
+    constexpr explicit Logic(C c) {
+        switch (c) {
+        case '0':
+            value_ = _0;
+            return;
+        case '1':
+            value_ = _1;
+            return;
+        case 'X':
+        case 'x':
+            value_ = X;
+            return;
+        case 'Z':
+        case 'z':
+            value_ = Z;
+            return;
+        case 'U':
+        case 'u':
+            value_ = U;
+            return;
+        case 'W':
+        case 'w':
+            value_ = W;
+            return;
+        case 'L':
+        case 'l':
+            value_ = L;
+            return;
+        case 'H':
+        case 'h':
+            value_ = H;
+            return;
+        case '-':
+            value_ = DC;
+            return;
+        default:
+            throw std::invalid_argument(
+                std::string("Invalid logic literal: '") + static_cast<char>(c) + "'"
+            );
+        }
+    }
+    constexpr explicit Logic(std::string_view s)
+        : Logic(
+              (s.size() == 1) ? s[0] : throw std::invalid_argument("Invalid logic value")
+          ) {}
+    constexpr explicit Logic(char const* s) : Logic(std::string_view(s)) {}
+    template <Integer I>
+    constexpr explicit Logic(I v) {
+        if (v == 0) {
+            value_ = _0;
+        } else if (v == 1) {
+            value_ = _1;
+        } else {
+            throw std::invalid_argument("Invalid logic value");
+        }
+    }
+    constexpr explicit Logic(bool v) noexcept : value_(v ? _1 : _0) {}
+
     constexpr value_type value() const noexcept { return value_; }
 
-    // Resolve under `method`. Returns nullopt iff the value is not resolvable
-    // under `method` -- ERROR accepts only 0/1; WEAK additionally accepts L/H;
-    // ZEROS, ONES, RANDOM accept anything. This unifies the old separate
-    // is_resolvable/resolve pair: `r.has_value()` answers the predicate,
-    // `r.value()` extracts the Bit.
-    std::optional<Bit> resolve(ResolveMethod method) const noexcept;
+    // Egress conversion operators.
+    template <Integer T>
+    constexpr explicit operator T() const {
+        if (value_ == _0 || value_ == L) {
+            return T(0);
+        } else if (value_ == _1 || value_ == H) {
+            return T(1);
+        } else {
+            throw std::invalid_argument(
+                "Cannot convert Logic with non-binary value to integer"
+            );
+        }
+    }
+    template <Character C>
+    constexpr explicit operator C() const noexcept {
+        constexpr char char_map[] = {'0', '1', 'X', 'Z', 'U', 'W', 'L', 'H', '-'};
+        return static_cast<C>(char_map[static_cast<size_t>(value_)]);
+    }
 
-    // Default to WEAK.
+    explicit constexpr operator bool() const {
+        switch (value_) {
+        case _0:
+        case L:
+            return false;
+        case _1:
+        case H:
+            return true;
+        default:
+            throw std::out_of_range("Cannot convert Logic with non-0/1 value to bool");
+        }
+    }
+
+    std::optional<Bit> resolve(ResolveMethod method) const noexcept;
     std::optional<Bit> resolve() const noexcept;
 
   private:
@@ -64,33 +150,68 @@ class Bit {
 
     constexpr Bit() noexcept = default;
     constexpr Bit(value_type value) noexcept : value_(value) {}
+
+    template <Character C>
+    constexpr explicit Bit(C c) {
+        if (c == '0') {
+            value_ = _0;
+        } else if (c == '1') {
+            value_ = _1;
+        } else {
+            throw std::invalid_argument(
+                std::string("Invalid bit value: '") + static_cast<char>(c) + "'"
+            );
+        }
+    }
+    constexpr explicit Bit(std::string_view s)
+        : Bit((s.size() == 1) ? s[0] : throw std::invalid_argument("Invalid bit value")) {}
+    constexpr explicit Bit(char const* s) : Bit(std::string_view(s)) {}
+    template <Integer I>
+    constexpr explicit Bit(I v) {
+        if (v == 0) {
+            value_ = _0;
+        } else if (v == 1) {
+            value_ = _1;
+        } else {
+            throw std::invalid_argument("Invalid bit value");
+        }
+    }
+    constexpr explicit Bit(bool v) noexcept : value_(v ? _1 : _0) {}
+    constexpr explicit Bit(Logic const& v) {
+        if (v.value() == Logic::_0 || v.value() == Logic::L) {
+            value_ = _0;
+        } else if (v.value() == Logic::_1 || v.value() == Logic::H) {
+            value_ = _1;
+        } else {
+            throw std::invalid_argument("Invalid bit value");
+        }
+    }
+
     constexpr value_type value() const noexcept { return value_; }
 
-    // Every Bit is resolvable under every method, so the optional is always
-    // engaged. Kept for uniformity with Logic::resolve so generic code over
-    // LogicType can treat both the same way.
     constexpr std::optional<Bit> resolve(ResolveMethod) const noexcept { return *this; }
     constexpr std::optional<Bit> resolve() const noexcept { return *this; }
+
+    template <Integer T>
+    constexpr explicit operator T() const noexcept {
+        return value_ == _0 ? T(0) : T(1);
+    }
+    template <Character C>
+    constexpr explicit operator C() const noexcept {
+        return value_ == _0 ? C('0') : C('1');
+    }
 
     // Implicit conversion from Bit to Logic mimics subtype upcasting.
     constexpr operator Logic() const noexcept {
         return value_ == _0 ? Logic::_0 : Logic::_1;
     }
 
-    // Bit is a 2-element numeric domain {0, 1}, so conversion to int and bool
-    // is total and lossless -- implicit, unlike the Logic counterparts which
-    // can fail on X/Z/U/W/-. `operator bool` is explicit (matches std::optional
-    // / std::unique_ptr) to keep `if (b)` working while preventing ambiguity
-    // with `operator int` in arithmetic contexts like `b + 2`.
-    constexpr operator int() const noexcept { return value_ == _0 ? 0 : 1; }
     explicit constexpr operator bool() const noexcept { return value_ != _0; }
 
   private:
     value_type value_ = _0;
 };
 
-// Out-of-line: needs the Bit definition above to instantiate
-// std::optional<Bit>.
 inline std::optional<Bit> Logic::resolve() const noexcept {
     return resolve(ResolveMethod::WEAK);
 }
@@ -103,122 +224,13 @@ constexpr bool operator==(Bit const& lhs, Bit const& rhs) noexcept {
     return lhs.value() == rhs.value();
 }
 
-template <Character CharType>
-constexpr Logic to_logic(CharType c) {
-    switch (c) {
-    case '0':
-        return Logic::_0;
-    case '1':
-        return Logic::_1;
-    case 'X':
-    case 'x':
-        return Logic::X;
-    case 'Z':
-    case 'z':
-        return Logic::Z;
-    case 'U':
-    case 'u':
-        return Logic::U;
-    case 'W':
-    case 'w':
-        return Logic::W;
-    case 'L':
-    case 'l':
-        return Logic::L;
-    case 'H':
-    case 'h':
-        return Logic::H;
-    case '-':
-        return Logic::DC;
-    default:
-        throw std::invalid_argument(
-            std::string("Invalid logic literal: '") + static_cast<char>(c) + "'"
-        );
-    }
-}
+// Prevent cross-type equality.
+bool operator==(Logic const&, Bit const&) = delete;
+bool operator==(Bit const&, Logic const&) = delete;
 
-template <Character CharType>
-constexpr Bit to_bit(CharType value) {
-    if (value == '0') {
-        return Bit::_0;
-    } else if (value == '1') {
-        return Bit::_1;
-    } else {
-        throw std::invalid_argument(
-            std::string("Invalid bit value: '") + static_cast<char>(value) + "'"
-        );
-    }
-}
+consteval Logic operator""_l(char c) { return Logic(c); }
 
-constexpr Logic operator""_l(char c) { return to_logic(c); }
-
-constexpr Bit operator""_b(char c) { return to_bit(c); }
-
-constexpr Logic to_logic(std::string_view value) {
-    if (value.size() != 1) {
-        throw std::invalid_argument("Invalid logic value");
-    }
-    return to_logic(value[0]);
-}
-
-constexpr Logic to_logic(char const* value) {
-    // Without this, string literals will choose the bool overload since const
-    // char* can decay to bool which is defined by the language and the
-    // string_view overload is defined in a library.
-    return to_logic(std::string_view(value));
-}
-
-template <Integer IntType>
-constexpr Logic to_logic(IntType value) {
-    if (value == 0) {
-        return Logic::_0;
-    } else if (value == 1) {
-        return Logic::_1;
-    } else {
-        throw std::invalid_argument("Invalid logic value");
-    }
-}
-
-constexpr Logic to_logic(bool value) { return value ? Logic::_1 : Logic::_0; }
-
-constexpr Logic to_logic(Bit const& value) { return value; }
-
-constexpr Bit to_bit(std::string_view value) {
-    if (value.size() != 1) {
-        throw std::invalid_argument("Invalid bit value");
-    }
-    return to_bit(value[0]);
-}
-
-constexpr Bit to_bit(char const* value) {
-    // Without this, string literals will choose the bool overload since const
-    // char* can decay to bool which is defined by the language and the
-    // string_view overload is defined in a library.
-    return to_bit(std::string_view(value));
-}
-
-template <Integer IntType>
-constexpr Bit to_bit(IntType value) {
-    if (value == 0) {
-        return Bit::_0;
-    } else if (value == 1) {
-        return Bit::_1;
-    } else {
-        throw std::invalid_argument("Invalid bit value");
-    }
-}
-
-constexpr Bit to_bit(bool value) { return value ? Bit::_1 : Bit::_0; }
-
-constexpr Bit to_bit(Logic const& value) {
-    if (value == Logic::_0) {
-        return Bit::_0;
-    } else if (value == Logic::_1) {
-        return Bit::_1;
-    } else {
-        throw std::invalid_argument("Invalid bit value");
-    }
-}
+consteval Bit operator""_b(char c) { return Bit(c); }
 
 constexpr std::string_view to_string(Logic const& value) noexcept {
     constexpr char const* const str_map[] = {"0", "1", "X", "Z", "U", "W", "L", "H", "-"};
@@ -228,29 +240,6 @@ constexpr std::string_view to_string(Logic const& value) noexcept {
 constexpr std::string_view to_string(Bit const& value) noexcept {
     return value.value() == Bit::_0 ? "0" : "1";
 }
-
-constexpr char to_char(Logic const& value) noexcept {
-    constexpr char char_map[] = {'0', '1', 'X', 'Z', 'U', 'W', 'L', 'H', '-'};
-    return char_map[static_cast<size_t>(value.value())];
-}
-
-constexpr char to_char(Bit const& value) noexcept {
-    return value.value() == Bit::_0 ? '0' : '1';
-}
-
-constexpr int to_int(Logic const& value) {
-    if (value.value() == Logic::_0 || value.value() == Logic::L) {
-        return 0;
-    } else if (value.value() == Logic::_1 || value.value() == Logic::H) {
-        return 1;
-    } else {
-        throw std::invalid_argument(
-            "Cannot convert Logic with non-binary value to integer"
-        );
-    }
-}
-
-constexpr int to_int(Bit const& value) noexcept { return value.value() == Bit::_0 ? 0 : 1; }
 
 constexpr Logic operator|(Logic const& lhs, Logic const& rhs) noexcept {
     using enum Logic::value_type;
@@ -343,10 +332,6 @@ constexpr Bit operator~(Bit const& value) noexcept {
     return value.value() == Bit::_0 ? Bit::_1 : Bit::_0;
 }
 
-// Compound bitwise assignment. Bit is implicitly convertible to Logic, so the
-// Logic overloads accept `Logic l; l &= bit;`. The reverse (`Bit b; b &= logic;`)
-// has no overload (Logic doesn't convert to Bit), which is the intended behavior:
-// non-resolvable values can't be assigned into a Bit.
 constexpr Logic& operator&=(Logic& lhs, Logic const& rhs) noexcept {
     return lhs = lhs & rhs;
 }
@@ -360,8 +345,6 @@ constexpr Bit& operator&=(Bit& lhs, Bit const& rhs) noexcept { return lhs = lhs 
 constexpr Bit& operator|=(Bit& lhs, Bit const& rhs) noexcept { return lhs = lhs | rhs; }
 constexpr Bit& operator^=(Bit& lhs, Bit const& rhs) noexcept { return lhs = lhs ^ rhs; }
 
-// Free function in-place complement. C++ has no `~=` operator, so this is the
-// in-place counterpart of `operator~`.
 constexpr Logic& inplace_not(Logic& v) noexcept { return v = ~v; }
 constexpr Bit& inplace_not(Bit& v) noexcept { return v = ~v; }
 
@@ -426,17 +409,5 @@ struct std::formatter<coconext::types::Bit> {
         return std::format_to(ctx.out(), "Bit{{{}}}", coconext::types::to_string(v));
     }
 };
-
-// Pull in the Logic/Bit-specialized array formatters so any TU that can name
-// Logic or Bit also sees the LogicType-constrained std::formatter
-// specializations for Vector<Logic/Bit>, Array<Logic/Bit, R>, and
-// their StaticArraySlice views. Without this, a TU that includes only logic.hpp +
-// (vector|array).hpp would instantiate the generic Array formatter
-// for those element types, while a TU with the umbrella header would
-// instantiate the terse LogicType form -- an ODR violation. The recursive
-// include is safe: logic_array.hpp's guarded include of logic.hpp is a no-op
-// here (we're at the bottom of logic.hpp's body), and Logic/Bit are fully
-// defined above.
-#include <coconext/types/logic_array.hpp>
 
 #endif  // COCONEXT_LOGIC_HPP

--- a/cpp/include/coconext/types/logic_array.hpp
+++ b/cpp/include/coconext/types/logic_array.hpp
@@ -14,11 +14,8 @@
 #include <stdexcept>
 #include <string>
 
-// The Logic/Bit Vector ctors below delegate to VectorImpl ctors that are
-// only constexpr in C++23 (gated by COCONEXT_VECTOR_CONSTEXPR inside
-// vector.hpp, which #undefs the macro at its end). Mirror the gating here
-// so clang doesn't diagnose "constexpr ctor never produces a constant
-// expression" under C++20.
+// The Logic/Bit Vector ctors below delegate to VectorImpl ctors that are only constexpr in
+// C++23.
 #if __cplusplus >= 202302L
 #define COCONEXT_DYN_LOGIC_ARRAY_CONSTEXPR constexpr
 #else
@@ -87,10 +84,6 @@ class Vector<Logic> : public detail::VectorImpl<Logic> {
     using detail::VectorImpl<Logic>::VectorImpl;
     using detail::VectorImpl<Logic>::operator=;
 
-    // Length-only constructors default to DOWNTO (HDL bit-vector convention).
-    // The base ctors default to TO; these specializations override that for
-    // logic arrays so `Vector<Logic>({...})` and friends produce ranges that
-    // match what HDL code expects.
     explicit COCONEXT_DYN_LOGIC_ARRAY_CONSTEXPR Vector(size_t length)
         : detail::VectorImpl<Logic>(detail::logic_downto_range(length)) {}
 
@@ -104,6 +97,27 @@ class Vector<Logic> : public detail::VectorImpl<Logic> {
         : detail::VectorImpl<Logic>(
               obj, detail::logic_downto_range(std::ranges::size(obj))
           ) {}
+
+    explicit COCONEXT_DYN_LOGIC_ARRAY_CONSTEXPR Vector(std::string_view s)
+        : Vector(s, detail::logic_downto_range(s.size())) {}
+    explicit COCONEXT_DYN_LOGIC_ARRAY_CONSTEXPR Vector(char const* s)
+        : Vector(std::string_view(s)) {}
+
+    COCONEXT_DYN_LOGIC_ARRAY_CONSTEXPR Vector(std::string_view s, Range r)
+        : detail::VectorImpl<Logic>(r) {
+        if (s.size() != r.length()) {
+            throw std::invalid_argument(
+                "String of length " + std::to_string(s.size())
+                + " does not match Range length " + std::to_string(r.length())
+            );
+        }
+        auto out = this->begin();
+        for (char c : s) {
+            *out++ = Logic(c);
+        }
+    }
+    COCONEXT_DYN_LOGIC_ARRAY_CONSTEXPR Vector(char const* s, Range r)
+        : Vector(std::string_view(s), r) {}
 };
 
 template <>
@@ -124,7 +138,74 @@ class Vector<Bit> : public detail::VectorImpl<Bit> {
     explicit COCONEXT_DYN_LOGIC_ARRAY_CONSTEXPR Vector(R const& obj)
         : detail::VectorImpl<Bit>(obj, detail::logic_downto_range(std::ranges::size(obj))) {
     }
+
+    explicit COCONEXT_DYN_LOGIC_ARRAY_CONSTEXPR Vector(std::string_view s)
+        : Vector(s, detail::logic_downto_range(s.size())) {}
+    explicit COCONEXT_DYN_LOGIC_ARRAY_CONSTEXPR Vector(char const* s)
+        : Vector(std::string_view(s)) {}
+
+    COCONEXT_DYN_LOGIC_ARRAY_CONSTEXPR Vector(std::string_view s, Range r)
+        : detail::VectorImpl<Bit>(r) {
+        if (s.size() != r.length()) {
+            throw std::invalid_argument(
+                "String of length " + std::to_string(s.size())
+                + " does not match Range length " + std::to_string(r.length())
+            );
+        }
+        auto out = this->begin();
+        for (char c : s) {
+            *out++ = Bit(c);
+        }
+    }
+    COCONEXT_DYN_LOGIC_ARRAY_CONSTEXPR Vector(char const* s, Range r)
+        : Vector(std::string_view(s), r) {}
 };
+
+namespace detail {
+
+template <Range R>
+class Array<Logic, R> : public ArrayImpl<Logic, R> {
+  public:
+    using ArrayImpl<Logic, R>::ArrayImpl;
+    using ArrayImpl<Logic, R>::operator=;
+
+    explicit constexpr Array(std::string_view s) : ArrayImpl<Logic, R>() {
+        if (s.size() != R.length()) {
+            throw std::invalid_argument(
+                "String of length " + std::to_string(s.size())
+                + " does not match Array length " + std::to_string(R.length())
+            );
+        }
+        auto out = this->begin();
+        for (char c : s) {
+            *out++ = Logic(c);
+        }
+    }
+    explicit constexpr Array(char const* s) : Array(std::string_view(s)) {}
+};
+
+template <Range R>
+class Array<Bit, R> : public ArrayImpl<Bit, R> {
+  public:
+    using ArrayImpl<Bit, R>::ArrayImpl;
+    using ArrayImpl<Bit, R>::operator=;
+
+    explicit constexpr Array(std::string_view s) : ArrayImpl<Bit, R>() {
+        if (s.size() != R.length()) {
+            throw std::invalid_argument(
+                "String of length " + std::to_string(s.size())
+                + " does not match Array length " + std::to_string(R.length())
+            );
+        }
+        auto out = this->begin();
+        for (char c : s) {
+            *out++ = Bit(c);
+        }
+    }
+    explicit constexpr Array(char const* s) : Array(std::string_view(s)) {}
+};
+
+}  // namespace detail
 
 template <RangedSequence T>
     requires LogicType<std::ranges::range_value_t<T>>
@@ -198,13 +279,8 @@ auto xor_reduce(T const& self) {
 using LogicVector = Vector<Logic>;
 using BitVector = Vector<Bit>;
 
-// LogicArray<N> / BitArray<N> default to {N-1 DOWNTO 0} for the length-only
-// form (HDL bit-vector convention). Explicit-Range and (L, [D,] H) forms pass
-// through unchanged. The generic `Array<Logic, N>` sugar still produces TO --
-// users wanting HDL conventions should prefer these aliases.
 template <auto... Args>
 using LogicArray = detail::Array<Logic, detail::make_logic_static_range<Args...>()>;
-
 template <auto... Args>
 using BitArray = detail::Array<Bit, detail::make_logic_static_range<Args...>()>;
 
@@ -226,14 +302,14 @@ auto logic_binop(LHS const& lhs, RHS const& rhs, Op op) {
     ));
     // When both sides have compile-time-known ranges, fold the length check
     // into a static_assert and return a stack-allocated static Array. A
-    // runtime range on either side forces a heap-allocated Vector.
+    // runtime range on either side forces a heap-allocated Vector. The result
+    // Range is always normalized to {N-1 DOWNTO 0} (HDL convention).
     if constexpr (StaticRangedSequence<LHS> && StaticRangedSequence<RHS>) {
         constexpr auto LR = std::remove_cvref_t<LHS>::static_range;
         constexpr auto RR = std::remove_cvref_t<RHS>::static_range;
         static_assert(
             LR.length() == RR.length(), "Bitwise operation requires arrays of equal length"
         );
-        // LR's length is already bounded by Range::value_type (int32_t).
         Array<
             result_elem,
             Range{static_cast<Range::value_type>(LR.length()) - 1, Direction::DOWNTO, 0}>
@@ -254,8 +330,6 @@ auto logic_binop(LHS const& lhs, RHS const& rhs, Op op) {
                 + std::to_string(rhs.range().length())
             );
         }
-        // lhs.range() was constructed validly so its length already fits in
-        // Range::value_type.
         auto const n = static_cast<Range::value_type>(lhs.range().length());
         Vector<result_elem> result(Range{n - 1, Direction::DOWNTO, 0});
         std::transform(
@@ -271,6 +345,7 @@ auto logic_binop(LHS const& lhs, RHS const& rhs, Op op) {
 
 // Scalar broadcast: per-element op(elem, scalar). Same static/dynamic dispatch
 // shape as logic_binop, but no length-check branch (a scalar fits any array).
+// Result Range is normalized to {N-1 DOWNTO 0}, matching logic_binop.
 template <RangedSequence Arr, LogicType Scalar, typename Op>
     requires LogicType<std::ranges::range_value_t<Arr>>
 auto logic_binop_scalar(Arr const& arr, Scalar const& s, Op op) {
@@ -380,13 +455,6 @@ auto operator^(Arr const& arr, Scalar const& s) {
 }
 
 // -- Compound bitwise assignment -------------------------------------------
-//
-// Free functions taking the LHS by forwarding reference so they bind to both
-// owning arrays (`arr &= mask`) and slice rvalues (`arr[{2, 1}] &= mask`).
-// RHS may be another array (length-checked) or a scalar Bit/Logic (broadcast).
-// Element-type compatibility is enforced by the underlying `v = v <op> rhs`
-// assignment -- e.g. `BitArray &= LogicArray` fails to compile because the
-// elementwise `Bit & Logic` returns Logic and Logic isn't assignable to Bit.
 
 namespace detail {
 
@@ -477,8 +545,6 @@ constexpr decltype(auto) operator^=(LHS&& lhs, RHS const& rhs) {
     return std::forward<LHS>(lhs);
 }
 
-// In-place complement of an array. Like the compound assignment ops, taken by
-// forwarding reference so it binds to slice rvalues too.
 template <typename Arr>
     requires LogicArrayType<std::remove_cvref_t<Arr>>
 constexpr decltype(auto) inplace_not(Arr&& arr) {
@@ -540,13 +606,6 @@ constexpr void concat_copy_one(OutIt& out, T const& t) {
 
 }  // namespace detail
 
-// Variadic concat of Logic/Bit scalars and Logic/Bit arrays. First argument
-// occupies the high bits; within each operand, elements are taken in iteration
-// order (begin to end) regardless of the operand's direction. Result is a
-// static `Array<Elem, {N-1 DOWNTO 0}>` when every operand has a compile-time
-// size (scalar or StaticRangedSequence), else a runtime `Vector<Elem>`.
-// Element type is `std::common_type_t<...>` over the operand element types
-// (Logic if any operand is Logic, else Bit).
 template <typename... Args>
     requires(sizeof...(Args) >= 1) && (... && detail::ConcatOperand<Args>)
 auto concat(Args const&... args) {
@@ -580,11 +639,9 @@ template <RangedSequence T>
 auto operator~(T const& arr) {
     using elem_t = std::ranges::range_value_t<T>;
     if constexpr (StaticRangedSequence<T>) {
-        constexpr auto AR = std::remove_cvref_t<T>::static_range;
-        // AR's length is already bounded by Range::value_type (int32_t).
         Array<
             elem_t,
-            Range{static_cast<Range::value_type>(AR.length()) - 1, Direction::DOWNTO, 0}>
+            Range{std::remove_cvref_t<T>::static_range.length() - 1, Direction::DOWNTO, 0}>
             result{};
         std::transform(
             std::ranges::begin(arr),
@@ -594,8 +651,6 @@ auto operator~(T const& arr) {
         );
         return result;
     } else {
-        // arr.range() was constructed validly so its length already fits in
-        // Range::value_type.
         auto const n = static_cast<Range::value_type>(arr.range().length());
         Vector<elem_t> result(Range{n - 1, Direction::DOWNTO, 0});
         std::transform(
@@ -612,46 +667,12 @@ auto operator~(T const& arr) {
 
 namespace detail {
 
-template <typename ElemT, typename CharToElem>
-Vector<ElemT> parse_logic_string(std::string_view s, CharToElem char_to_elem) {
-    size_t count = 0;
-    for (char c : s) {
-        if (c != '_') {
-            ++count;
-        }
-    }
-    if (count > static_cast<size_t>(std::numeric_limits<Range::value_type>::max())) {
-        throw std::length_error("logic string too long for Range::value_type");
-    }
-    auto const n = static_cast<Range::value_type>(count);
-    Vector<ElemT> result(Range{n - 1, Direction::DOWNTO, 0});
-    size_t j = 0;
-    for (char c : s) {
-        if (c != '_') {
-            *(result.begin() + j++) = char_to_elem(c);
-        }
-    }
-    return result;
-}
-
-template <StringLiteral S>
-constexpr size_t count_non_underscore() {
-    size_t n = 0;
-    for (size_t i = 0; i < S.size; ++i) {
-        if (S.data[i] != '_') {
-            ++n;
-        }
-    }
-    return n;
-}
-
-// Emit '<prefix>[range]{"<bit-string>"}' for Logic/Bit-element arrays.
 template <RangedSequence ArrayT, typename OutIt>
     requires LogicType<std::ranges::range_value_t<ArrayT>>
 OutIt format_logic_array(std::string_view prefix, ArrayT const& arr, OutIt out) {
     out = std::format_to(out, "{}{}{{\"", prefix, arr.range());
     for (auto const& elem : arr) {
-        *out++ = to_char(elem);
+        *out++ = char(elem);
     }
     *out++ = '"';
     *out++ = '}';
@@ -666,23 +687,28 @@ std::string to_string(T const& arr) {
     std::string result;
     result.reserve(arr.range().length());
     for (auto const& elem : arr) {
-        result += to_char(elem);
+        result += char(elem);
     }
     return result;
 }
 
-inline Vector<Logic> to_logic_array(std::string_view s) {
-    return detail::parse_logic_string<Logic>(s, [](char c) { return to_logic(c); });
-}
-
-inline Vector<Bit> to_bit_array(std::string_view s) {
-    return detail::parse_logic_string<Bit>(s, [](char c) { return to_bit(c); });
-}
-
-// -- String-literal UDL ----------------------------------------------------
+namespace detail {
 
 template <StringLiteral S>
-constexpr auto operator""_l() {
+constexpr size_t count_non_underscore() {
+    size_t n = 0;
+    for (size_t i = 0; i < S.size; ++i) {
+        if (S.data[i] != '_') {
+            ++n;
+        }
+    }
+    return n;
+}
+
+}  // namespace detail
+
+template <StringLiteral S>
+consteval auto operator""_l() {
     constexpr auto N = detail::count_non_underscore<S>();
     static_assert(
         N <= static_cast<size_t>(std::numeric_limits<Range::value_type>::max()),
@@ -693,14 +719,14 @@ constexpr auto operator""_l() {
     auto out = result.begin();
     for (auto in = S.data; in != S.data + S.size; ++in) {
         if (*in != '_') {
-            *out++ = to_logic(*in);
+            *out++ = Logic(*in);
         }
     }
     return result;
 }
 
 template <StringLiteral S>
-constexpr auto operator""_b() {
+consteval auto operator""_b() {
     constexpr auto N = detail::count_non_underscore<S>();
     static_assert(
         N <= static_cast<size_t>(std::numeric_limits<Range::value_type>::max()),
@@ -711,7 +737,7 @@ constexpr auto operator""_b() {
     auto out = result.begin();
     for (auto in = S.data; in != S.data + S.size; ++in) {
         if (*in != '_') {
-            *out++ = to_bit(*in);
+            *out++ = Bit(*in);
         }
     }
     return result;
@@ -719,13 +745,7 @@ constexpr auto operator""_b() {
 
 }  // namespace coconext::types
 
-// Per-type formatters for Logic/Bit-element arrays. These are more-specialized
-// partial specializations of std::formatter than the corresponding non-logic
-// formatters in array.hpp / vector.hpp / array_base.hpp, so they win by C++20
-// partial-ordering rules when both headers are visible.
-//
-// Output format: `<Prefix>[range]{"<bit-string>"}`. The prefix encodes the
-// type kind (Array / Vector / ArraySlice) and the element type (Logic / Bit).
+// -- std::formatter specializations -------------------------------------------
 
 #define COCONEXT_DEFINE_LOGIC_ARRAY_FORMATTER(PREFIX, ...)                                 \
     struct std::formatter<__VA_ARGS__> {                                                   \
@@ -783,7 +803,7 @@ template <typename ArrayT, coconext::types::Range R>
                  std::remove_cv_t<std::ranges::range_value_t<ArrayT>>,
                  coconext::types::Logic>
 COCONEXT_DEFINE_LOGIC_ARRAY_FORMATTER(
-    "LogicArraySlice", coconext::types::StaticArraySlice<ArrayT, R>
+    "LogicStaticArraySlice", coconext::types::StaticArraySlice<ArrayT, R>
 );
 
 template <typename ArrayT, coconext::types::Range R>
@@ -792,7 +812,7 @@ template <typename ArrayT, coconext::types::Range R>
                  std::remove_cv_t<std::ranges::range_value_t<ArrayT>>,
                  coconext::types::Bit>
 COCONEXT_DEFINE_LOGIC_ARRAY_FORMATTER(
-    "BitArraySlice", coconext::types::StaticArraySlice<ArrayT, R>
+    "BitStaticArraySlice", coconext::types::StaticArraySlice<ArrayT, R>
 );
 
 #undef COCONEXT_DEFINE_LOGIC_ARRAY_FORMATTER

--- a/cpp/include/coconext/types/range.hpp
+++ b/cpp/include/coconext/types/range.hpp
@@ -53,28 +53,10 @@ struct Range {
     value_type right = -1;
     Direction direction = Direction::TO;
 
-    // length() is the only safe place to enforce the size_t-overflow check:
-    // the fields are public, so a Range can be mutated into the full-domain
-    // span after construction.
-    //
-    // Throws std::length_error if the range spans the full value_type domain
-    // (mathematical length 2^width(value_type), doesn't fit in size_t).
-    //
-    // The arithmetic is in size_t. See the static_assert above for why direct
-    // signed-to-size_t casts give us the correct unsigned difference. Without
-    // the full-span check below, the +1 on a SIZE_MAX-1 difference would wrap
-    // silently to 0.
-    constexpr size_t length() const {
-        constexpr value_type lo = std::numeric_limits<value_type>::min();
-        constexpr value_type hi = std::numeric_limits<value_type>::max();
-        bool const full_to = direction == Direction::TO && left == lo && right == hi;
-        bool const full_downto =
-            direction == Direction::DOWNTO && left == hi && right == lo;
-        if (full_to || full_downto) {
-            throw std::length_error(
-                "Range spans the full value_type domain; length overflows size_t"
-            );
-        }
+    // Two ranges [INT_MIN to INT_MAX] and [INT_MAX downto INT_MIN] are both invalid, when
+    // getting the length it will read 0. There is no protection for this case for
+    // performance reasons.
+    constexpr size_t length() const noexcept {
         if (direction == Direction::TO) {
             if (right < left) {
                 return 0;
@@ -86,6 +68,8 @@ struct Range {
         }
         return static_cast<size_t>(left) - static_cast<size_t>(right) + 1;
     }
+
+    constexpr size_t size() const noexcept { return length(); }
 
     constexpr iterator begin() const noexcept { return iterator(left, direction); }
 
@@ -167,20 +151,32 @@ constexpr Range reverse(Range const& r) noexcept {
     };
 }
 
-// more optimal implementation of std::ranges::find for Range
-constexpr Range::iterator find(Range const& range, Range::value_type value) {
+namespace detail {
+
+constexpr std::optional<Range::value_type> offset_of(
+    Range const& range, Range::value_type value
+) {
     if (range.direction == Direction::TO) {
         if (value < range.left || value > range.right) {
-            return range.end();
+            return std::nullopt;
         }
-        return range.begin() + (value - range.left);
+        return value - range.left;
     } else {
         if (value > range.left || value < range.right) {
-            return range.end();
+            return std::nullopt;
         }
-        return range.begin() + (range.left - value);
+        return range.left - value;
     }
 }
+
+constexpr bool contains(Range const& range, Range::value_type value) {
+    if (range.direction == Direction::TO) {
+        return value >= range.left && value <= range.right;
+    }
+    return value <= range.left && value >= range.right;
+}
+
+}  // namespace detail
 
 static_assert(std::ranges::random_access_range<Range>);
 

--- a/cpp/include/coconext/types/vector.hpp
+++ b/cpp/include/coconext/types/vector.hpp
@@ -11,16 +11,13 @@
 #include <initializer_list>
 #include <iterator>
 #include <memory>
-#include <optional>
 #include <ranges>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
 #include <typeinfo>
 
-// std::unique_ptr's constexpr support landed in C++23 (P2273R3); under C++20
-// the constexpr keyword on Vector's members is still legal but evaluating
-// those members in a constant expression fails. Gate accordingly.
+// std::unique_ptr's constexpr support landed in C++23 (P2273R3).
 #if __cplusplus >= 202302L
 #define COCONEXT_VECTOR_CONSTEXPR constexpr
 #else
@@ -126,10 +123,18 @@ class VectorImpl {
     constexpr size_t size() const noexcept { return range_.length(); }
 
     COCONEXT_VECTOR_CONSTEXPR reference operator[](index_type idx) {
-        return access_(*this, idx);
+        auto offset = offset_of(range_, idx);
+        if (!offset.has_value()) {
+            throw std::out_of_range("Index out of bounds");
+        }
+        return *(data_.get() + offset.value());
     }
     COCONEXT_VECTOR_CONSTEXPR const_reference operator[](index_type idx) const {
-        return access_(*this, idx);
+        auto offset = offset_of(range_, idx);
+        if (!offset.has_value()) {
+            throw std::out_of_range("Index out of bounds");
+        }
+        return *(data_.get() + offset.value());
     }
 
     // Slices route through the outer `Vector<ValueT>` (or const variant)
@@ -213,15 +218,6 @@ class VectorImpl {
     }
 
   private:
-    template <typename Self>
-    static COCONEXT_VECTOR_CONSTEXPR auto& access_(Self& self, index_type idx) {
-        auto it = find(self.range_, idx);
-        if (it == self.range_.end()) {
-            throw std::out_of_range("Index out of bounds");
-        }
-        return *(self.data_.get() + std::distance(self.range_.begin(), it));
-    }
-
     std::unique_ptr<value_type[]> data_;
     Range range_;
 };

--- a/docs/dev/array_slice_api.md
+++ b/docs/dev/array_slice_api.md
@@ -87,7 +87,7 @@ Random-access iteration over the slice's range. Free-function `index_of(slice, v
 
 `ArraySlice` supports `std::formatter`, per the conventions in `conventions_api.md`. `std::formatter<ArraySlice>` produces `ArraySlice[range]{elem, elem, ...}`, e.g. `ArraySlice[1 to 3]{20, 30, 40}`. The parent container type is not included in the header; a slice prints as its own view over its own range. The specialization is available only when the element type is `Formattable`. Takes no format spec; any spec character throws `std::format_error` at parse time.
 
-Slices whose element type is `Logic` or `Bit` get a specialized output that mirrors the owning bit-array containers: `ArraySlice<Logic>[3 downto 2]{"01"}`, `ArraySlice<Bit>[1 to 2]{"10"}`. The element type is called out in the header so the printed form matches how the reader thinks of the slice, and the value is the same bit-string form used by `LogicArray` / `BitArray` (round-trippable via the string-view ctor after collecting into an owning container).
+Slices whose element type is `Logic` or `Bit` get a specialized output that mirrors the owning bit-array containers, with the element type folded into the type name: `LogicArraySlice[3 downto 2]{"01"}`, `BitArraySlice[1 to 2]{"10"}`. Value form matches `LogicArray` / `BitArray` (bit-string, round-trippable via the `std::string_view` ctor after collecting into an owning container).
 
 ## `StaticArraySlice`
 
@@ -128,7 +128,7 @@ Identical to `ArraySlice`. When the parent is also a `StaticRangedSequence`, `St
 
 `std::formatter<StaticArraySlice>` produces `StaticArraySlice[range]{elem, elem, ...}`, e.g. `StaticArraySlice[6 to 7]{7, 8}`. Same rules as `ArraySlice`: parent type omitted, requires a `Formattable` element type, no format spec.
 
-Same `Logic` / `Bit` specialization applies: `StaticArraySlice<Logic>[3 downto 2]{"01"}`, `StaticArraySlice<Bit>[1 to 2]{"10"}`.
+Same `Logic` / `Bit` specialization applies, with the element type folded into the type name: `LogicStaticArraySlice[3 downto 2]{"01"}`, `BitStaticArraySlice[1 to 2]{"10"}`.
 
 ## `constexpr` and `noexcept` contract
 

--- a/docs/dev/logic_array_bit_array_api.md
+++ b/docs/dev/logic_array_bit_array_api.md
@@ -189,6 +189,17 @@ The result type is determined by two rules from [`ranged_sequence_api.md`](range
 
 Both operands must be the same length. When both are `StaticRangedSequence`s the mismatch is a `static_assert`; otherwise it is a runtime `std::invalid_argument`.
 
+The result's `Range` is always normalized to `[N-1 downto 0]` regardless of the operands' ranges  --  the operands may have different (possibly incompatible) ranges of the same length, so there is no non-arbitrary way to inherit from one side, and the HDL convention for a freshly-computed bit-array is `downto 0`.
+
+### Scalar broadcast
+
+Either operand may be a `LogicType` scalar (`Logic` or `Bit`) instead of a `RangedSequence`. The scalar is broadcast against every element of the sequence, and the result follows the container-kind and element-type rules with the sequence operand as the container source:
+
+```c++
+auto a = "01XZ"_l & '1'_l;   // LogicArray[3 downto 0]{"01XZ"}  (AND with '1' is identity on Logic)
+auto b = '0'_b | "1010"_b;   // BitArray[3 downto 0]{"1010"}
+```
+
 ```c++
 auto a = "0101"_l;
 auto b = "0110"_l;
@@ -212,9 +223,9 @@ Canonical result-type examples:
 
 ## `RangedSequence<LogicType>` compound assignment
 
-`&=`, `|=`, `^=` are defined on any mutating `RangedSequence<LogicType>` and take any `RangedSequence<LogicType>` as the RHS. Assignment is elementwise; the RHS must have the same length as the LHS.
+`&=`, `|=`, `^=` are defined on any mutating `RangedSequence<LogicType>` and take either a `RangedSequence<LogicType>` or a `LogicType` scalar as the RHS. Assignment is elementwise; when the RHS is a `RangedSequence` it must have the same length as the LHS. When the RHS is a scalar it is broadcast against every element.
 
-- The `Logic` / `Bit` downcast rule from the scalar layer lifts: an LHS of `Bit` element type only accepts an RHS of `Bit` element type; `logic_bit_arr &= bit_arr` is fine (elementwise `Bit -> Logic` upcast), but `bit_arr &= logic_arr` is ill-formed at compile time.
+- The `Logic` / `Bit` downcast rule from the scalar layer lifts: an LHS of `Bit` element type only accepts an RHS whose (scalar or elementwise) type is `Bit`; `logic_bit_arr &= bit_arr` is fine (elementwise `Bit -> Logic` upcast), but `bit_arr &= logic_arr` and `bit_arr &= 'X'_l` are ill-formed at compile time.
 - Length match: when both sides are `StaticRangedSequence`, mismatch is a `static_assert`; otherwise it is a runtime `std::invalid_argument`.
 - These work on mutating slices (`ArraySlice<...>` / `StaticArraySlice<...>` over a non-`const` parent) and write through to the parent's storage.
 
@@ -230,6 +241,9 @@ b |= "0X10"_l;                     // ill-formed: Bit LHS cannot take Logic RHS
 
 Vector<Bit> v {'0'_b, '1'_b, '0'_b, '1'_b};
 v[{1, 2}] &= "10"_b;               // writes through slice into v: v is now "0001"
+
+LogicVector d {"01XZ"_l};
+d |= '1'_l;                        // broadcast: d is now "1111" ('1' dominates in Logic OR)
 ```
 
 ## `RangedSequence<LogicType>` unary `~`
@@ -254,6 +268,28 @@ inplace_not(a);                       // a is now "1001"
 
 LogicVector v {"01XZ"_l};             // range 3 downto 0
 inplace_not(v[{2, 1}]);               // ~v[2]='1'->'0', ~v[1]='X'->'X'; v is now "00XZ"
+```
+
+## `concat`
+
+Free function that concatenates a variadic list of `LogicType` scalars and `RangedSequence<LogicType>` operands into a single owning container:
+
+```c++
+template <typename... Args>
+    requires (sizeof...(Args) >= 1) && (... && (LogicType<Args> || RangedSequence<Args, Logic> || RangedSequence<Args, Bit>))
+auto concat(Args const&... args);
+```
+
+- The first argument occupies the high bits (MSB); the last argument occupies the low bits (LSB). Within each `RangedSequence` operand, elements are taken in iteration order (`begin()` to `end()`) regardless of the operand's direction.
+- Element type is `Logic` if any operand's element is `Logic`, else `Bit`.
+- Result is a `LogicArray<N>` / `BitArray<N>` when every operand has a compile-time size (a scalar, or a `StaticRangedSequence`). Otherwise it is a `LogicVector` / `BitVector`. Result range is `N-1 downto 0`.
+
+```c++
+auto a = concat('1'_l, "01X"_b);       // LogicArray[3 downto 0]{"101X"}
+auto b = concat("1010"_b, "0011"_b);   // BitArray[7 downto 0]{"10100011"}
+
+LogicVector v {"01"_l};
+auto c = concat('1'_l, v);             // LogicVector[2 downto 0]{"101"} (runtime because v is)
 ```
 
 ## Reduction and resolution free functions

--- a/docs/dev/logic_bit_api.md
+++ b/docs/dev/logic_bit_api.md
@@ -92,7 +92,7 @@ class Logic {
     constexpr explicit Logic(char const* s);                           // string_view overload
     template <Integer I> constexpr explicit Logic(I v);                // 0 -> _0, 1 -> _1; throws otherwise
     constexpr explicit Logic(bool v) noexcept;                         // total
-    constexpr Logic(Bit const& v) noexcept;                            // implicit upcast (see below)
+    // Bit -> Logic upcast is implemented on Bit via operator Logic() (see below).
     // ... value_type ctor, default ctor, etc.
 };
 

--- a/docs/dev/range_direction_api.md
+++ b/docs/dev/range_direction_api.md
@@ -12,7 +12,7 @@ The cross-cutting formatting, hashing, and construction-vs-conversion convention
 cpp/include/coconext/types/
   direction.hpp       --  Direction enum, to_string,
                           std::formatter specialization
-  range.hpp           --  Range, its iterator, reverse(), find(),
+  range.hpp           --  Range, its iterator, reverse(),
                           std::hash / std::formatter specializations
   count_iterator.hpp  --  CountIterator<value_type> that Range uses [internal]
   hash.hpp            --  hash_combine helper used by std::hash<Range> [internal]
@@ -220,16 +220,6 @@ constexpr Range reverse(Range const& r) noexcept;
 
 Returns `Range{r.right, opposite_direction, r.left}`: the values are the same set in the reverse order.
 
-### `find`
-
-`Range` is a `std::ranges::range`, so `std::find` works. An O(1) coconext-native overload is provided as a free function:
-
-```c++
-constexpr Range::iterator find(Range const& r, Range::value_type value);
-```
-
-Returns an iterator to the position of `value` in `r`, or `r.end()` if the value is outside the range.
-
 ### Ordering / equality
 
 `Range` only supports `==` and `!=`, and equality is strict on all three fields (`left`, `right`, `direction`). `Range{5, 5}` (TO) and `Range{5, DOWNTO, 5}` compare `!=` even though they iterate to the same one-element sequence  --  the direction is part of the identity so that hashing and equality agree (see `conventions_api.md`).
@@ -268,4 +258,4 @@ Every `Direction` and `Range` operation is marked `constexpr`, and every operati
 
 `Range::length()` itself is `noexcept`; it produces unspecified results on the two full-domain invalid values (see [Invalid values](#invalid-values)).
 
-Everything else  --  copy, comparison, iteration, `is_subsequence_of`, `reverse`, `find`, `to_string(Direction)`, `std::hash`  --  is `constexpr noexcept`. `Range` is therefore usable as an NTTP in `constexpr` contexts (subject to the standard's NTTP structural-type rules), which is how `Array<T, Range{...}>` and the compile-time-bounded family carry their shape.
+Everything else  --  copy, comparison, iteration, `is_subsequence_of`, `reverse`, `to_string(Direction)`, `std::hash`  --  is `constexpr noexcept`. `Range` is therefore usable as an NTTP in `constexpr` contexts (subject to the standard's NTTP structural-type rules), which is how `Array<T, Range{...}>` and the compile-time-bounded family carry their shape.

--- a/nanobind/src/types/bind_logic.cpp
+++ b/nanobind/src/types/bind_logic.cpp
@@ -42,21 +42,14 @@ void register_logic(nb::module_& m) {
 
     nb::class_<Logic>(m, "Logic")
         .def(nb::init<Logic const&>())
+        .def("__init__", [](Logic* self, Bit const& value) { new (self) Logic(value); })
         .def(
-            "__init__",
-            [](Logic* self, Bit const& value) { new (self) Logic(to_logic(value)); }
+            "__init__", [](Logic* self, std::string_view value) { new (self) Logic(value); }
         )
-        .def(
-            "__init__",
-            [](Logic* self, std::string_view value) { new (self) Logic(to_logic(value)); }
-        )
-        .def(
-            "__init__",
-            [](Logic* self, long long value) { new (self) Logic(to_logic(value)); }
-        )
+        .def("__init__", [](Logic* self, long long value) { new (self) Logic(value); })
         .def("__str__", [](Logic const& self) { return to_string(self); })
-        .def("__index__", [](Logic const& self) { return to_int(self); })
-        .def("__bool__", [](Logic const& self) { return to_int(self) != 0; })
+        .def("__index__", [](Logic const& self) { return int(self); })
+        .def("__bool__", [](Logic const& self) { return int(self) != 0; })
         .def(
             "__repr__",
             [](Logic const& self) {
@@ -74,14 +67,14 @@ void register_logic(nb::module_& m) {
         )
         .def(
             "__eq__",
-            [](Logic const& lhs, Bit const& rhs) { return lhs == rhs; },
+            [](Logic const& lhs, Bit const& rhs) { return lhs == Logic(rhs); },
             nb::is_operator()
         )
         .def(
             "__eq__",
             [](Logic const& self, long long other) {
                 try {
-                    return self == to_logic(other);
+                    return self == Logic(other);
                 } catch (std::invalid_argument const&) {
                     return false;
                 }
@@ -92,7 +85,7 @@ void register_logic(nb::module_& m) {
             "__eq__",
             [](Logic const& self, std::string_view other) {
                 try {
-                    return self == to_logic(other);
+                    return self == Logic(other);
                 } catch (std::invalid_argument const&) {
                     return false;
                 }
@@ -170,17 +163,12 @@ void register_logic(nb::module_& m) {
 
     nb::class_<Bit>(m, "Bit")
         .def(nb::init<Bit const&>())
-        .def(
-            "__init__", [](Bit* self, Logic const& value) { new (self) Bit(to_bit(value)); }
-        )
-        .def(
-            "__init__",
-            [](Bit* self, std::string_view value) { new (self) Bit(to_bit(value)); }
-        )
-        .def("__init__", [](Bit* self, long long value) { new (self) Bit(to_bit(value)); })
+        .def("__init__", [](Bit* self, Logic const& value) { new (self) Bit(value); })
+        .def("__init__", [](Bit* self, std::string_view value) { new (self) Bit(value); })
+        .def("__init__", [](Bit* self, long long value) { new (self) Bit(value); })
         .def("__str__", [](Bit const& self) { return to_string(self); })
-        .def("__index__", [](Bit const& self) { return to_int(self); })
-        .def("__bool__", [](Bit const& self) { return to_int(self) != 0; })
+        .def("__index__", [](Bit const& self) { return int(self); })
+        .def("__bool__", [](Bit const& self) { return int(self) != 0; })
         .def(
             "__repr__",
             [](Bit const& self) {
@@ -198,14 +186,14 @@ void register_logic(nb::module_& m) {
         )
         .def(
             "__eq__",
-            [](Bit const& lhs, Logic const& rhs) { return lhs == rhs; },
+            [](Bit const& lhs, Logic const& rhs) { return Logic(lhs) == rhs; },
             nb::is_operator()
         )
         .def(
             "__eq__",
             [](Bit const& self, long long other) {
                 try {
-                    return self == to_bit(other);
+                    return self == Bit(other);
                 } catch (std::invalid_argument const&) {
                     return false;
                 }
@@ -216,7 +204,7 @@ void register_logic(nb::module_& m) {
             "__eq__",
             [](Bit const& self, std::string_view other) {
                 try {
-                    return self == to_bit(other);
+                    return self == Bit(other);
                 } catch (std::invalid_argument const&) {
                     return false;
                 }

--- a/nanobind/src/types/bind_range.cpp
+++ b/nanobind/src/types/bind_range.cpp
@@ -9,7 +9,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <format>
-#include <iterator>
 #include <stdexcept>
 #include <string_view>
 
@@ -175,11 +174,11 @@ void register_range(nb::module_& m) {
         .def(
             "index",
             [](Range const& self, int32_t value) {
-                auto it = find(self, value);
-                if (it == self.end()) {
+                auto offset = detail::offset_of(self, value);
+                if (!offset.has_value()) {
                     throw nb::value_error("Value not found in range");
                 }
-                return std::distance(self.begin(), it);
+                return offset.value();
             },
             nb::arg().noconvert()
         )
@@ -196,13 +195,11 @@ void register_range(nb::module_& m) {
 
                 auto sliced = slice_range(self, start, len);
 
-                auto it = find(sliced, value);
-
-                if (it == sliced.end()) {
+                auto offset = detail::offset_of(sliced, value);
+                if (!offset.has_value()) {
                     throw nb::value_error("Value not found in range");
                 }
-
-                return start + std::distance(sliced.begin(), it);
+                return start + offset.value();
             },
             nb::arg().noconvert(),
             nb::arg().noconvert()
@@ -223,13 +220,11 @@ void register_range(nb::module_& m) {
 
                 auto sliced = slice_range(self, start, stop);
 
-                auto it = find(sliced, value);
-
-                if (it == sliced.end()) {
+                auto offset = detail::offset_of(sliced, value);
+                if (!offset.has_value()) {
                     throw nb::value_error("Value not found in range");
                 }
-
-                return start + std::distance(sliced.begin(), it);
+                return start + offset.value();
             },
             nb::arg().noconvert(),
             nb::arg().noconvert(),

--- a/tests/cpp/test_logic.cpp
+++ b/tests/cpp/test_logic.cpp
@@ -13,83 +13,83 @@ using namespace coconext::types;
 TEST(TestLogic, LogicConversions) {
     EXPECT_EQ('U'_l, 'u'_l);
     EXPECT_EQ(Logic('U'_l), 'U'_l);
-    EXPECT_EQ(to_logic('U'), 'U'_l);
-    EXPECT_EQ(to_logic('u'), 'U'_l);
-    EXPECT_EQ(to_logic("U"), 'U'_l);
-    EXPECT_EQ(to_logic("u"), 'U'_l);
+    EXPECT_EQ(Logic('U'), 'U'_l);
+    EXPECT_EQ(Logic('u'), 'U'_l);
+    EXPECT_EQ(Logic("U"), 'U'_l);
+    EXPECT_EQ(Logic("u"), 'U'_l);
 
     EXPECT_EQ('X'_l, 'x'_l);
     EXPECT_EQ(Logic('X'_l), 'X'_l);
-    EXPECT_EQ(to_logic('X'), 'X'_l);
-    EXPECT_EQ(to_logic('x'), 'X'_l);
-    EXPECT_EQ(to_logic("X"), 'X'_l);
-    EXPECT_EQ(to_logic("x"), 'X'_l);
+    EXPECT_EQ(Logic('X'), 'X'_l);
+    EXPECT_EQ(Logic('x'), 'X'_l);
+    EXPECT_EQ(Logic("X"), 'X'_l);
+    EXPECT_EQ(Logic("x"), 'X'_l);
 
-    EXPECT_EQ('0'_l, to_logic('0'));
-    EXPECT_EQ('0'_l, to_logic("0"));
-    EXPECT_EQ('0'_l, to_logic(0));
-    EXPECT_EQ('0'_l, to_logic(false));
+    EXPECT_EQ('0'_l, Logic('0'));
+    EXPECT_EQ('0'_l, Logic("0"));
+    EXPECT_EQ('0'_l, Logic(0));
+    EXPECT_EQ('0'_l, Logic(false));
     EXPECT_EQ(Logic('0'_l), '0'_l);
 
-    EXPECT_EQ('1'_l, to_logic('1'));
-    EXPECT_EQ('1'_l, to_logic("1"));
-    EXPECT_EQ('1'_l, to_logic(1));
-    EXPECT_EQ('1'_l, to_logic(true));
+    EXPECT_EQ('1'_l, Logic('1'));
+    EXPECT_EQ('1'_l, Logic("1"));
+    EXPECT_EQ('1'_l, Logic(1));
+    EXPECT_EQ('1'_l, Logic(true));
     EXPECT_EQ(Logic('1'_l), '1'_l);
 
     EXPECT_EQ('Z'_l, 'z'_l);
     EXPECT_EQ(Logic('Z'_l), 'Z'_l);
-    EXPECT_EQ(to_logic('Z'), 'Z'_l);
-    EXPECT_EQ(to_logic('z'), 'Z'_l);
-    EXPECT_EQ(to_logic("Z"), 'Z'_l);
-    EXPECT_EQ(to_logic("z"), 'Z'_l);
+    EXPECT_EQ(Logic('Z'), 'Z'_l);
+    EXPECT_EQ(Logic('z'), 'Z'_l);
+    EXPECT_EQ(Logic("Z"), 'Z'_l);
+    EXPECT_EQ(Logic("z"), 'Z'_l);
 
     EXPECT_EQ('W'_l, 'w'_l);
     EXPECT_EQ(Logic('W'_l), 'W'_l);
-    EXPECT_EQ(to_logic('W'), 'W'_l);
-    EXPECT_EQ(to_logic('w'), 'W'_l);
-    EXPECT_EQ(to_logic("W"), 'W'_l);
-    EXPECT_EQ(to_logic("w"), 'W'_l);
+    EXPECT_EQ(Logic('W'), 'W'_l);
+    EXPECT_EQ(Logic('w'), 'W'_l);
+    EXPECT_EQ(Logic("W"), 'W'_l);
+    EXPECT_EQ(Logic("w"), 'W'_l);
 
     EXPECT_EQ('L'_l, 'l'_l);
     EXPECT_EQ(Logic('L'_l), 'L'_l);
-    EXPECT_EQ(to_logic('L'), 'L'_l);
-    EXPECT_EQ(to_logic('l'), 'L'_l);
-    EXPECT_EQ(to_logic("L"), 'L'_l);
-    EXPECT_EQ(to_logic("l"), 'L'_l);
+    EXPECT_EQ(Logic('L'), 'L'_l);
+    EXPECT_EQ(Logic('l'), 'L'_l);
+    EXPECT_EQ(Logic("L"), 'L'_l);
+    EXPECT_EQ(Logic("l"), 'L'_l);
 
     EXPECT_EQ('H'_l, 'h'_l);
     EXPECT_EQ(Logic('H'_l), 'H'_l);
-    EXPECT_EQ(to_logic('H'), 'H'_l);
-    EXPECT_EQ(to_logic('h'), 'H'_l);
-    EXPECT_EQ(to_logic("H"), 'H'_l);
-    EXPECT_EQ(to_logic("h"), 'H'_l);
+    EXPECT_EQ(Logic('H'), 'H'_l);
+    EXPECT_EQ(Logic('h'), 'H'_l);
+    EXPECT_EQ(Logic("H"), 'H'_l);
+    EXPECT_EQ(Logic("h"), 'H'_l);
 
     EXPECT_EQ('-'_l, Logic::DC);
     EXPECT_EQ(Logic('-'_l), '-'_l);
-    EXPECT_EQ(to_logic('-'), '-'_l);
-    EXPECT_EQ(to_logic("-"), '-'_l);
+    EXPECT_EQ(Logic('-'), '-'_l);
+    EXPECT_EQ(Logic("-"), '-'_l);
 
     // Test invalid conversions
-    EXPECT_THROW(to_logic('j'), std::invalid_argument);
-    EXPECT_THROW(to_logic(2), std::invalid_argument);
-    EXPECT_THROW(to_logic("lol"), std::invalid_argument);
+    EXPECT_THROW(Logic('j'), std::invalid_argument);
+    EXPECT_THROW(Logic(2), std::invalid_argument);
+    EXPECT_THROW(Logic("lol"), std::invalid_argument);
 }
 
 TEST(TestBit, BitConversions) {
-    EXPECT_EQ('0'_b, to_bit('0'));
-    EXPECT_EQ('1'_b, to_bit('1'));
-    EXPECT_EQ('0'_b, to_bit("0"));
-    EXPECT_EQ('1'_b, to_bit("1"));
-    EXPECT_EQ('0'_b, to_bit(0));
-    EXPECT_EQ('1'_b, to_bit(1));
-    EXPECT_EQ('0'_b, to_bit(false));
-    EXPECT_EQ('1'_b, to_bit(true));
+    EXPECT_EQ('0'_b, Bit('0'));
+    EXPECT_EQ('1'_b, Bit('1'));
+    EXPECT_EQ('0'_b, Bit("0"));
+    EXPECT_EQ('1'_b, Bit("1"));
+    EXPECT_EQ('0'_b, Bit(0));
+    EXPECT_EQ('1'_b, Bit(1));
+    EXPECT_EQ('0'_b, Bit(false));
+    EXPECT_EQ('1'_b, Bit(true));
 
     // Test invalid conversions
-    EXPECT_THROW(to_bit('2'), std::invalid_argument);
-    EXPECT_THROW(to_bit("10"), std::invalid_argument);
-    EXPECT_THROW(to_bit(2), std::invalid_argument);
+    EXPECT_THROW(Bit('2'), std::invalid_argument);
+    EXPECT_THROW(Bit("10"), std::invalid_argument);
+    EXPECT_THROW(Bit(2), std::invalid_argument);
 }
 
 // Test Logic bool conversions
@@ -173,35 +173,37 @@ TEST(TestBit, BitFormatter) {
 }
 
 TEST(TestLogic, LogicCharConversions) {
-    EXPECT_EQ(to_char('0'_l), '0');
-    EXPECT_EQ(to_char('1'_l), '1');
-    EXPECT_EQ(to_char('X'_l), 'X');
-    EXPECT_EQ(to_char('Z'_l), 'Z');
+    EXPECT_EQ(char('0'_l), '0');
+    EXPECT_EQ(char('1'_l), '1');
+    EXPECT_EQ(char('X'_l), 'X');
+    EXPECT_EQ(char('Z'_l), 'Z');
 }
 
 TEST(TestBit, BitCharConversions) {
-    EXPECT_EQ(to_char('0'_b), '0');
-    EXPECT_EQ(to_char('1'_b), '1');
+    EXPECT_EQ(char('0'_b), '0');
+    EXPECT_EQ(char('1'_b), '1');
 }
 
 // Test Logic int conversions
 TEST(TestLogic, LogicIntConversions) {
-    EXPECT_EQ(to_int('0'_l), 0);
-    EXPECT_EQ(to_int('1'_l), 1);
-    EXPECT_EQ(to_int('L'_l), 0);
-    EXPECT_EQ(to_int('H'_l), 1);
+    EXPECT_EQ(int('0'_l), 0);
+    EXPECT_EQ(int('1'_l), 1);
+    EXPECT_EQ(int('L'_l), 0);
+    EXPECT_EQ(int('H'_l), 1);
 
-    // Non-convertible values should throw
-    EXPECT_THROW(to_int('X'_l), std::invalid_argument);
-    EXPECT_THROW(to_int('Z'_l), std::invalid_argument);
-    EXPECT_THROW(to_int('U'_l), std::invalid_argument);
-    EXPECT_THROW(to_int('W'_l), std::invalid_argument);
-    EXPECT_THROW(to_int('-'_l), std::invalid_argument);
+    // Non-convertible values should throw. Casting to (void) inside
+    // EXPECT_THROW silences clang's unused-value warning without changing
+    // when the operator conversion runs.
+    EXPECT_THROW((void)int('X'_l), std::invalid_argument);
+    EXPECT_THROW((void)int('Z'_l), std::invalid_argument);
+    EXPECT_THROW((void)int('U'_l), std::invalid_argument);
+    EXPECT_THROW((void)int('W'_l), std::invalid_argument);
+    EXPECT_THROW((void)int('-'_l), std::invalid_argument);
 }
 
 TEST(TestBit, BitIntConversions) {
-    EXPECT_EQ(to_int('0'_b), 0);
-    EXPECT_EQ(to_int('1'_b), 1);
+    EXPECT_EQ(int('0'_b), 0);
+    EXPECT_EQ(int('1'_b), 1);
 }
 
 // Test Logic AND operator
@@ -378,16 +380,16 @@ TEST(TestBit, BitResolveNoArgAlwaysEngaged) {
 // These can be evaluated at compile time and reduce observed coverage.
 TEST(TestLogic, RuntimeIntAndBitConversions) {
     std::vector<int> const ints{0, 1, 2};
-    EXPECT_EQ(to_logic(ints[0]), '0'_l);
-    EXPECT_EQ(to_logic(ints[1]), '1'_l);
-    EXPECT_THROW((void)to_logic(ints[2]), std::invalid_argument);
-    EXPECT_EQ(to_bit(ints[0]), '0'_b);
-    EXPECT_EQ(to_bit(ints[1]), '1'_b);
-    EXPECT_THROW((void)to_bit(ints[2]), std::invalid_argument);
+    EXPECT_EQ(Logic(ints[0]), '0'_l);
+    EXPECT_EQ(Logic(ints[1]), '1'_l);
+    EXPECT_THROW((void)Logic(ints[2]), std::invalid_argument);
+    EXPECT_EQ(Bit(ints[0]), '0'_b);
+    EXPECT_EQ(Bit(ints[1]), '1'_b);
+    EXPECT_THROW((void)Bit(ints[2]), std::invalid_argument);
 
     std::vector<Bit> const bits{'0'_b, '1'_b};
-    EXPECT_EQ(to_logic(bits[0]), '0'_l);
-    EXPECT_EQ(to_logic(bits[1]), '1'_l);
+    EXPECT_EQ(Logic(bits[0]), '0'_l);
+    EXPECT_EQ(Logic(bits[1]), '1'_l);
     EXPECT_EQ(bits[0].resolve(ResolveMethod::WEAK), '0'_b);
     EXPECT_EQ(bits[1].resolve(ResolveMethod::ZEROS), '1'_b);
 }
@@ -512,17 +514,7 @@ TEST(TestLogic, InplaceNotReturnsReference) {
     EXPECT_EQ(&ref, &v);
 }
 
-// -- Bit implicit conversions to int and bool ------------------------------
-//
-// Bit is a 2-element numeric domain so the conversions are lossless and
-// implicit. Logic has no such conversions because they can fail on metavalues.
-
-TEST(TestBit, BitImplicitToInt) {
-    int x = '1'_b;
-    EXPECT_EQ(x, 1);
-    int y = '0'_b;
-    EXPECT_EQ(y, 0);
-}
+// -- Bit contextual conversion to bool -------------------------------------
 
 TEST(TestBit, BitImplicitToBool) {
     // `operator bool` is explicit, but contextual conversion in `if`/`while`/
@@ -533,12 +525,6 @@ TEST(TestBit, BitImplicitToBool) {
     if ('0'_b) {
         FAIL() << "Bit('0') should convert to false";
     }
-}
-
-TEST(TestBit, BitInArithmeticExpression) {
-    // Bit -> int conversion lets it participate in integer arithmetic.
-    EXPECT_EQ('1'_b + 2, 3);
-    EXPECT_EQ('0'_b + '1'_b, 1);
 }
 
 // LCOV_EXCL_BR_STOP

--- a/tests/cpp/test_logic_array.cpp
+++ b/tests/cpp/test_logic_array.cpp
@@ -254,7 +254,7 @@ TEST(TestLogicArray, ScalarBitwiseOnSlice) {
 // -- to_logic_array from string ---------------------------------------------
 
 TEST(TestLogicArray, ToLogicArray) {
-    auto a = to_logic_array("01XZ");
+    auto a = Vector<Logic>("01XZ");
     EXPECT_EQ(a.range(), Range(3, Direction::DOWNTO, 0));
     EXPECT_EQ(a[3], '0'_l);
     EXPECT_EQ(a[2], '1'_l);
@@ -263,7 +263,7 @@ TEST(TestLogicArray, ToLogicArray) {
 }
 
 TEST(TestLogicArray, ToLogicArrayCaseInsensitive) {
-    auto a = to_logic_array("01xzulwh-");
+    auto a = Vector<Logic>("01xzulwh-");
     EXPECT_EQ(a[8], '0'_l);
     EXPECT_EQ(a[7], '1'_l);
     EXPECT_EQ(a[6], 'X'_l);
@@ -275,64 +275,62 @@ TEST(TestLogicArray, ToLogicArrayCaseInsensitive) {
     EXPECT_EQ(a[0], '-'_l);
 }
 
-TEST(TestLogicArray, ToLogicArrayUnderscore) {
-    auto a = to_logic_array("01_XZ");
-    EXPECT_EQ(a.range().length(), 4U);
-    EXPECT_EQ(a[3], '0'_l);
-    EXPECT_EQ(a[0], 'Z'_l);
+TEST(TestLogicArray, ToLogicArrayUnderscoreRejected) {
+    // `_` is not a valid Logic character; the runtime string ctor throws.
+    EXPECT_THROW((void)Vector<Logic>("01_XZ"), std::invalid_argument);
 }
 
 TEST(TestLogicArray, ToLogicArrayEmpty) {
-    auto a = to_logic_array("");
+    auto a = Vector<Logic>("");
     EXPECT_EQ(a.range().length(), 0U);
 }
 
 TEST(TestLogicArray, ToLogicArrayInvalidChar) {
-    EXPECT_THROW(to_logic_array("0!1"), std::invalid_argument);
+    EXPECT_THROW(Vector<Logic>("0!1"), std::invalid_argument);
 }
 
 // -- to_string on arrays ----------------------------------------------------
 
 TEST(TestLogicArray, ToStringLogic) {
-    auto a = to_logic_array("01XZULWH-");
+    auto a = Vector<Logic>("01XZULWH-");
     EXPECT_EQ(to_string(a), "01XZULWH-");
 }
 
 TEST(TestLogicArray, ToStringEmpty) {
-    auto a = to_logic_array("");
+    auto a = Vector<Logic>("");
     EXPECT_EQ(to_string(a), "");
 }
 
 // -- resolvability query on arrays ------------------------------------------
 
 TEST(TestLogicArray, ResolveEngagedOnResolvable) {
-    auto a = to_logic_array("01LH");
+    auto a = Vector<Logic>("01LH");
     EXPECT_TRUE(resolve(a, ResolveMethod::WEAK).has_value());
 }
 
 TEST(TestLogicArray, ResolveNulloptOnMetavalue) {
-    EXPECT_FALSE(resolve(to_logic_array("01X0"), ResolveMethod::WEAK).has_value());
-    EXPECT_FALSE(resolve(to_logic_array("Z"), ResolveMethod::WEAK).has_value());
-    EXPECT_FALSE(resolve(to_logic_array("U"), ResolveMethod::WEAK).has_value());
-    EXPECT_FALSE(resolve(to_logic_array("W"), ResolveMethod::WEAK).has_value());
-    EXPECT_FALSE(resolve(to_logic_array("-"), ResolveMethod::WEAK).has_value());
+    EXPECT_FALSE(resolve(Vector<Logic>("01X0"), ResolveMethod::WEAK).has_value());
+    EXPECT_FALSE(resolve(Vector<Logic>("Z"), ResolveMethod::WEAK).has_value());
+    EXPECT_FALSE(resolve(Vector<Logic>("U"), ResolveMethod::WEAK).has_value());
+    EXPECT_FALSE(resolve(Vector<Logic>("W"), ResolveMethod::WEAK).has_value());
+    EXPECT_FALSE(resolve(Vector<Logic>("-"), ResolveMethod::WEAK).has_value());
 }
 
 TEST(TestLogicArray, ResolveEngagedOnEmpty) {
-    auto a = to_logic_array("");
+    auto a = Vector<Logic>("");
     EXPECT_TRUE(resolve(a, ResolveMethod::WEAK).has_value());
 }
 
 // -- resolve on arrays ------------------------------------------------------
 
 TEST(TestLogicArray, ResolveZeros) {
-    auto a = to_logic_array("01XZULWH-");
+    auto a = Vector<Logic>("01XZULWH-");
     auto b = resolve(a, ResolveMethod::ZEROS);
     EXPECT_EQ(to_string(*b), "010000010");
 }
 
 TEST(TestLogicArray, ResolveOnes) {
-    auto a = to_logic_array("01XZULWH-");
+    auto a = Vector<Logic>("01XZULWH-");
     auto b = resolve(a, ResolveMethod::ONES);
     EXPECT_EQ(to_string(*b), "011110111");
 }
@@ -341,7 +339,7 @@ TEST(TestLogicArray, ResolveWeakAcceptsResolvable) {
     // WEAK passes 0/1/L/H -> 0/1/0/1 and returns nullopt on the rest. The
     // input must contain only resolvable-under-WEAK values for the result to
     // be engaged.
-    auto a = to_logic_array("01LH");
+    auto a = Vector<Logic>("01LH");
     auto b = resolve(a, ResolveMethod::WEAK);
     EXPECT_EQ(to_string(*b), "0101");
 }
@@ -349,17 +347,17 @@ TEST(TestLogicArray, ResolveWeakAcceptsResolvable) {
 TEST(TestLogicArray, ResolveWeakReturnsNulloptOnMetavalue) {
     // Even a single non-resolvable value makes the whole array's resolve
     // return nullopt (build-then-drop).
-    auto a = to_logic_array("01X");
+    auto a = Vector<Logic>("01X");
     EXPECT_FALSE(resolve(a, ResolveMethod::WEAK).has_value());
 }
 
 TEST(TestLogicArray, ResolveError) {
-    auto a = to_logic_array("01X");
+    auto a = Vector<Logic>("01X");
     EXPECT_FALSE(resolve(a, ResolveMethod::ERROR).has_value());
 }
 
 TEST(TestLogicArray, ResolveErrorPass) {
-    auto a = to_logic_array("01");
+    auto a = Vector<Logic>("01");
     auto b = resolve(a, ResolveMethod::ERROR);
     EXPECT_EQ(to_string(*b), "01");
 }
@@ -379,12 +377,12 @@ TEST(TestLogicArray, ResolveStaticReturnsStaticArray) {
 // No-arg resolve() defaults to WEAK -- engages iff every element is 0/1/L/H,
 // matching the scalar Logic::resolve() shortcut.
 TEST(TestLogicArray, ResolveNoArgDefaultsToWeak) {
-    auto resolvable = to_logic_array("01LH");
+    auto resolvable = Vector<Logic>("01LH");
     auto a = resolve(resolvable);
     ASSERT_TRUE(a.has_value());
     EXPECT_EQ(to_string(*a), "0101");
 
-    auto mixed = to_logic_array("01X");
+    auto mixed = Vector<Logic>("01X");
     EXPECT_FALSE(resolve(mixed).has_value());
 }
 
@@ -399,7 +397,7 @@ TEST(TestLogicArray, ResolveNoArgDefaultsToWeak) {
 TEST(TestLogicArray, DynSliceIsResolvable) {
     // to_logic_array parses MSB-first into a DOWNTO range, so "01X" has
     // a[2]='0', a[1]='1', a[0]='X'.
-    auto a = to_logic_array("01X");
+    auto a = Vector<Logic>("01X");
     auto s_full = a[{2, 0}];
     EXPECT_FALSE(resolve(s_full, ResolveMethod::WEAK).has_value());  // covers the X at a[0]
     auto s_excl_x = a[{2, 1}];
@@ -409,7 +407,7 @@ TEST(TestLogicArray, DynSliceIsResolvable) {
 }
 
 TEST(TestLogicArray, DynSliceResolveReturnsVector) {
-    auto a = to_logic_array("01XZ");
+    auto a = Vector<Logic>("01XZ");
     auto s = a[{3, 0}];
     auto r = resolve(s, ResolveMethod::ZEROS);
     static_assert(std::is_same_v<decltype(r), std::optional<BitVector>>);
@@ -446,7 +444,7 @@ TEST(TestLogicArray, ConstOwnerDynSliceResolves) {
     // make the constraint fail to match. The check is structural (the call has
     // to compile and return a bool), not the value -- a const slice over a
     // resolvable Logic array.
-    Vector<Logic> const a = to_logic_array("01LH");
+    Vector<Logic> const a = Vector<Logic>("01LH");
     auto s = a[{3, 0}];
     static_assert(
         std::same_as<decltype(s), ArraySlice<Vector<Logic> const>>,
@@ -458,7 +456,7 @@ TEST(TestLogicArray, ConstOwnerDynSliceResolves) {
 }
 
 TEST(TestLogicArray, SubSliceResolves) {
-    auto a = to_logic_array("01XZ");
+    auto a = Vector<Logic>("01XZ");
     auto s = a[{3, 0}];
     auto sub = s[{2, 1}];  // sub-slice via ArraySliceImpl::operator[]
     EXPECT_FALSE(resolve(sub, ResolveMethod::WEAK).has_value());
@@ -935,6 +933,9 @@ TEST(TestLogicArray, UdlLogic) {
 }
 
 TEST(TestLogicArray, UdlLogicUnderscore) {
+    // Underscores in the literal are stripped as digit separators (HDL
+    // convention); the resulting array has the length of the non-underscore
+    // characters only.
     auto a = "01_XZ"_l;
     static_assert(std::is_same_v<decltype(a), LogicArray<Range{3, Direction::DOWNTO, 0}>>);
     EXPECT_EQ(a[3], '0'_l);
@@ -954,8 +955,8 @@ TEST(TestLogicArray, UdlLogicEmpty) {
 }
 
 TEST(TestLogicArray, UdlLogicAllUnderscores) {
-    // All-underscore literal yields a zero-length array just like the empty
-    // literal -- the underscores are stripped, count_non_underscore returns 0.
+    // All-underscore literal strips to a zero-length array just like the empty
+    // literal.
     auto a = "____"_l;
     static_assert(std::is_same_v<decltype(a), LogicArray<Range{-1, Direction::DOWNTO, 0}>>);
     EXPECT_EQ(a.range().length(), 0U);
@@ -1177,7 +1178,7 @@ TEST(TestBitArray, StaticBitDynLogicOrPromotesToDynLogic) {
 // -- to_bit_array from string ----------------------------------------------
 
 TEST(TestBitArray, ToBitArray) {
-    auto a = to_bit_array("0110");
+    auto a = Vector<Bit>("0110");
     EXPECT_EQ(a.range(), Range(3, Direction::DOWNTO, 0));
     EXPECT_EQ(a[3], '0'_b);
     EXPECT_EQ(a[2], '1'_b);
@@ -1185,27 +1186,25 @@ TEST(TestBitArray, ToBitArray) {
     EXPECT_EQ(a[0], '0'_b);
 }
 
-TEST(TestBitArray, ToBitArrayUnderscore) {
-    auto a = to_bit_array("01_10");
-    EXPECT_EQ(a.range().length(), 4U);
-    EXPECT_EQ(a[3], '0'_b);
-    EXPECT_EQ(a[0], '0'_b);
+TEST(TestBitArray, ToBitArrayUnderscoreRejected) {
+    // `_` is not a valid Bit character; the runtime string ctor throws.
+    EXPECT_THROW((void)Vector<Bit>("01_10"), std::invalid_argument);
 }
 
 TEST(TestBitArray, ToBitArrayEmpty) {
-    auto a = to_bit_array("");
+    auto a = Vector<Bit>("");
     EXPECT_EQ(a.range().length(), 0U);
 }
 
 TEST(TestBitArray, ToBitArrayInvalidChar) {
-    EXPECT_THROW(to_bit_array("01X0"), std::invalid_argument);
-    EXPECT_THROW(to_bit_array("2"), std::invalid_argument);
+    EXPECT_THROW(Vector<Bit>("01X0"), std::invalid_argument);
+    EXPECT_THROW(Vector<Bit>("2"), std::invalid_argument);
 }
 
 // -- to_string on BitArray -------------------------------------------------
 
 TEST(TestBitArray, ToStringBit) {
-    auto a = to_bit_array("0110");
+    auto a = Vector<Bit>("0110");
     EXPECT_EQ(to_string(a), "0110");
 }
 
@@ -1217,16 +1216,16 @@ TEST(TestBitArray, ToStringStaticBit) {
 // -- resolve on BitArray (always engaged) ----------------------------------
 
 TEST(TestBitArray, ResolveAlwaysEngaged) {
-    auto a = to_bit_array("0110");
+    auto a = Vector<Bit>("0110");
     EXPECT_TRUE(resolve(a, ResolveMethod::WEAK).has_value());
-    auto empty = to_bit_array("");
+    auto empty = Vector<Bit>("");
     EXPECT_TRUE(resolve(empty, ResolveMethod::WEAK).has_value());
 }
 
 // -- resolve on BitArray ---------------------------------------------------
 
 TEST(TestBitArray, ResolveBitIsIdentity) {
-    auto a = to_bit_array("0110");
+    auto a = Vector<Bit>("0110");
     static_assert(
         std::is_same_v<decltype(resolve(a, ResolveMethod::ZEROS)), std::optional<BitVector>>
     );
@@ -1296,7 +1295,7 @@ TEST(TestLogicArray, IndexOfBitArray) {
 }
 
 TEST(TestLogicArray, IndexOfLogicVector) {
-    auto a = to_logic_array("01XZ");  // Vector<Logic>, DOWNTO {3..0}
+    auto a = Vector<Logic>("01XZ");  // Vector<Logic>, DOWNTO {3..0}
     EXPECT_EQ(a.index<3>(), '0'_l);
     EXPECT_EQ(a.index<0>(), 'Z'_l);
 }

--- a/tests/cpp/test_range.cpp
+++ b/tests/cpp/test_range.cpp
@@ -25,9 +25,6 @@ TEST(TestRange, ToRange) {
     EXPECT_EQ(r[0], 1);
     EXPECT_EQ(r[7], 8);
     EXPECT_THROW((void)r[8], std::out_of_range);
-
-    EXPECT_NE(find(r, 8), r.end());
-    EXPECT_EQ(find(r, 10), r.end());
 }
 
 TEST(TestRange, DowntoRange) {
@@ -46,9 +43,6 @@ TEST(TestRange, DowntoRange) {
     EXPECT_EQ(r[0], 4);
     EXPECT_EQ(r[7], -3);
     EXPECT_THROW((void)r[8], std::out_of_range);
-
-    EXPECT_NE(find(r, 0), r.end());
-    EXPECT_EQ(find(r, 10), r.end());
 }
 
 TEST(TestRange, NullRange) {
@@ -65,14 +59,6 @@ TEST(TestRange, NullRange) {
     EXPECT_TRUE(reverse.empty());
 
     EXPECT_THROW((void)r[0], std::out_of_range);
-    EXPECT_EQ(find(r, 2), r.end());
-}
-
-TEST(TestRange, BadArgumentsEquivalent) {
-    EXPECT_THROW((void)to_direction("BAD DIRECTION"), std::invalid_argument);
-    EXPECT_THROW((void)to_direction("nope"), std::invalid_argument);
-    EXPECT_THROW((void)to_direction("xx"), std::invalid_argument);
-    EXPECT_THROW((void)to_direction("nottto"), std::invalid_argument);
 }
 
 TEST(TestRange, Equality) {
@@ -105,11 +91,6 @@ TEST(TestRange, Formatter) {
 TEST(TestDirection, Formatter) {
     EXPECT_EQ(std::format("{}", Direction::TO), "Direction{to}");
     EXPECT_EQ(std::format("{}", Direction::DOWNTO), "Direction{downto}");
-}
-
-TEST(TestRange, UppercaseDirection) {
-    Range const r(1, to_direction("TO"), 8);
-    EXPECT_EQ(r.direction, Direction::TO);
 }
 
 TEST(TestRange, Copy) {
@@ -199,45 +180,11 @@ TEST(TestRange, IsSubsequenceConstexpr) {
     );
 }
 
-// -- Length overflow protection --------------------------------------------
+// -- Near-max length -------------------------------------------------------
 //
-// A Range spanning the full int64_t domain (INT64_MIN..INT64_MAX in TO, or
-// reversed in DOWNTO) would mathematically have length 2^64 -- doesn't fit
-// in size_t. length() is the only place this check can live: Range's fields
-// are public and a Range can be mutated into the full-span state after
-// construction, so a construction-time check would be bypassable. Throws
-// std::length_error when invoked on such a Range.
-
-TEST(TestRange, LengthFullSpanTOThrows) {
-    constexpr auto lo = std::numeric_limits<Range::value_type>::min();
-    constexpr auto hi = std::numeric_limits<Range::value_type>::max();
-    Range r1{lo, Direction::TO, hi};
-    EXPECT_THROW((void)r1.length(), std::length_error);
-    // Two-arg auto-direction picks TO since lo < hi -- same behavior.
-    Range r2{lo, hi};
-    EXPECT_THROW((void)r2.length(), std::length_error);
-}
-
-TEST(TestRange, LengthFullSpanDOWNTOThrows) {
-    constexpr auto lo = std::numeric_limits<Range::value_type>::min();
-    constexpr auto hi = std::numeric_limits<Range::value_type>::max();
-    Range r1{hi, Direction::DOWNTO, lo};
-    EXPECT_THROW((void)r1.length(), std::length_error);
-    // Two-arg auto-direction picks DOWNTO since hi > lo -- same behavior.
-    Range r2{hi, lo};
-    EXPECT_THROW((void)r2.length(), std::length_error);
-}
-
-TEST(TestRange, LengthAfterPostConstructionMutationThrows) {
-    // Confirms that the check fires when fields are mutated into the full-
-    // span state after construction (the case construction-time checks
-    // can't catch).
-    Range r{0, Direction::TO, 5};
-    EXPECT_EQ(r.length(), 6U);  // sanity
-    r.left = std::numeric_limits<Range::value_type>::min();
-    r.right = std::numeric_limits<Range::value_type>::max();
-    EXPECT_THROW((void)r.length(), std::length_error);
-}
+// One step short of the full int64_t domain: the largest representable length
+// (SIZE_MAX on a 64-bit platform). Full-domain spans are Undefined Behavior
+// per the spec (no runtime check anywhere), so we don't test them.
 
 TEST(TestRange, NearMaxLengthIsValidTO) {
     // One step short of the full span: max representable length (SIZE_MAX


### PR DESCRIPTION
And also update those types with the changes.

Basically, I had a change of heart when it came to constructors/conversion operators vs free functions. `to_int` and `to_char` require concrete types and if you're going to do that, you might as well just use conversion operators like we are on `Unsigned` and `Signed`. And then I propagated that idea to the other types as well.

Then I also realized there were a handful of discrepancies between my concept of the types and the actual implementation. Minor mostly. Those are fixed here too.

Other things:
* made UDLs `consteval`
* removed `find()` on Range since it can't be used together with `std::ranges::find`