### PR TITLE
Port APInt algos to Bits

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -3,11 +3,6 @@ add_library(coconext SHARED
     src/random.cpp
 )
 
-option(COCONEXT_USE_APINT "Use LLVM APInt backend" OFF)
-if(COCONEXT_USE_APINT)
-    target_compile_definitions(coconext PUBLIC COCONEXT_USE_APINT)
-endif()
-
 target_include_directories(coconext PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:coconext/include>)

--- a/cpp/include/coconext/types/bigint.hpp
+++ b/cpp/include/coconext/types/bigint.hpp
@@ -1,0 +1,856 @@
+#ifndef COCONEXT_BIGINT_HPP
+#define COCONEXT_BIGINT_HPP
+
+// The multi-word arithmetic kernels below (the `tc*` word-array primitives, the
+// Knuth division algorithm, and the division driver) are derived from LLVM's
+// APInt implementation (llvm/lib/Support/APInt.cpp). They have been adapted to
+// operate on fixed-size, compile-time-sized std::array storage so the whole
+// type remains constexpr and never allocates.
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <array>
+#include <bit>
+#include <climits>
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <string_view>
+#include <type_traits>
+
+namespace coconext::types::detail {
+
+// ---------------------------------------------------------------------------
+// Word-array kernels (derived from LLVM APInt tc* primitives)
+//
+// These operate on raw uint64_t words, `parts` of them, little-endian (word 0
+// is least significant). They carry no notion of bit width; the owning BigInt
+// masks the top word after each mutating op.
+// ---------------------------------------------------------------------------
+
+using Word = uint64_t;
+inline constexpr unsigned word_bits = 64;
+
+// DST += RHS + carry (carry is 0 or 1). Returns the carry out.
+constexpr Word tc_add(Word* dst, Word const* rhs, Word carry, unsigned parts) {
+    for (unsigned i = 0; i < parts; ++i) {
+        Word l = dst[i];
+        if (carry) {
+            dst[i] += rhs[i] + 1;
+            carry = (dst[i] <= l);
+        } else {
+            dst[i] += rhs[i];
+            carry = (dst[i] < l);
+        }
+    }
+    return carry;
+}
+
+// DST -= RHS + carry (carry is 0 or 1). Returns the borrow out.
+constexpr Word tc_subtract(Word* dst, Word const* rhs, Word carry, unsigned parts) {
+    for (unsigned i = 0; i < parts; ++i) {
+        Word l = dst[i];
+        if (carry) {
+            dst[i] -= rhs[i] + 1;
+            carry = (dst[i] >= l);
+        } else {
+            dst[i] -= rhs[i];
+            carry = (dst[i] > l);
+        }
+    }
+    return carry;
+}
+
+constexpr Word low_half(Word part) { return part & (~Word(0) >> (word_bits / 2)); }
+constexpr Word high_half(Word part) { return part >> (word_bits / 2); }
+
+// DST = SRC * MULTIPLIER + CARRY (add == false) or DST += ... (add == true).
+// Mirrors APInt::tcMultiplyPart; emulates the 128-bit intermediate via 32-bit
+// half-words so it needs no wider integer type.
+constexpr int tc_multiply_part(
+    Word* dst,
+    Word const* src,
+    Word multiplier,
+    Word carry,
+    unsigned src_parts,
+    unsigned dst_parts,
+    bool add
+) {
+    unsigned n = src_parts < dst_parts ? src_parts : dst_parts;
+
+    for (unsigned i = 0; i < n; ++i) {
+        Word src_part = src[i];
+        Word low, mid, high;
+        if (multiplier == 0 || src_part == 0) {
+            low = carry;
+            high = 0;
+        } else {
+            low = low_half(src_part) * low_half(multiplier);
+            high = high_half(src_part) * high_half(multiplier);
+
+            mid = low_half(src_part) * high_half(multiplier);
+            high += high_half(mid);
+            mid <<= word_bits / 2;
+            if (low + mid < low) {
+                high++;
+            }
+            low += mid;
+
+            mid = high_half(src_part) * low_half(multiplier);
+            high += high_half(mid);
+            mid <<= word_bits / 2;
+            if (low + mid < low) {
+                high++;
+            }
+            low += mid;
+
+            if (low + carry < low) {
+                high++;
+            }
+            low += carry;
+        }
+
+        if (add) {
+            if (low + dst[i] < low) {
+                high++;
+            }
+            dst[i] += low;
+        } else {
+            dst[i] = low;
+        }
+
+        carry = high;
+    }
+
+    if (src_parts < dst_parts) {
+        dst[src_parts] = carry;
+        return 0;
+    }
+
+    if (carry) {
+        return 1;
+    }
+
+    if (multiplier) {
+        for (unsigned i = dst_parts; i < src_parts; ++i) {
+            if (src[i]) {
+                return 1;
+            }
+        }
+    }
+
+    return 0;
+}
+
+// DST = LHS * RHS, truncated to `parts` words. DST must be disjoint from both
+// operands. Returns nonzero on overflow.
+constexpr int tc_multiply(Word* dst, Word const* lhs, Word const* rhs, unsigned parts) {
+    int overflow = 0;
+    for (unsigned i = 0; i < parts; ++i) {
+        overflow |= tc_multiply_part(&dst[i], lhs, rhs[i], 0, parts, parts - i, i != 0);
+    }
+    return overflow;
+}
+
+// Shift a bignum left `count` bits in-place; shifted-in bits are zero.
+constexpr void tc_shift_left(Word* dst, unsigned words, unsigned count) {
+    if (!count) {
+        return;
+    }
+
+    unsigned word_shift = count / word_bits;
+    if (word_shift > words) {
+        word_shift = words;
+    }
+    unsigned bit_shift = count % word_bits;
+
+    if (bit_shift == 0) {
+        for (unsigned i = words; i-- > word_shift;) {
+            dst[i] = dst[i - word_shift];
+        }
+    } else {
+        for (unsigned i = words; i-- > word_shift;) {
+            dst[i] = dst[i - word_shift] << bit_shift;
+            if (i > word_shift) {
+                dst[i] |= dst[i - word_shift - 1] >> (word_bits - bit_shift);
+            }
+        }
+    }
+
+    for (unsigned i = 0; i < word_shift; ++i) {
+        dst[i] = 0;
+    }
+}
+
+// Shift a bignum right `count` bits in-place (logical); shifted-in bits zero.
+constexpr void tc_shift_right(Word* dst, unsigned words, unsigned count) {
+    if (!count) {
+        return;
+    }
+
+    unsigned word_shift = count / word_bits;
+    if (word_shift > words) {
+        word_shift = words;
+    }
+    unsigned bit_shift = count % word_bits;
+    unsigned words_to_move = words - word_shift;
+
+    if (bit_shift == 0) {
+        for (unsigned i = 0; i < words_to_move; ++i) {
+            dst[i] = dst[i + word_shift];
+        }
+    } else {
+        for (unsigned i = 0; i != words_to_move; ++i) {
+            dst[i] = dst[i + word_shift] >> bit_shift;
+            if (i + 1 != words_to_move) {
+                dst[i] |= dst[i + word_shift + 1] << (word_bits - bit_shift);
+            }
+        }
+    }
+
+    for (unsigned i = words_to_move; i < words; ++i) {
+        dst[i] = 0;
+    }
+}
+
+// Unsigned comparison of two bignums: -1, 0, or 1.
+constexpr int tc_compare(Word const* lhs, Word const* rhs, unsigned parts) {
+    while (parts) {
+        --parts;
+        if (lhs[parts] != rhs[parts]) {
+            return (lhs[parts] > rhs[parts]) ? 1 : -1;
+        }
+    }
+    return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Division (derived from LLVM APInt::divide + the file-static KnuthDiv)
+//
+// The algorithm is generic over the limb type; only the double-width limb used
+// for the trial-quotient divide and the multiply-subtract is width-specific.
+// That is the single #ifdef below: 64-bit limbs (needing __uint128_t) when
+// available, else the portable 32-bit-limb form (needing only uint64_t).
+// ---------------------------------------------------------------------------
+
+template <typename Limb>
+struct wider;
+
+// Signed counterpart of the double-width limb type. std::make_signed does not
+// accept __int128 under strict -std=c++20 in libstdc++, so select explicitly.
+template <typename D>
+struct as_signed {
+    using type = std::make_signed_t<D>;
+};
+
+template <>
+struct wider<uint32_t> {
+    using type = uint64_t;
+};
+
+#if defined(__SIZEOF_INT128__)
+template <>
+struct wider<uint64_t> {
+    using type = __uint128_t;
+};
+template <>
+struct as_signed<__uint128_t> {
+    using type = __int128_t;
+};
+using DivLimb = uint64_t;
+#else
+using DivLimb = uint32_t;
+#endif
+
+inline constexpr unsigned limb_bits = sizeof(DivLimb) * CHAR_BIT;
+inline constexpr unsigned limbs_per_word = word_bits / limb_bits;
+
+// Knuth's Algorithm D over base 2^limb_bits. `u` has m+n+1 limbs (the extra one
+// for spill), `v` has n limbs, `q` receives m+1 quotient limbs, and `r` (if not
+// null) receives n remainder limbs. Requires n > 1.
+template <typename Limb>
+constexpr void knuth_div(Limb* u, Limb* v, Limb* q, Limb* r, unsigned m, unsigned n) {
+    using D = typename wider<Limb>::type;
+    using SD = typename as_signed<D>::type;
+    constexpr unsigned lb = sizeof(Limb) * CHAR_BIT;
+    constexpr D b = D(1) << lb;
+
+    auto lo = [](D x) -> Limb { return static_cast<Limb>(x); };
+    auto hi = [](D x) -> Limb { return static_cast<Limb>(x >> lb); };
+    auto make = [](Limb h, Limb l) -> D { return (D(h) << lb) | l; };
+
+    // D1. Normalize so the divisor's high limb has its top bit set.
+    unsigned shift = static_cast<unsigned>(std::countl_zero(v[n - 1]));
+    Limb v_carry = 0;
+    Limb u_carry = 0;
+    if (shift) {
+        for (unsigned i = 0; i < m + n; ++i) {
+            Limb u_tmp = u[i] >> (lb - shift);
+            u[i] = (u[i] << shift) | u_carry;
+            u_carry = u_tmp;
+        }
+        for (unsigned i = 0; i < n; ++i) {
+            Limb v_tmp = v[i] >> (lb - shift);
+            v[i] = (v[i] << shift) | v_carry;
+            v_carry = v_tmp;
+        }
+    }
+    u[m + n] = u_carry;
+
+    // D2-D7. Main loop over quotient limbs.
+    int j = static_cast<int>(m);
+    do {
+        // D3. Estimate the quotient limb qp.
+        D dividend = make(u[j + n], u[j + n - 1]);
+        D qp = dividend / v[n - 1];
+        D rp = dividend % v[n - 1];
+        if (qp == b || qp * v[n - 2] > b * rp + u[j + n - 2]) {
+            qp--;
+            rp += v[n - 1];
+            if (rp < b && (qp == b || qp * v[n - 2] > b * rp + u[j + n - 2])) {
+                qp--;
+            }
+        }
+
+        // D4. Multiply and subtract. `borrow` is a non-negative propagated
+        // borrow in [0, 2^lb): the high-limb difference is taken in unsigned
+        // limb arithmetic (wrapping) exactly as in LLVM's 32-bit-limb form.
+        SD borrow = 0;
+        for (unsigned i = 0; i < n; ++i) {
+            D p = qp * D(v[i]);
+            SD subres = SD(u[j + i]) - borrow - SD(lo(p));
+            u[j + i] = lo(static_cast<D>(subres));
+            borrow = static_cast<SD>(static_cast<Limb>(hi(p) - hi(static_cast<D>(subres))));
+        }
+        bool is_neg = SD(u[j + n]) < borrow;
+        u[j + n] -= lo(static_cast<D>(borrow));
+
+        // D5. Set quotient limb; D6. add back on the rare negative case.
+        q[j] = lo(qp);
+        if (is_neg) {
+            q[j]--;
+            bool carry = false;
+            for (unsigned i = 0; i < n; ++i) {
+                Limb limit = u[j + i] < v[i] ? u[j + i] : v[i];
+                u[j + i] += v[i] + carry;
+                carry = u[j + i] < limit || (carry && u[j + i] == limit);
+            }
+            u[j + n] += carry;
+        }
+    } while (--j >= 0);
+
+    // D8. Unnormalize to recover the remainder.
+    if (r) {
+        if (shift) {
+            Limb carry = 0;
+            for (int i = static_cast<int>(n) - 1; i >= 0; --i) {
+                r[i] = (u[i] >> shift) | carry;
+                carry = u[i] << (lb - shift);
+            }
+        } else {
+            for (int i = static_cast<int>(n) - 1; i >= 0; --i) {
+                r[i] = u[i];
+            }
+        }
+    }
+}
+
+// Split a uint64_t word into limbs (little-endian), storing into out[0..].
+constexpr void word_to_limbs(Word w, DivLimb* out) {
+    if constexpr (limbs_per_word == 1) {
+        out[0] = static_cast<DivLimb>(w);
+    } else {
+        for (unsigned k = 0; k < limbs_per_word; ++k) {
+            out[k] = static_cast<DivLimb>(w >> (k * limb_bits));
+        }
+    }
+}
+
+// Reassemble a uint64_t word from limbs (little-endian).
+constexpr Word limbs_to_word(DivLimb const* in) {
+    if constexpr (limbs_per_word == 1) {
+        return static_cast<Word>(in[0]);
+    } else {
+        Word w = 0;
+        for (unsigned k = 0; k < limbs_per_word; ++k) {
+            w |= static_cast<Word>(in[k]) << (k * limb_bits);
+        }
+        return w;
+    }
+}
+
+// Division driver: computes quotient and/or remainder of LHS / RHS, each of
+// `num_words` uint64_t words. `lhs_words`/`rhs_words` are the significant
+// (non-zero-high) word counts. quotient/remainder may be null. Caller has
+// already handled the degenerate cases (zero, single-word, lhs < rhs, equal).
+template <size_t NumWords>
+constexpr void divide(
+    Word const* lhs,
+    unsigned lhs_words,
+    Word const* rhs,
+    unsigned rhs_words,
+    Word* quotient,
+    Word* remainder
+) {
+    // Widen into limbs. n = divisor limbs, m = dividend excess.
+    unsigned n = rhs_words * limbs_per_word;
+    unsigned m = (lhs_words * limbs_per_word) - n;
+
+    // Scratch sized for the worst case at compile time.
+    constexpr unsigned max_limbs = NumWords * limbs_per_word;
+    std::array<DivLimb, max_limbs + max_limbs + 1> U{};
+    std::array<DivLimb, max_limbs> V{};
+    std::array<DivLimb, max_limbs + max_limbs> Q{};
+    std::array<DivLimb, max_limbs> R{};
+
+    for (unsigned i = 0; i < lhs_words; ++i) {
+        word_to_limbs(lhs[i], &U[i * limbs_per_word]);
+    }
+    U[m + n] = 0;
+    for (unsigned i = 0; i < rhs_words; ++i) {
+        word_to_limbs(rhs[i], &V[i * limbs_per_word]);
+    }
+
+    // Trim leading zero limbs the widening may have introduced.
+    for (unsigned i = n; i > 0 && V[i - 1] == 0; --i) {
+        n--;
+        m++;
+    }
+    for (unsigned i = m + n; i > 0 && U[i - 1] == 0; --i) {
+        m--;
+    }
+
+    if (n == 1) {
+        // Short division in base 2^limb_bits.
+        using D = typename wider<DivLimb>::type;
+        DivLimb divisor = V[0];
+        DivLimb rem = 0;
+        for (int i = static_cast<int>(m); i >= 0; --i) {
+            D partial = (D(rem) << limb_bits) | U[i];
+            if (partial == 0) {
+                Q[i] = 0;
+                rem = 0;
+            } else if (partial < divisor) {
+                Q[i] = 0;
+                rem = static_cast<DivLimb>(partial);
+            } else if (partial == divisor) {
+                Q[i] = 1;
+                rem = 0;
+            } else {
+                Q[i] = static_cast<DivLimb>(partial / divisor);
+                rem = static_cast<DivLimb>(partial - (D(Q[i]) * divisor));
+            }
+        }
+        R[0] = rem;
+    } else {
+        knuth_div<DivLimb>(
+            U.data(), V.data(), Q.data(), remainder ? R.data() : nullptr, m, n
+        );
+    }
+
+    if (quotient) {
+        for (unsigned i = 0; i < lhs_words; ++i) {
+            quotient[i] = limbs_to_word(&Q[i * limbs_per_word]);
+        }
+        for (unsigned i = lhs_words; i < NumWords; ++i) {
+            quotient[i] = 0;
+        }
+    }
+    if (remainder) {
+        for (unsigned i = 0; i < rhs_words; ++i) {
+            remainder[i] = limbs_to_word(&R[i * limbs_per_word]);
+        }
+        for (unsigned i = rhs_words; i < NumWords; ++i) {
+            remainder[i] = 0;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// BigInt<BitWidth>: fixed-width, std::array-backed, constexpr big integer.
+// Backs the wide (W > 128) storage tier of detail::Bits.
+// ---------------------------------------------------------------------------
+
+template <size_t BitWidth>
+class BigInt {
+  public:
+    using WordType = uint64_t;
+    static constexpr unsigned word_width = 64;
+    static constexpr unsigned num_of_words = (BitWidth + word_width - 1) / word_width;
+
+  private:
+    static constexpr WordType get_last_word_mask() {
+        unsigned valid_bits = BitWidth % word_width;
+        if (valid_bits == 0) {
+            return ~WordType(0);
+        }
+        return (WordType(1) << valid_bits) - 1;
+    }
+
+    static constexpr WordType last_word_mask = get_last_word_mask();
+    std::array<WordType, num_of_words> data{};
+
+    constexpr void clear_unused_bits() { data.back() &= last_word_mask; }
+
+    // Count of significant (non-zero-high) words; 0 for a zero value.
+    constexpr unsigned active_words() const {
+        for (unsigned i = num_of_words; i > 0; --i) {
+            if (data[i - 1] != 0) {
+                return i;
+            }
+        }
+        return 0;
+    }
+
+  public:
+    constexpr bool is_negative() const {
+        unsigned sign_bit = (BitWidth - 1) % word_width;
+        return (data.back() >> sign_bit) & 1;
+    }
+
+    constexpr WordType get_word(size_t index) const { return data[index]; }
+    constexpr std::array<WordType, num_of_words> get_data() const { return data; }
+
+    constexpr BigInt() = default;
+
+    constexpr BigInt(WordType val, bool is_signed = false) {
+        data[0] = val;
+        if (is_signed && (static_cast<int64_t>(val) < 0)) {
+            for (unsigned i = 1; i < num_of_words; ++i) {
+                data[i] = ~WordType(0);
+            }
+        }
+        clear_unused_bits();
+    }
+
+    explicit constexpr BigInt(std::string_view str) {
+        if (str.empty()) {
+            return;
+        }
+
+        bool is_neg = false;
+        size_t i = 0;
+
+        if (str[i] == '-') {
+            is_neg = true;
+            i++;
+        } else if (str[i] == '+') {
+            i++;
+        }
+
+        bool is_hex = false;
+        if (i + 1 < str.length() && str[i] == '0'
+            && (str[i + 1] == 'x' || str[i + 1] == 'X'))
+        {
+            is_hex = true;
+            i += 2;
+        }
+
+        if (is_hex) {
+            if (is_neg) {
+                throw std::invalid_argument("Hexadecimal value cannot be negative");
+            }
+            unsigned word_idx = 0;
+            unsigned bit_shift = 0;
+
+            for (int j = static_cast<int>(str.length()) - 1; j >= static_cast<int>(i); --j)
+            {
+                char c = str[j];
+                uint64_t val = 0;
+
+                if (c >= '0' && c <= '9') {
+                    val = c - '0';
+                } else if (c >= 'a' && c <= 'f') {
+                    val = c - 'a' + 10;
+                } else if (c >= 'A' && c <= 'F') {
+                    val = c - 'A' + 10;
+                } else if (c == '\'' || c == '_') {
+                    continue;
+                } else {
+                    throw std::invalid_argument("Invalid hexadecimal character");
+                }
+
+                // Throw if any set bit of this nibble lands at bit index >= W.
+                unsigned abs_bit = word_idx * word_width + bit_shift;
+                if (val != 0
+                    && (abs_bit >= BitWidth || (abs_bit + std::bit_width(val)) > BitWidth))
+                {
+                    throw std::out_of_range("Hexadecimal literal exceeds BigInt width");
+                }
+
+                data[word_idx] |= (val << bit_shift);
+                bit_shift += 4;
+
+                if (bit_shift == 64) {
+                    bit_shift = 0;
+                    word_idx++;
+                }
+            }
+        } else {
+            for (; i < str.length(); ++i) {
+                char c = str[i];
+                if (c == '\'' || c == '_') {
+                    continue;
+                }
+                if (c < '0' || c > '9') {
+                    throw std::invalid_argument("Invalid base-10 character");
+                }
+                uint64_t digit = c - '0';
+
+                uint64_t carry = digit;
+                for (unsigned w = 0; w < num_of_words; ++w) {
+                    uint64_t lower = (data[w] & 0xFFFFFFFF) * 10 + carry;
+                    uint64_t upper = (data[w] >> 32) * 10 + (lower >> 32);
+                    data[w] = (lower & 0xFFFFFFFF) | (upper << 32);
+                    carry = upper >> 32;
+                }
+                if (carry != 0 || (data.back() & ~last_word_mask) != 0) {
+                    throw std::out_of_range("Decimal literal exceeds BigInt width");
+                }
+            }
+        }
+
+        if (is_neg) {
+            uint64_t carry = 1;
+            for (unsigned w = 0; w < num_of_words; ++w) {
+                data[w] = ~data[w];
+                uint64_t sum = data[w] + carry;
+                carry = (sum < data[w]) ? 1 : 0;
+                data[w] = sum;
+            }
+        }
+        clear_unused_bits();
+    }
+
+    constexpr BigInt& operator=(BigInt const&) = default;
+    constexpr BigInt& operator=(BigInt&&) noexcept = default;
+    constexpr BigInt(BigInt const&) = default;
+    constexpr BigInt(BigInt&&) noexcept = default;
+
+    constexpr explicit operator bool() const { return active_words() != 0; }
+
+    constexpr bool operator==(BigInt const& rhs) const { return data == rhs.data; }
+    constexpr bool operator!=(BigInt const& rhs) const { return !(*this == rhs); }
+
+    // Unsigned magnitude comparison over the raw bit pattern.
+    constexpr int ucompare(BigInt const& rhs) const {
+        return tc_compare(data.data(), rhs.data.data(), num_of_words);
+    }
+
+    // Signed (two's-complement) comparison under the W-bit interpretation.
+    constexpr int scompare(BigInt const& rhs) const {
+        bool lhs_neg = is_negative();
+        bool rhs_neg = rhs.is_negative();
+        if (lhs_neg != rhs_neg) {
+            return lhs_neg ? -1 : 1;
+        }
+        return ucompare(rhs);
+    }
+
+    constexpr BigInt operator&(BigInt const& rhs) const {
+        BigInt result;
+        for (unsigned i = 0; i < num_of_words; ++i) {
+            result.data[i] = data[i] & rhs.data[i];
+        }
+        return result;
+    }
+
+    constexpr BigInt operator|(BigInt const& rhs) const {
+        BigInt result;
+        for (unsigned i = 0; i < num_of_words; ++i) {
+            result.data[i] = data[i] | rhs.data[i];
+        }
+        return result;
+    }
+
+    constexpr BigInt operator^(BigInt const& rhs) const {
+        BigInt result;
+        for (unsigned i = 0; i < num_of_words; ++i) {
+            result.data[i] = data[i] ^ rhs.data[i];
+        }
+        return result;
+    }
+
+    constexpr BigInt operator~() const {
+        BigInt result(*this);
+        for (auto& word : result.data) {
+            word = ~word;
+        }
+        result.clear_unused_bits();
+        return result;
+    }
+
+    constexpr BigInt operator+(BigInt const& rhs) const {
+        BigInt result(*this);
+        tc_add(result.data.data(), rhs.data.data(), 0, num_of_words);
+        result.clear_unused_bits();
+        return result;
+    }
+
+    constexpr BigInt operator-(BigInt const& rhs) const {
+        BigInt result(*this);
+        tc_subtract(result.data.data(), rhs.data.data(), 0, num_of_words);
+        result.clear_unused_bits();
+        return result;
+    }
+
+    constexpr BigInt operator*(BigInt const& rhs) const {
+        BigInt result;
+        tc_multiply(result.data.data(), data.data(), rhs.data.data(), num_of_words);
+        result.clear_unused_bits();
+        return result;
+    }
+
+    // Unsigned division; caller guarantees rhs != 0.
+    constexpr BigInt udiv(BigInt const& rhs) const {
+        unsigned lhs_words = active_words();
+        unsigned rhs_words = rhs.active_words();
+
+        if (lhs_words == 0 || ucompare(rhs) < 0) {
+            return BigInt{};  // lhs < rhs (covers lhs == 0)
+        }
+        if (*this == rhs) {
+            return BigInt(WordType{1});
+        }
+        BigInt result;
+        divide<num_of_words>(
+            data.data(), lhs_words, rhs.data.data(), rhs_words, result.data.data(), nullptr
+        );
+        result.clear_unused_bits();
+        return result;
+    }
+
+    // Unsigned remainder; caller guarantees rhs != 0.
+    constexpr BigInt umod(BigInt const& rhs) const {
+        unsigned lhs_words = active_words();
+        unsigned rhs_words = rhs.active_words();
+
+        if (lhs_words == 0 || ucompare(rhs) < 0) {
+            return *this;  // lhs < rhs (covers lhs == 0)
+        }
+        if (*this == rhs) {
+            return BigInt{};
+        }
+        BigInt result;
+        divide<num_of_words>(
+            data.data(), lhs_words, rhs.data.data(), rhs_words, nullptr, result.data.data()
+        );
+        result.clear_unused_bits();
+        return result;
+    }
+
+    // Signed division (truncating toward zero); caller guarantees rhs != 0.
+    constexpr BigInt sdiv(BigInt const& rhs) const {
+        bool lhs_neg = is_negative();
+        bool rhs_neg = rhs.is_negative();
+        BigInt a = lhs_neg ? -(*this) : *this;
+        BigInt b = rhs_neg ? -rhs : rhs;
+        BigInt q = a.udiv(b);
+        return (lhs_neg ^ rhs_neg) ? -q : q;
+    }
+
+    // Signed remainder (sign follows dividend); caller guarantees rhs != 0.
+    constexpr BigInt smod(BigInt const& rhs) const {
+        bool lhs_neg = is_negative();
+        BigInt a = lhs_neg ? -(*this) : *this;
+        BigInt b = rhs.is_negative() ? -rhs : rhs;
+        BigInt r = a.umod(b);
+        return lhs_neg ? -r : r;
+    }
+
+    constexpr BigInt operator-() const { return (~(*this)) + BigInt(WordType{1}); }
+
+    constexpr size_t count_trailing_zeros() const {
+        for (unsigned i = 0; i < num_of_words; ++i) {
+            if (data[i] != 0) {
+                return (i * word_width) + std::countr_zero(data[i]);
+            }
+        }
+        return BitWidth;
+    }
+
+    constexpr size_t count_leading_zeros() const {
+        for (unsigned i = num_of_words; i > 0; --i) {
+            if (data[i - 1] != 0) {
+                size_t leading_in_word = std::countl_zero(data[i - 1]);
+                size_t total_leading = ((num_of_words - i) * word_width) + leading_in_word;
+                size_t unused_top_bits = (num_of_words * word_width) - BitWidth;
+                return total_leading - unused_top_bits;
+            }
+        }
+        return BitWidth;
+    }
+
+    constexpr size_t popcount() const {
+        size_t n = 0;
+        for (unsigned i = 0; i < num_of_words; ++i) {
+            n += std::popcount(data[i]);
+        }
+        return n;
+    }
+
+    template <size_t BW>
+    friend constexpr void shift_right_logical(BigInt<BW>& val, size_t amount);
+
+    template <size_t BW>
+    friend constexpr void shift_right_arith(BigInt<BW>& val, size_t amount);
+
+    template <size_t BW>
+    friend constexpr void shift_left(BigInt<BW>& val, size_t amount);
+};
+
+template <size_t BitWidth>
+constexpr void shift_right_logical(BigInt<BitWidth>& val, size_t amount) {
+    if (amount >= BitWidth) {
+        for (auto& word : val.data) {
+            word = 0;
+        }
+        return;
+    }
+    tc_shift_right(
+        val.data.data(), BigInt<BitWidth>::num_of_words, static_cast<unsigned>(amount)
+    );
+}
+
+template <size_t BitWidth>
+constexpr void shift_right_arith(BigInt<BitWidth>& val, size_t amount) {
+    if (amount == 0) {
+        return;
+    }
+
+    bool negative = val.is_negative();
+    shift_right_logical(val, amount);
+
+    if (!negative) {
+        return;
+    }
+
+    // Set the top `amount` bits to sign-extend.
+    size_t bits_to_set = (amount < BitWidth) ? amount : BitWidth;
+    size_t start_bit = BitWidth - bits_to_set;
+    constexpr unsigned word_width = BigInt<BitWidth>::word_width;
+    for (size_t bit = start_bit; bit < BitWidth; ++bit) {
+        val.data[bit / word_width] |= (uint64_t{1} << (bit % word_width));
+    }
+    val.clear_unused_bits();
+}
+
+template <size_t BitWidth>
+constexpr void shift_left(BigInt<BitWidth>& val, size_t amount) {
+    if (amount >= BitWidth) {
+        for (auto& word : val.data) {
+            word = 0;
+        }
+        return;
+    }
+    tc_shift_left(
+        val.data.data(), BigInt<BitWidth>::num_of_words, static_cast<unsigned>(amount)
+    );
+    val.clear_unused_bits();
+}
+
+}  // namespace coconext::types::detail
+
+#endif  // COCONEXT_BIGINT_HPP

--- a/cpp/include/coconext/types/bit_array.hpp
+++ b/cpp/include/coconext/types/bit_array.hpp
@@ -1,11 +1,11 @@
 #ifndef COCONEXT_BIT_ARRAY_HPP
 #define COCONEXT_BIT_ARRAY_HPP
 
-#include <bit>
+#include <coconext/types/array.hpp>
 #include <coconext/types/int_base.hpp>
 #include <coconext/types/logic.hpp>
+#include <coconext/types/range.hpp>
 #include <coconext/types/string_literal.hpp>
-#include <format>
 
 namespace coconext::types {
 
@@ -15,12 +15,10 @@ class Array;
 }
 
 // all reductions are better off without a loop
-// popcount is one asm instruction so we get O(1)
+// All bits set iff every one of the R.length() bits is counted.
 template <Range R>
 auto and_reduce(detail::Array<Bit, R> const& s) {
-    auto bits = s.value_;
-    detail::Bits<R.length()> zero(0);
-    return (~bits == zero) ? '1'_b : '0'_b;
+    return (s.value_.popcount() == R.length()) ? '1'_b : '0'_b;
 }
 
 template <Range R>

--- a/cpp/include/coconext/types/int_base.hpp
+++ b/cpp/include/coconext/types/int_base.hpp
@@ -4,377 +4,18 @@
 #include <algorithm>
 #include <array>
 #include <bit>
+#include <coconext/types/bigint.hpp>
 #include <coconext/types/logic.hpp>
 #include <cstddef>
 #include <cstdint>
+#include <format>
+#include <limits>
 #include <stdexcept>
+#include <string>
 #include <string_view>
 #include <type_traits>
 
-#ifdef COCONEXT_USE_APINT
-#include <llvm/ADT/APInt.h>
-#endif
-
 namespace coconext::types::detail {
-
-#ifdef COCONEXT_USE_APINT
-
-static constexpr bool using_APInt = true;
-
-template <size_t BitWidth>
-class BigInt {
-    // TODO
-};
-
-#else
-
-static constexpr bool using_APInt = false;
-
-// This class can handle arbitrary precision integer's basic essential
-// arithmetic E.g. shifting, bitwise operations, equality e.t.c. For complete arithmetic
-// operations, we fall back to APInt based BigInt
-template <size_t BitWidth>
-class BigInt {
-  public:
-    using WordType = uint64_t;
-    static constexpr unsigned word_width = 64;
-    static constexpr unsigned num_of_words = (BitWidth + word_width - 1) / word_width;
-
-  private:
-    static constexpr WordType get_last_word_mask() {
-        uint8_t valid_bits = BitWidth % word_width;
-        if (valid_bits == 0) {
-            return ~WordType(0);
-        }
-        return (WordType(1) << valid_bits) - 1;
-    }
-
-    static constexpr WordType last_word_mask = get_last_word_mask();
-    std::array<WordType, num_of_words> data{};
-
-    bool isNegative() const {
-        unsigned sign_bit = (BitWidth - 1) % 64;
-        return (data.back() >> sign_bit) & 1;
-    }
-
-  public:
-    WordType get_word(size_t index) const { return data[index]; }
-    std::array<WordType, num_of_words> get_data() const { return data; }
-
-    BigInt() = default;
-
-    BigInt(WordType val, bool is_signed = false) {
-        data[0] = val;
-
-        if (is_signed && (static_cast<int64_t>(val) < 0)) {
-            std::fill(data.begin() + 1, data.end(), ~WordType(0));
-        }
-
-        data.back() &= last_word_mask;
-    }
-
-    explicit constexpr BigInt(std::string_view str) {
-        if (str.empty()) {
-            return;
-        }
-
-        bool is_neg = false;
-        size_t i = 0;
-
-        if (str[i] == '-') {
-            is_neg = true;
-            i++;
-        } else if (str[i] == '+') {
-            i++;
-        }
-
-        bool is_hex = false;
-        if (i + 1 < str.length() && str[i] == '0'
-            && (str[i + 1] == 'x' || str[i + 1] == 'X'))
-        {
-            is_hex = true;
-            i += 2;
-        }
-
-        if (is_hex) {
-            if (is_neg) {
-                throw std::invalid_argument("Hexadecimal value cannot be negative");
-            }
-            unsigned word_idx = 0;
-            unsigned bit_shift = 0;
-
-            for (int j = str.length() - 1; j >= static_cast<int>(i); --j) {
-                if (word_idx >= num_of_words) {
-                    break;
-                }
-
-                char c = str[j];
-                uint64_t val = 0;
-
-                if (c >= '0' && c <= '9') {
-                    val = c - '0';
-                } else if (c >= 'a' && c <= 'f') {
-                    val = c - 'a' + 10;
-                } else if (c >= 'A' && c <= 'F') {
-                    val = c - 'A' + 10;
-                } else if (c == '\'' || c == '_') {
-                    continue;
-                } else {
-                    throw std::invalid_argument("Invalid hexadecimal character");
-                }
-
-                data[word_idx] |= (val << bit_shift);
-                bit_shift += 4;
-
-                if (bit_shift == 64) {
-                    bit_shift = 0;
-                    word_idx++;
-                }
-            }
-        } else {
-            for (; i < str.length(); ++i) {
-                char c = str[i];
-                if (c < '0' || c > '9') {
-                    throw std::invalid_argument("Invalid base-10 character");
-                }
-                uint64_t digit = c - '0';
-
-                uint64_t carry = digit;
-                for (unsigned w = 0; w < num_of_words; ++w) {
-                    uint64_t lower = (data[w] & 0xFFFFFFFF) * 10 + carry;
-                    uint64_t upper = (data[w] >> 32) * 10 + (lower >> 32);
-
-                    data[w] = (lower & 0xFFFFFFFF) | (upper << 32);
-                    carry = upper >> 32;
-                }
-            }
-        }
-
-        if (is_neg) {
-            uint64_t carry = 1;
-            for (unsigned w = 0; w < num_of_words; ++w) {
-                data[w] = ~data[w];
-                uint64_t sum = data[w] + carry;
-                carry = (sum < data[w]) ? 1 : 0;
-                data[w] = sum;
-            }
-        }
-        data.back() &= last_word_mask;
-    }
-
-    BigInt& operator=(BigInt const&) = default;
-    BigInt& operator=(BigInt&&) noexcept = default;
-    BigInt(BigInt const&) = default;
-    BigInt(BigInt&&) noexcept = default;
-
-    bool operator==(BigInt const& rhs) const { return data == rhs.data; }
-
-    bool operator!=(BigInt const& rhs) const { return !(*this == rhs); }
-
-    bool operator<(BigInt const& rhs) const {
-        bool lhs_neg = isNegative();
-        bool rhs_neg = rhs.isNegative();
-
-        if (lhs_neg != rhs_neg) {
-            return lhs_neg;
-        }
-
-        for (int i = num_of_words - 1; i >= 0; --i) {
-            if (data[i] != rhs.data[i]) {
-                return data[i] < rhs.data[i];
-            }
-        }
-
-        return false;
-    }
-
-    bool operator>(BigInt const& rhs) const { return rhs < *this; }
-    bool operator<=(BigInt const& rhs) const { return !(rhs < *this); }
-    bool operator>=(BigInt const& rhs) const { return !(*this < rhs); }
-
-    BigInt operator&(BigInt const& rhs) const {
-        BigInt result;
-
-        for (unsigned i = 0; i < num_of_words; ++i) {
-            result.data[i] = data[i] & rhs.data[i];
-        }
-
-        return result;
-    }
-
-    BigInt operator|(BigInt const& rhs) const {
-        BigInt result;
-
-        for (unsigned i = 0; i < num_of_words; ++i) {
-            result.data[i] = data[i] | rhs.data[i];
-        }
-
-        return result;
-    }
-
-    BigInt operator^(BigInt const& rhs) const {
-        BigInt result;
-
-        for (unsigned i = 0; i < num_of_words; ++i) {
-            result.data[i] = data[i] ^ rhs.data[i];
-        }
-
-        return result;
-    }
-
-    BigInt operator~() const {
-        BigInt result(*this);
-
-        for (auto& word : result.data) {
-            word = ~word;
-        }
-
-        result.data.back() &= last_word_mask;
-        return result;
-    }
-
-    constexpr size_t count_trailing_zeros() const {
-        for (size_t i = 0; i < num_of_words; ++i) {
-            if (data[i] != 0) {
-                return (i * 64) + std::countr_zero(data[i]);
-            }
-        }
-        return BitWidth;
-    }
-
-    constexpr size_t count_leading_zeros() const {
-        for (int i = num_of_words - 1; i >= 0; --i) {
-            if (data[i] != 0) {
-                size_t leading_in_word = std::countl_zero(data[i]);
-                size_t total_leading = ((num_of_words - 1 - i) * 64) + leading_in_word;
-
-                size_t unused_top_bits = (num_of_words * 64) - BitWidth;
-                return total_leading - unused_top_bits;
-            }
-        }
-        return BitWidth;
-    }
-
-    constexpr size_t popcount() const {
-        size_t n = 0;
-        for (int i = 0; i < num_of_words; ++i) {
-            n += std::popcount(data[i]);
-        }
-        return n;
-    }
-
-    template <size_t BW>
-    friend void shift_right_logical(BigInt<BW>& val, size_t amount);
-
-    template <size_t BW>
-    friend void shift_right_arith(BigInt<BW>& val, size_t amount);
-
-    template <size_t BW>
-    friend void shift_left(BigInt<BW>& val, size_t amount);
-};
-
-template <size_t BitWidth>
-inline void shift_right_logical(BigInt<BitWidth>& val, size_t amount) {
-    if (amount == 0) {
-        return;
-    }
-
-    if (amount >= BitWidth) {
-        std::fill(val.data.begin(), val.data.end(), 0);
-        return;
-    }
-
-    size_t const word_shift = amount / 64;
-    size_t const bit_shift = amount % 64;
-    size_t const size = val.num_of_words;
-
-    if (word_shift > 0) {
-        std::rotate(val.data.begin(), val.data.begin() + word_shift, val.data.end());
-        std::fill(val.data.end() - word_shift, val.data.end(), 0);
-    }
-
-    if (bit_shift > 0) {
-        size_t const active_words_end = size - word_shift;
-        for (size_t i = 0; i < active_words_end - 1; ++i) {
-            val.data[i] =
-                (val.data[i] >> bit_shift) | (val.data[i + 1] << (64 - bit_shift));
-        }
-        val.data[active_words_end - 1] >>= bit_shift;
-    }
-}
-
-template <size_t BitWidth>
-inline void shift_right_arith(BigInt<BitWidth>& val, size_t amount) {
-    if (amount == 0) {
-        return;
-    }
-
-    bool isNegative = val.isNegative();
-    shift_right_logical(val, amount);
-
-    if (!isNegative) {
-        return;
-    }
-
-    size_t bits_to_set = (amount < BitWidth) ? amount : BitWidth;
-    if (bits_to_set > 0) {
-        size_t start_bit = BitWidth - bits_to_set;
-        size_t end_bit = BitWidth - 1;
-
-        size_t start_word = start_bit / 64;
-        size_t end_word = end_bit / 64;
-
-        size_t top_bits = (end_bit % 64) + 1;
-        uint64_t top_mask =
-            (top_bits == 64) ? ~uint64_t(0) : ((uint64_t(1) << top_bits) - 1);
-
-        if (start_word == end_word) {
-            val.data[start_word] |= top_mask & (~uint64_t(0) << (start_bit % 64));
-        } else {
-            val.data[end_word] |= top_mask;
-
-            for (size_t w = start_word + 1; w < end_word; ++w) {
-                val.data[w] |= ~uint64_t(0);
-            }
-
-            val.data[start_word] |= (~uint64_t(0) << (start_bit % 64));
-        }
-    }
-}
-
-template <size_t BitWidth>
-inline void shift_left(BigInt<BitWidth>& val, size_t amount) {
-    if (amount == 0) {
-        return;
-    }
-
-    if (amount >= BitWidth) {
-        std::fill(val.data.begin(), val.data.end(), 0);
-        return;
-    }
-
-    size_t const word_shift = amount / 64;
-    size_t const bit_shift = amount % 64;
-    size_t const size = val.num_of_words;
-
-    if (word_shift > 0) {
-        std::rotate(val.data.rbegin(), val.data.rbegin() + word_shift, val.data.rend());
-        std::fill(val.data.begin(), val.data.begin() + word_shift, 0);
-    }
-
-    if (bit_shift > 0) {
-        for (size_t i = size - 1; i > word_shift; --i) {
-            val.data[i] =
-                (val.data[i] << bit_shift) | (val.data[i - 1] >> (64 - bit_shift));
-        }
-
-        val.data[word_shift] <<= bit_shift;
-    }
-
-    val.data.back() &= val.last_word_mask;
-}
-
-#endif  // COCONEXT_USE_APINT
 
 struct EmptyStorage {};
 
@@ -414,7 +55,6 @@ class Bits {
   public:
     using IntType = IntTypePicker<W>::type;
     static constexpr bool is_not_native_int = std::is_same_v<IntType, BigInt<W>>;
-    static constexpr bool supports_overloaded_op = !is_not_native_int || using_APInt;
 
     constexpr Bits() = default;
 
@@ -423,7 +63,7 @@ class Bits {
         requires(!is_not_native_int)
         : storage_(std::move(val)) {}
 
-    // BigInt from an BigInt
+    // BigInt from a BigInt
     constexpr Bits(BigInt<W> val)
         requires is_not_native_int
         : storage_(std::move(val)) {}
@@ -611,129 +251,115 @@ class Bits {
     }
 
     constexpr Bits operator+(Bits<W> const& other) const {
-        static_assert(
-            supports_overloaded_op,
-            "operator(+) only supported by native ints and APInt BigInt"
-        );
-        return Bits<W>(static_cast<IntType>(storage_ + other.storage_));
+        if constexpr (is_not_native_int) {
+            return Bits<W>(storage_ + other.storage_);
+        } else {
+            return Bits<W>(static_cast<IntType>(storage_ + other.storage_));
+        }
     }
 
     constexpr Bits operator-(Bits<W> const& other) const {
-        static_assert(
-            supports_overloaded_op,
-            "operator(-) only supported by native ints and APInt BigInt"
-        );
-        return Bits<W>(static_cast<IntType>(storage_ - other.storage_));
+        if constexpr (is_not_native_int) {
+            return Bits<W>(storage_ - other.storage_);
+        } else {
+            return Bits<W>(static_cast<IntType>(storage_ - other.storage_));
+        }
     }
 
     constexpr Bits operator*(Bits<W> const& other) const {
-        static_assert(
-            supports_overloaded_op,
-            "operator(*) only supported by native ints and APInt BigInt"
-        );
-        return Bits<W>(static_cast<IntType>(storage_ * other.storage_));
+        if constexpr (is_not_native_int) {
+            return Bits<W>(storage_ * other.storage_);
+        } else {
+            return Bits<W>(static_cast<IntType>(storage_ * other.storage_));
+        }
     }
 
     constexpr Bits udiv(Bits<W> const& other) const {
-        static_assert(
-            supports_overloaded_op,
-            "Division only supported by native ints and APInt BigInt"
-        );
-        if (other.raw() == 0) {
+        if (other == Bits<W>{}) {
             throw std::domain_error("Division by zero");
         }
-
-        if constexpr (using_APInt) {
-            // TODO
+        if constexpr (is_not_native_int) {
+            return Bits<W>(storage_.udiv(other.storage_));
         } else {
             return Bits<W>(static_cast<IntType>(this->raw() / other.raw()));
         }
     }
 
     constexpr Bits sdiv(Bits<W> const& other) const {
-        static_assert(
-            supports_overloaded_op,
-            "Division only supported by native ints and APInt BigInt"
-        );
-        if (other.raw() == 0) {
+        if (other == Bits<W>{}) {
             throw std::domain_error("Division by zero");
         }
-
-        if constexpr (using_APInt) {
-            // TODO
+        if constexpr (is_not_native_int) {
+            return Bits<W>(storage_.sdiv(other.storage_));
         } else {
             auto lhs_ext = this->sign_extended();
             auto rhs_ext = other.sign_extended();
+            // Guard the sole two's-complement overflow: MIN / -1 == MIN.
+            using SType = decltype(lhs_ext);
+            if (rhs_ext == -1 && lhs_ext == std::numeric_limits<SType>::min()) {
+                return *this;
+            }
             return Bits<W>(static_cast<IntType>(lhs_ext / rhs_ext));
         }
     }
 
     constexpr Bits umod(Bits<W> const& other) const {
-        static_assert(
-            supports_overloaded_op, "Mod only supported by native ints and APInt BigInt"
-        );
-        if (other.raw() == 0) {
+        if (other == Bits<W>{}) {
             throw std::domain_error("Division by zero");
         }
-
-        if constexpr (using_APInt) {
-            // TODO
+        if constexpr (is_not_native_int) {
+            return Bits<W>(storage_.umod(other.storage_));
         } else {
             return Bits<W>(static_cast<IntType>(this->raw() % other.raw()));
         }
     }
 
     constexpr Bits smod(Bits<W> const& other) const {
-        static_assert(
-            supports_overloaded_op, "Mod only supported by native ints and APInt BigInt"
-        );
-        if (other.raw() == 0) {
+        if (other == Bits<W>{}) {
             throw std::domain_error("Division by zero");
         }
-
-        if constexpr (using_APInt) {
-            // TODO
+        if constexpr (is_not_native_int) {
+            return Bits<W>(storage_.smod(other.storage_));
         } else {
             auto lhs_ext = this->sign_extended();
             auto rhs_ext = other.sign_extended();
+            // MIN % -1 == 0; avoid the divide's overflow on that input.
+            using SType = decltype(lhs_ext);
+            if (rhs_ext == -1 && lhs_ext == std::numeric_limits<SType>::min()) {
+                return Bits<W>{};
+            }
             return Bits<W>(static_cast<IntType>(lhs_ext % rhs_ext));
         }
     }
 
     constexpr Bits operator<<(size_t amount) const {
-        if constexpr (!is_not_native_int) {
-            return Bits<W>(static_cast<IntType>(raw() << amount));
-        } else if constexpr (using_APInt) {
-            // TODO
-        } else {
+        if constexpr (is_not_native_int) {
             BigInt<W> result = storage_;
             shift_left(result, amount);
             return Bits<W>(result);
+        } else {
+            return Bits<W>(static_cast<IntType>(raw() << amount));
         }
     }
 
     constexpr Bits sra(size_t amount) const {
-        if constexpr (!is_not_native_int) {
-            auto ext = this->sign_extended();
-            return Bits<W>(static_cast<IntType>(ext >> amount));
-        } else if constexpr (using_APInt) {
-            // TODO
-        } else {
+        if constexpr (is_not_native_int) {
             BigInt<W> result = storage_;
             shift_right_arith(result, amount);
             return Bits<W>(result);
+        } else {
+            auto ext = this->sign_extended();
+            return Bits<W>(static_cast<IntType>(ext >> amount));
         }
     }
 
     constexpr Bits srl(size_t amount) const {
-        if constexpr (!is_not_native_int) {
-            return Bits<W>(static_cast<IntType>(raw() >> amount));
-        } else if constexpr (using_APInt) {
-            // TODO
-        } else {
+        if constexpr (is_not_native_int) {
             BigInt<W> result = storage_;
             shift_right_logical(result, amount);
             return Bits<W>(result);
+        } else {
+            return Bits<W>(static_cast<IntType>(raw() >> amount));
         }
     }
 
@@ -744,40 +370,35 @@ class Bits {
         return (raw() == other.raw());
     }
 
-    constexpr bool operator!=(Bits<W> const& other) const {
+    constexpr bool operator!=(Bits<W> const& other) const { return !(*this == other); }
+
+    // Bits is sign-agnostic storage, so ordering must name its interpretation:
+    // u* treat the bits as unsigned, s* as two's-complement. There is
+    // deliberately no operator< / operator<=>; the interpretation is the
+    // caller's (matching LLVM APInt's ult/slt API).
+    constexpr bool ult(Bits<W> const& other) const {
         if constexpr (is_not_native_int) {
-            return storage_ != other.storage_;
+            return storage_.ucompare(other.storage_) < 0;
+        } else {
+            return raw() < other.raw();
         }
-        return (raw() != other.raw());
     }
 
-    constexpr bool operator<(Bits<W> const& other) const {
+    constexpr bool ule(Bits<W> const& other) const { return !other.ult(*this); }
+    constexpr bool ugt(Bits<W> const& other) const { return other.ult(*this); }
+    constexpr bool uge(Bits<W> const& other) const { return !ult(other); }
+
+    constexpr bool slt(Bits<W> const& other) const {
         if constexpr (is_not_native_int) {
-            return storage_ < other.storage_;
+            return storage_.scompare(other.storage_) < 0;
+        } else {
+            return sign_extended() < other.sign_extended();
         }
-        return (raw() < other.raw());
     }
 
-    constexpr bool operator<=(Bits<W> const& other) const {
-        if constexpr (is_not_native_int) {
-            return storage_ <= other.storage_;
-        }
-        return (raw() <= other.raw());
-    }
-
-    constexpr bool operator>(Bits<W> const& other) const {
-        if constexpr (is_not_native_int) {
-            return storage_ > other.storage_;
-        }
-        return (raw() > other.raw());
-    }
-
-    constexpr bool operator>=(Bits<W> const& other) const {
-        if constexpr (is_not_native_int) {
-            return storage_ >= other.storage_;
-        }
-        return (raw() >= other.raw());
-    }
+    constexpr bool sle(Bits<W> const& other) const { return !other.slt(*this); }
+    constexpr bool sgt(Bits<W> const& other) const { return other.slt(*this); }
+    constexpr bool sge(Bits<W> const& other) const { return !slt(other); }
 
     constexpr Bits operator&(Bits<W> const& other) const {
         if constexpr (is_not_native_int) {
@@ -888,12 +509,178 @@ class Bits {
         }
     }
 
+    template <size_t bits>
+    constexpr auto max_unsigned_native() const {
+        static_assert(!is_not_native_int, "Not a native integer");
+        if constexpr (bits > 64 && bits <= 128) {
+            static_assert(supports_128B, "128 is not a native integer width");
+            if constexpr (bits == 128) {
+                return ~__uint128_t{0};
+            } else {
+                return ((__uint128_t)1 << bits) - 1;
+            }
+        } else if constexpr (bits == 64) {
+            return ~uint64_t{0};
+        } else if constexpr (bits < 64) {
+            return (uint64_t{1} << bits) - 1;
+        } else {
+            static_assert(bits <= 128, "Not a native integer width");
+        }
+    }
+
+    template <size_t bits>
+    constexpr auto max_unsigned_bigInt() const {
+        static_assert(is_not_native_int, "Not a BigInt");
+        return BigInt<bits>(~uint64_t{0}, true);
+    }
+
+    template <size_t bits>
+    constexpr auto max_signed_native() const {
+        static_assert(!is_not_native_int, "Not a native integer");
+        if constexpr (bits == 0) {
+            return int64_t{0};
+        } else if constexpr (bits > 64 && bits <= 128) {
+            static_assert(supports_128B, "128-bit is not supported on this platform");
+            if constexpr (bits == 128) {
+                return static_cast<__int128_t>((~__uint128_t{0}) >> 1);
+            } else {
+                return static_cast<__int128_t>(((__uint128_t)1 << (bits - 1)) - 1);
+            }
+        } else if constexpr (bits == 64) {
+            return static_cast<int64_t>((~uint64_t{0}) >> 1);
+        } else if constexpr (bits < 64) {
+            return static_cast<int64_t>((uint64_t{1} << (bits - 1)) - 1);
+        } else {
+            static_assert(bits <= 128, "Not a native integer width");
+        }
+    }
+
+    std::string to_binary_string() const {
+        if constexpr (W == 0) {
+            return "0";
+        } else if constexpr (!is_not_native_int) {
+            using cast_type = std::conditional_t<supports_128B, __uint128_t, uint64_t>;
+            return std::format("{:0{}b}", static_cast<cast_type>(raw()), W);
+        } else {
+            std::string res;
+            res.reserve(W);
+            auto val = raw();
+            for (size_t i = W; i > 0; --i) {
+                size_t bit_idx = i - 1;
+                res.push_back(
+                    ((val.get_word(bit_idx / 64) >> (bit_idx % 64)) & 1) ? '1' : '0'
+                );
+            }
+            return res;
+        }
+    }
+
+    std::string to_decimal_string(bool is_signed = false) const {
+        if constexpr (W == 0) {
+            return "0";
+        } else if constexpr (!is_not_native_int) {
+            using uint_cast_type = std::conditional_t<supports_128B, __uint128_t, uint64_t>;
+            using int_cast_type = std::conditional_t<supports_128B, __int128_t, int64_t>;
+            if (is_signed) {
+                constexpr size_t total_bits = sizeof(int_cast_type) * 8;
+                int_cast_type signed_val =
+                    static_cast<int_cast_type>(
+                        static_cast<uint_cast_type>(raw()) << (total_bits - W)
+                    )
+                    >> (total_bits - W);
+                return std::format("{}", signed_val);
+            }
+            return std::format("{}", static_cast<uint_cast_type>(raw()));
+        } else {
+            bool negative = is_signed && storage_.is_negative();
+            BigInt<W> mag = negative ? -storage_ : storage_;
+            if (!static_cast<bool>(mag)) {
+                return "0";
+            }
+            BigInt<W> ten(uint64_t{10});
+            std::string digits;
+            while (static_cast<bool>(mag)) {
+                BigInt<W> rem = mag.umod(ten);
+                digits.push_back(static_cast<char>('0' + rem.get_word(0)));
+                mag = mag.udiv(ten);
+            }
+            if (negative) {
+                digits.push_back('-');
+            }
+            std::reverse(digits.begin(), digits.end());
+            return digits;
+        }
+    }
+
+    std::string to_hexadecimal_string() const {
+        constexpr size_t hex_chars = (W + 3) / 4;
+        if constexpr (W == 0) {
+            return "0";
+        } else if constexpr (!is_not_native_int) {
+            using cast_type = std::conditional_t<supports_128B, __uint128_t, uint64_t>;
+            return std::format("{:0{}x}", static_cast<cast_type>(raw()), hex_chars);
+        } else {
+            std::string res;
+            res.reserve(hex_chars);
+            auto val = raw();
+            char const hex_digits[] = "0123456789abcdef";
+            for (size_t i = hex_chars; i > 0; --i) {
+                uint8_t nibble = 0;
+                for (int j = 3; j >= 0; --j) {
+                    size_t bit_idx = (i - 1) * 4 + j;
+                    if (bit_idx < W) {
+                        nibble = (nibble << 1)
+                               | ((val.get_word(bit_idx / 64) >> (bit_idx % 64)) & 1);
+                    }
+                }
+                res.push_back(hex_digits[nibble]);
+            }
+            return res;
+        }
+    }
+
+    std::string to_octal_string() const {
+        constexpr size_t octal_chars = (W + 2) / 3;
+        if constexpr (W == 0) {
+            return "0";
+        } else if constexpr (!is_not_native_int) {
+            using cast_type = std::conditional_t<supports_128B, __uint128_t, uint64_t>;
+            return std::format("{:0{}o}", static_cast<cast_type>(raw()), octal_chars);
+        } else {
+            std::string res;
+            res.reserve(octal_chars);
+            auto val = raw();
+            for (size_t i = octal_chars; i > 0; --i) {
+                uint8_t oct = 0;
+                for (int j = 2; j >= 0; --j) {
+                    size_t bit_idx = (i - 1) * 3 + j;
+                    if (bit_idx < W) {
+                        oct = (oct << 1)
+                            | ((val.get_word(bit_idx / 64) >> (bit_idx % 64)) & 1);
+                    }
+                }
+                res.push_back(static_cast<char>('0' + oct));
+            }
+            return res;
+        }
+    }
+
   private:
     IntType storage_;
-    static constexpr IntType topMask =
-        (W % (sizeof(IntType) * 8) == 0)
-            ? ~static_cast<IntType>(0)
-            : (static_cast<IntType>(1) << (W % (sizeof(IntType) * 8))) - 1;
+
+    // Mask of the W valid low bits within the native storage word. Only used on
+    // the native path; the wide (BigInt) path masks its own top word.
+    static constexpr IntType compute_top_mask() {
+        if constexpr (is_not_native_int) {
+            return IntType{};
+        } else if constexpr (W % (sizeof(IntType) * 8) == 0) {
+            return ~static_cast<IntType>(0);
+        } else {
+            return (static_cast<IntType>(1) << (W % (sizeof(IntType) * 8))) - 1;
+        }
+    }
+
+    static constexpr IntType topMask = compute_top_mask();
 
     constexpr auto sign_extended() const {
         using SType = std::make_signed_t<IntType>;

--- a/tests/cpp/test_int.cpp
+++ b/tests/cpp/test_int.cpp
@@ -6,12 +6,6 @@
 
 using namespace coconext::types;
 
-#ifdef COCONEXT_USE_APINT
-
-// Test detail::Bits with APInt
-
-#else
-
 #if defined(__SIZEOF_INT128__)
 
 TEST(TestBits, JustAbove128) {
@@ -77,15 +71,15 @@ TEST(TestBits, comparison_operations_supports_128) {
     __uint128_t large_raw = ((__uint128_t)0xAAAULL << 64) | 0x0ULL;
     detail::Bits<128> b128_large(large_raw);
 
-    EXPECT_TRUE(b128_small < b128_large);
-    EXPECT_TRUE(b128_large >= b128_small);
+    EXPECT_TRUE(b128_small.ult(b128_large));
+    EXPECT_TRUE(b128_large.uge(b128_small));
 
     // 93 bits max: 29 high bits + 64 low bits
     detail::Bits<93> b93_max(-1);
     detail::Bits<93> b93_zero(0);
 
-    EXPECT_TRUE(b93_max > b93_zero);
-    EXPECT_TRUE(b93_zero < b93_max);
+    EXPECT_TRUE(b93_max.ugt(b93_zero));
+    EXPECT_TRUE(b93_zero.ult(b93_max));
     EXPECT_TRUE(b93_max != b93_zero);
 }
 
@@ -207,13 +201,26 @@ TEST(TestBits, single_word_constructor) {
 }
 
 TEST(TestBits, string_constructor) {
+    // Same in-range value written with and without leading zeros.
     detail::Bits<232> a{
-        "0x10000_4F33_000000000000_9FF0_000000000000_BD73_000000000000_9AF0_000000"
+        "0x0000_4F33_000000000000_9FF0_000000000000_BD73_000000000000_9AF0_000000"
     };
     detail::Bits<232> b{
-        "0x10_4F33_000000000000_9FF0_000000000000_BD73_000000000000_9AF0_000000"
+        "0x4F33_000000000000_9FF0_000000000000_BD73_000000000000_9AF0_000000"
     };
     EXPECT_EQ(a, b);
+
+    // A literal wider than the type throws rather than silently truncating.
+    EXPECT_THROW(
+        (detail::Bits<232>{
+            "0x10000_4F33_000000000000_9FF0_000000000000_BD73_000000000000_9AF0_000000"
+        }),
+        std::out_of_range
+    );
+    // A decimal literal that does not fit also throws.
+    EXPECT_THROW(
+        (detail::Bits<130>{"1361129467683753853853498429727072845824"}), std::out_of_range
+    );
 
     detail::Bits<264> expected_hex{
         "0x"
@@ -241,16 +248,19 @@ TEST(TestBits, comparison_operations) {
     EXPECT_TRUE(b32_a != b32_diff);
     EXPECT_FALSE(b32_a == b32_diff);
 
+    // Ordering is via named unsigned (u*) / signed (s*) comparisons; Bits has
+    // no operator< because the interpretation of the bit pattern is the
+    // caller's. This mirrors LLVM APInt's ult/slt API.
     detail::Bits<12> b12_small(0x055);
     detail::Bits<12> b12_large(0xAAA);
-    EXPECT_TRUE(b12_small < b12_large);
-    EXPECT_TRUE(b12_large >= b12_small);
+    EXPECT_TRUE(b12_small.ult(b12_large));
+    EXPECT_TRUE(b12_large.uge(b12_small));
 
     detail::Bits<63> b63_max(0x7FFFFFFFFFFFFFFF);
     detail::Bits<63> b63_zero(0);
 
-    EXPECT_TRUE(b63_max > b63_zero);
-    EXPECT_TRUE(b63_zero < b63_max);
+    EXPECT_TRUE(b63_max.ugt(b63_zero));
+    EXPECT_TRUE(b63_zero.ult(b63_max));
     EXPECT_TRUE(b63_max != b63_zero);
 
     detail::Bits<200> a{"0xABCDEF01_00000000_00000000"};
@@ -268,38 +278,47 @@ TEST(TestBits, comparison_operations) {
 
     detail::Bits<256> u_massive{"0x22222222_00000000_00000000_00000000"};
 
-    EXPECT_TRUE(u_small < u_large);
-    EXPECT_TRUE(u_large > u_small);
-    EXPECT_TRUE(u_large < u_massive);
-    EXPECT_TRUE(u_massive > u_large);
+    EXPECT_TRUE(u_small.ult(u_large));
+    EXPECT_TRUE(u_large.ugt(u_small));
+    EXPECT_TRUE(u_large.ult(u_massive));
+    EXPECT_TRUE(u_massive.ugt(u_large));
 
-    EXPECT_TRUE(u_small <= u_large);
-    EXPECT_TRUE(u_large >= u_small);
+    EXPECT_TRUE(u_small.ule(u_large));
+    EXPECT_TRUE(u_large.uge(u_small));
 
-    EXPECT_TRUE(u_small <= u_small);
-    EXPECT_TRUE(u_small >= u_small);
-    EXPECT_FALSE(u_small < u_small);
-    EXPECT_FALSE(u_small > u_small);
+    EXPECT_TRUE(u_small.ule(u_small));
+    EXPECT_TRUE(u_small.uge(u_small));
+    EXPECT_FALSE(u_small.ult(u_small));
+    EXPECT_FALSE(u_small.ugt(u_small));
 
+    // A negative literal stores its two's-complement pattern. Under the signed
+    // interpretation (s*) it orders below a positive value; under the unsigned
+    // interpretation (u*) its high bit makes it the larger magnitude.
     detail::Bits<150> pos("5000000");
     detail::Bits<150> neg("-5000000");
     detail::Bits<150> zero(0);
 
-    EXPECT_TRUE(neg < pos);
-    EXPECT_TRUE(pos > neg);
-    EXPECT_TRUE(neg <= pos);
-    EXPECT_TRUE(pos >= neg);
+    EXPECT_TRUE(neg.slt(pos));
+    EXPECT_TRUE(pos.sgt(neg));
+    EXPECT_TRUE(neg.sle(pos));
+    EXPECT_TRUE(pos.sge(neg));
+    EXPECT_TRUE(neg.slt(zero));
+    EXPECT_TRUE(pos.sgt(zero));
 
-    EXPECT_TRUE(neg < zero);
-    EXPECT_TRUE(pos > zero);
+    EXPECT_TRUE(pos.ult(neg));  // unsigned: neg's pattern is larger
+    EXPECT_TRUE(neg.ugt(pos));
 
+    // Signed: -10 > -20. Unsigned: -10's pattern is also larger than -20's.
     detail::Bits<150> neg_10("-10");
     detail::Bits<150> neg_20("-20");
 
-    EXPECT_TRUE(neg_10 > neg_20);
-    EXPECT_TRUE(neg_20 < neg_10);
-    EXPECT_TRUE(neg_10 >= neg_20);
-    EXPECT_TRUE(neg_20 <= neg_10);
+    EXPECT_TRUE(neg_10.sgt(neg_20));
+    EXPECT_TRUE(neg_20.slt(neg_10));
+    EXPECT_TRUE(neg_10.sge(neg_20));
+    EXPECT_TRUE(neg_20.sle(neg_10));
+
+    EXPECT_TRUE(neg_10.ugt(neg_20));
+    EXPECT_TRUE(neg_20.ult(neg_10));
 }
 
 TEST(TestBits, and_or_op) {
@@ -369,7 +388,7 @@ TEST(TestBits, not_op) {
     detail::Bits<170> not_a = ~a;
 
     detail::Bits<170> expected_not_a{
-        "0x3FFF'FFFF'FFFF'FFFF'FFFF'FFFF'FFFF'FFFF'FFFF'FFFF'FFFF"
+        "0x3FF'FFFF'FFFF'FFFF'FFFF'FFFF'FFFF'FFFF'FFFF'FFFF'FFFF"
     };
     EXPECT_EQ(not_a, expected_not_a);
 }
@@ -502,6 +521,96 @@ TEST(TestBits, shift_left) {
     EXPECT_EQ(a, b);
 }
 
-#endif  // COCONEXT_USE_APINT
+// Wide (BigInt-backed) arithmetic. Reference values computed with Python's
+// arbitrary-precision integers.
+TEST(TestBits, arithmetic_operations_wide) {
+    detail::Bits<200> a{"0x1234567890ABCDEF1122334455667788AABBCCDD"};
+    detail::Bits<200> b{"0xFEDCBA98765432100123456789"};
+
+    EXPECT_EQ(
+        (a + b).to_decimal_string(), "103929005307927776916288754849918835164314678374"
+    );
+    EXPECT_EQ(
+        (a - b).to_decimal_string(), "103929005307927736531757632912370613094305916244"
+    );
+    EXPECT_EQ(
+        (a * b).to_decimal_string(),
+        "329963546613616313339723066835445579609796160260803833793861"
+    );
+    EXPECT_EQ(a.udiv(b).to_decimal_string(), "5146971002046463");
+    EXPECT_EQ(a.umod(b).to_decimal_string(), "20112278405973339191843622874214");
+
+    // Division identity holds.
+    EXPECT_EQ(a.udiv(b) * b + a.umod(b), a);
+
+    // Degenerate cases.
+    detail::Bits<200> zero(0);
+    detail::Bits<200> one(1);
+    EXPECT_EQ(a.udiv(a), one);
+    EXPECT_EQ(a.umod(a), zero);
+    EXPECT_EQ(b.udiv(a), zero);  // b < a
+    EXPECT_EQ(b.umod(a), b);
+    EXPECT_EQ(zero.udiv(a), zero);
+    EXPECT_EQ(a.udiv(one), a);
+
+    EXPECT_THROW(a.udiv(zero), std::domain_error);
+    EXPECT_THROW(a.umod(zero), std::domain_error);
+    EXPECT_THROW(a.sdiv(zero), std::domain_error);
+    EXPECT_THROW(a.smod(zero), std::domain_error);
+}
+
+TEST(TestBits, signed_arithmetic_wide) {
+    detail::Bits<200> neg{"-1000000000000000000000"};
+    detail::Bits<200> pos{"7"};
+
+    EXPECT_EQ(neg.sdiv(pos).to_decimal_string(true), "-142857142857142857142");
+    EXPECT_EQ(neg.smod(pos).to_decimal_string(true), "-6");
+
+    detail::Bits<200> neg2{"-3"};
+    EXPECT_EQ(neg.sdiv(neg2).to_decimal_string(true), "333333333333333333333");
+    EXPECT_EQ(neg.smod(neg2).to_decimal_string(true), "-1");
+
+    // MIN / -1 wraps to MIN rather than invoking UB. On the wide path MIN is
+    // -2^(W-1); dividing by -1 yields the same pattern back.
+    detail::Bits<200> min = detail::Bits<200>(1) << 199;  // sign bit only
+    detail::Bits<200> neg_one = ~detail::Bits<200>(0);    // all ones == -1
+    EXPECT_EQ(min.sdiv(neg_one), min);
+    EXPECT_EQ(min.smod(neg_one), detail::Bits<200>(0));
+}
+
+TEST(TestBits, string_overflow_throws_wide) {
+    // Exactly-fitting literals are accepted.
+    EXPECT_NO_THROW((detail::Bits<200>{"0x" + std::string(50, 'F')}));  // 200 ones
+    // One nibble too many throws.
+    EXPECT_THROW((detail::Bits<200>{"0x" + std::string(51, 'F')}), std::out_of_range);
+}
+
+TEST(TestBits, to_string_wide) {
+    detail::Bits<200> a{"0x1234567890ABCDEF1122334455667788AABBCCDD"};
+    EXPECT_EQ(
+        a.to_hexadecimal_string(), "00000000001234567890abcdef1122334455667788aabbccdd"
+    );
+    EXPECT_EQ(a.to_decimal_string(), "103929005307927756724023193881144724129310297309");
+
+    detail::Bits<200> neg{"-5"};
+    EXPECT_EQ(neg.to_decimal_string(true), "-5");
+    EXPECT_EQ(detail::Bits<200>(0).to_decimal_string(), "0");
+}
+
+#if defined(__SIZEOF_INT128__)
+// Proof that the wide (BigInt) path remains fully usable in constant
+// expressions: division, multiplication and comparison all evaluate at compile
+// time, and the division identity holds.
+TEST(TestBits, constexpr_wide) {
+    constexpr detail::Bits<200> a{"0xFEDCBA9876543210FEDCBA98"};
+    constexpr detail::Bits<200> b(uint64_t{1000000007});
+    constexpr auto q = a.udiv(b);
+    constexpr auto r = a.umod(b);
+    static_assert(q * b + r == a, "division identity at compile time");
+    static_assert(a.ugt(b));
+    static_assert(a.umod(a) == detail::Bits<200>(0));
+    SUCCEED();
+}
+#endif
 
 // LCOV_EXCL_BR_STOP


### PR DESCRIPTION
Closes #226.

This ports the algos from APInt to `Bits` by replacing the `BigInt` class implementations with those from LLVM. Moved to a new file so I could put the license notice on it.

We couldn't simply vendor it in since we needed the BigInt type to be constexpr like the smaller ints. So the storage is a `std::array` which is constexpr. This means we had to move to a static bound instead of APInt's runtime size field.