### PR TITLE
Make Integer -> NativeInteger

### DIFF
--- a/cpp/include/coconext/types/bigint.hpp
+++ b/cpp/include/coconext/types/bigint.hpp
@@ -515,7 +515,7 @@ class BigInt {
 
     constexpr BigInt() = default;
 
-    template <Integer T>
+    template <NativeInteger T>
         requires(sizeof(T) <= sizeof(WordType))
     constexpr BigInt(T val) {
         data[0] = static_cast<WordType>(val);

--- a/cpp/include/coconext/types/concepts.hpp
+++ b/cpp/include/coconext/types/concepts.hpp
@@ -28,38 +28,38 @@ template <>
 struct is_char<char32_t> : public std::true_type {};
 
 template <typename T>
-struct is_int : public std::false_type {};
+struct is_native_int : public std::false_type {};
 
 template <typename T>
-concept Integer =
-    is_int<std::remove_cv_t<T>>::value && requires { std::numeric_limits<T>::is_integer; };
+concept NativeInteger =
+    is_native_int<std::remove_cv_t<T>>::value && std::numeric_limits<T>::is_integer;
 
 template <>
-struct is_int<signed char> : public std::true_type {};
+struct is_native_int<signed char> : public std::true_type {};
 template <>
-struct is_int<unsigned char> : public std::true_type {};
+struct is_native_int<unsigned char> : public std::true_type {};
 template <>
-struct is_int<short> : public std::true_type {};
+struct is_native_int<short> : public std::true_type {};
 template <>
-struct is_int<unsigned short> : public std::true_type {};
+struct is_native_int<unsigned short> : public std::true_type {};
 template <>
-struct is_int<int> : public std::true_type {};
+struct is_native_int<int> : public std::true_type {};
 template <>
-struct is_int<unsigned int> : public std::true_type {};
+struct is_native_int<unsigned int> : public std::true_type {};
 template <>
-struct is_int<long> : public std::true_type {};
+struct is_native_int<long> : public std::true_type {};
 template <>
-struct is_int<unsigned long> : public std::true_type {};
+struct is_native_int<unsigned long> : public std::true_type {};
 template <>
-struct is_int<long long> : public std::true_type {};
+struct is_native_int<long long> : public std::true_type {};
 template <>
-struct is_int<unsigned long long> : public std::true_type {};
+struct is_native_int<unsigned long long> : public std::true_type {};
 
 #if defined(__SIZEOF_INT128__)
 template <>
-struct is_int<__int128_t> : public std::true_type {};
+struct is_native_int<__int128_t> : public std::true_type {};
 template <>
-struct is_int<__uint128_t> : public std::true_type {};
+struct is_native_int<__uint128_t> : public std::true_type {};
 #endif
 
 namespace detail {

--- a/cpp/include/coconext/types/int_base.hpp
+++ b/cpp/include/coconext/types/int_base.hpp
@@ -58,7 +58,7 @@ class Bits {
     constexpr Bits() = default;
 
     // From native ints
-    template <Integer IntT>
+    template <NativeInteger IntT>
     constexpr Bits(IntT val) : storage_(val) {}
 
     // BigInt from a BigInt

--- a/cpp/include/coconext/types/logic.hpp
+++ b/cpp/include/coconext/types/logic.hpp
@@ -87,7 +87,7 @@ class Logic {
               (s.size() == 1) ? s[0] : throw std::invalid_argument("Invalid logic value")
           ) {}
     constexpr explicit Logic(char const* s) : Logic(std::string_view(s)) {}
-    template <Integer I>
+    template <NativeInteger I>
     constexpr explicit Logic(I v) {
         if (v == 0) {
             value_ = _0;
@@ -102,7 +102,7 @@ class Logic {
     constexpr value_type value() const noexcept { return value_; }
 
     // Egress conversion operators.
-    template <Integer T>
+    template <NativeInteger T>
     constexpr explicit operator T() const {
         if (value_ == _0 || value_ == L) {
             return T(0);
@@ -166,7 +166,7 @@ class Bit {
     constexpr explicit Bit(std::string_view s)
         : Bit((s.size() == 1) ? s[0] : throw std::invalid_argument("Invalid bit value")) {}
     constexpr explicit Bit(char const* s) : Bit(std::string_view(s)) {}
-    template <Integer I>
+    template <NativeInteger I>
     constexpr explicit Bit(I v) {
         if (v == 0) {
             value_ = _0;
@@ -192,7 +192,7 @@ class Bit {
     constexpr std::optional<Bit> resolve(ResolveMethod) const noexcept { return *this; }
     constexpr std::optional<Bit> resolve() const noexcept { return *this; }
 
-    template <Integer T>
+    template <NativeInteger T>
     constexpr explicit operator T() const noexcept {
         return value_ == _0 ? T(0) : T(1);
     }


### PR DESCRIPTION
This concept is only supposed to be for native integers, scoped this way so we can call `std::numeric_limits` on the object, which implies a host of other attributes common to all builtin integer types: cheaply copiable, movable, constructable, which are all castable to each other and into the `Bits` class as the other numeric user-facing classes: `Unsigned`, `Signed`, `Sfixed`, `Ufixed`, and `Float`.

We may add a more general `Integer` concept at some point to add in `Signed` and `Unsigned`, but not now.