### PR TITLE
Rework `uses_Bits`

### DIFF
--- a/cpp/include/coconext/types/bit_array.hpp
+++ b/cpp/include/coconext/types/bit_array.hpp
@@ -18,19 +18,18 @@ class Array;
 // All bits set iff every one of the R.length() bits is counted.
 template <Range R>
 auto and_reduce(detail::Array<Bit, R> const& s) {
-    return (s.value_.popcount() == R.length()) ? '1'_b : '0'_b;
+    return (detail::bits(s).popcount() == R.length()) ? '1'_b : '0'_b;
 }
 
 template <Range R>
 auto or_reduce(detail::Array<Bit, R> const& s) {
-    auto bits = s.value_;
     detail::Bits<R.length()> zero(0);
-    return (bits != zero) ? '1'_b : '0'_b;
+    return (detail::bits(s) != zero) ? '1'_b : '0'_b;
 }
 
 template <Range R>
 auto xor_reduce(detail::Array<Bit, R> const& s) {
-    return (s.value_.popcount() % 2 == 1) ? '1'_b : '0'_b;
+    return (detail::bits(s).popcount() % 2 == 1) ? '1'_b : '0'_b;
 }
 
 namespace detail {
@@ -118,39 +117,13 @@ class Array<Bit, R> {
         return StaticArraySlice<Array<Bit, R> const, R2>(this);
     }
 
-    template <Range R2>
-    friend constexpr std::optional<Range::value_type> coconext::types::index_of(
-        detail::Array<Bit, R2> const&, Bit const&
-    );
-
-    template <Range R2>
-    friend constexpr std::optional<Range::value_type> coconext::types::rindex_of(
-        detail::Array<Bit, R2> const&, Bit const&
-    );
-
-    template <Range R2>
-    friend auto coconext::types::and_reduce(detail::Array<Bit, R2> const& s);
-    template <Range R2>
-    friend auto coconext::types::or_reduce(detail::Array<Bit, R2> const& s);
-    template <Range R2>
-    friend auto coconext::types::xor_reduce(detail::Array<Bit, R2> const& s);
-
-    template <StringLiteral S>
-    friend constexpr auto coconext::types::operator""_b();
-
-    template <Range R2>
-    friend class Unsigned;
-    template <Range R2>
-    friend class Signed;
+    constexpr Array(Bits<R.length()> const& packed_val) : value_(packed_val) {}
 
   private:
-    constexpr Array(Bits<R.length()> const& packed_val) : value_(packed_val) {}
+    friend struct bits_fn;
 
     Bits<R.length()> value_;
 };
-
-template <Range R>
-inline constexpr bool uses_Bits<Array<Bit, R>> = true;
 
 constexpr Range::value_type offset_to_hdl_coord(
     Range r, size_t offset_from_begin
@@ -167,12 +140,12 @@ template <Range R>
 constexpr std::optional<Range::value_type> index_of(
     detail::Array<Bit, R> const& s, Bit const& v
 ) {
-    auto bits = s.value_;
+    auto packed = detail::bits(s);
     if (!static_cast<bool>(v)) {
-        bits = ~bits;
+        packed = ~packed;
     }
 
-    size_t clz = bits.count_leading_zeros();
+    size_t clz = packed.count_leading_zeros();
     if (clz == R.length()) {
         return std::nullopt;
     }
@@ -184,12 +157,12 @@ template <Range R>
 constexpr std::optional<Range::value_type> rindex_of(
     detail::Array<Bit, R> const& s, Bit const& v
 ) {
-    auto bits = s.value_;
+    auto packed = detail::bits(s);
     if (!static_cast<bool>(v)) {
-        bits = ~bits;
+        packed = ~packed;
     }
 
-    size_t ctz = bits.count_trailing_zeros();
+    size_t ctz = packed.count_trailing_zeros();
     if (ctz == R.length()) {
         return std::nullopt;
     }

--- a/cpp/include/coconext/types/concepts.hpp
+++ b/cpp/include/coconext/types/concepts.hpp
@@ -75,8 +75,24 @@ inline constexpr bool is_coconext_unsigned_v = false;
 template <typename T>
 inline constexpr bool is_coconext_signed_v = false;
 
+// Niebloid that reads a HasBits type's packed storage. Implementers declare
+// `friend struct detail::bits_fn;` and keep `value_` private; ADL cannot find
+// this call because `bits` is an object, so users can only reach it via the
+// qualified `detail::bits(x)`.
+struct bits_fn {
+    template <typename T>
+    constexpr auto const& operator()(T const& t) const noexcept {
+        return t.value_;
+    }
+};
+
+inline constexpr bits_fn bits{};
+
 template <typename T>
-inline constexpr bool uses_Bits = false;
+concept HasBits = requires(T const& t) {
+    T::static_range;
+    { detail::bits(t) };
+};
 
 template <typename T>
 concept Formattable = std::semiregular<std::formatter<std::remove_cvref_t<T>, char>>;

--- a/cpp/include/coconext/types/int_base.hpp
+++ b/cpp/include/coconext/types/int_base.hpp
@@ -803,14 +803,13 @@ template <typename T>
 
 }  // namespace detail
 
-template <typename Target, typename Source>
-    requires detail::uses_Bits<Target> && detail::uses_Bits<Source>
+template <detail::HasBits Target, detail::HasBits Source>
 constexpr Target as(Source const& source) noexcept {
     static_assert(
         Target::static_range.length() == Source::static_range.length(),
         "as() requires equal widths."
     );
-    return Target(static_cast<detail::Array<Bit, Source::static_range>>(source));
+    return Target(detail::bits(source));
 }
 
 }  // namespace coconext::types

--- a/cpp/include/coconext/types/signed.hpp
+++ b/cpp/include/coconext/types/signed.hpp
@@ -66,19 +66,15 @@ class Signed {
 
     template <Range R2>
     friend class Signed;
-    template <Range R2>
-    friend class Unsigned;
 
     constexpr Signed() noexcept : value_(0) {}
 
-  private:
     template <size_t W>
     constexpr Signed(Bits<W> const& val) {
         static_assert(W == R.length(), "Construction from Bits requires identical width");
         value_ = val;
     }
 
-  public:
     template <NativeInteger T>
     explicit(
         (std::is_signed_v<T> && std::numeric_limits<T>::digits >= R.length())
@@ -127,16 +123,17 @@ class Signed {
 
     template <Range R2>
     explicit(R.length() <= R2.length()) constexpr Signed(Unsigned<R2> const& other) {
+        auto const& src_bits = bits(other);
         if constexpr (R.length() <= R2.length()) {
             bool fits = true;
             if constexpr (!detail::Bits<R2.length()>::is_not_native_int) {
-                auto src_val = other.value_.raw();
+                auto src_val = src_bits.raw();
                 auto max_val = max_unsigned<R.length() - 1>();
                 if (src_val > max_val) {
                     fits = false;
                 }
             } else {
-                auto src_val = other.value_.raw();
+                auto src_val = src_bits.raw();
                 auto max_val = max_unsigned<R.length() - 1>();
                 if (src_val > max_val) {
                     fits = false;
@@ -156,10 +153,10 @@ class Signed {
         )
         {
             value_ = detail::Bits<R.length()>(
-                static_cast<typename detail::Bits<R.length()>::IntType>(other.value_.raw())
+                static_cast<typename detail::Bits<R.length()>::IntType>(src_bits.raw())
             );
         } else {
-            value_ = detail::Bits<R.length()>(other.value_.raw());
+            value_ = detail::Bits<R.length()>(src_bits.raw());
         }
     }
 
@@ -687,14 +684,13 @@ class Signed {
     friend struct std::hash;
 
   private:
+    friend struct bits_fn;
+
     Bits<R.length()> value_;
 };
 
 template <Range R>
 inline constexpr bool is_coconext_signed_v<Signed<R>> = true;
-
-template <Range R>
-inline constexpr bool uses_Bits<Signed<R>> = true;
 
 template <Range R1, Range R2>
 constexpr auto operator+(Unsigned<R1> const& lhs, Signed<R2> const& rhs) {

--- a/cpp/include/coconext/types/unsigned.hpp
+++ b/cpp/include/coconext/types/unsigned.hpp
@@ -53,10 +53,8 @@ class Unsigned {
     static constexpr Range range() noexcept { return R; }
     static constexpr size_t size() noexcept { return R.length(); }
 
-    // Allow different width Unsigned templates to read our private value_ (required for
-    // resize and Signed constructor)
-    template <Range R2>
-    friend class Signed;
+    // Allow different-width Unsigned instantiations to read our private value_
+    // (required for resize and cross-width Unsigned constructor).
     template <Range R2>
     friend class Unsigned;
 
@@ -125,17 +123,18 @@ class Unsigned {
     // or is negative.
     template <Range R2>
     explicit constexpr Unsigned(Signed<R2> const& other) {
+        auto const& src_bits = bits(other);
         bool is_negative = false;
         if constexpr (!detail::Bits<R2.length()>::is_not_native_int) {
-            is_negative = (other.value_.srl(R2.length() - 1).raw() & 1) != 0;
+            is_negative = (src_bits.srl(R2.length() - 1).raw() & 1) != 0;
         } else {
-            is_negative = (other.value_.srl(R2.length() - 1).raw().get_word(0) & 1) != 0;
+            is_negative = (src_bits.srl(R2.length() - 1).raw().get_word(0) & 1) != 0;
         }
 
         if (is_negative) {
             throw std::out_of_range("Cannot construct Unsigned from negative Signed value");
         }
-        *this = Unsigned<R>(Unsigned<R2>(other.value_));
+        *this = Unsigned<R>(Unsigned<R2>(src_bits));
     }
 
     // Construct from a BitArray. Throws if the source value is not exactly N bits.
@@ -145,7 +144,7 @@ class Unsigned {
             R.length() == R2.length(), "BitArray reinterpret requires identical width"
         );
 
-        value_ = other.value_;
+        value_ = bits(other);
     }
 
     // Implicit conversion to supertype BitArray
@@ -670,14 +669,13 @@ class Unsigned {
     friend struct std::hash;
 
   private:
+    friend struct bits_fn;
+
     Bits<R.length()> value_;
 };
 
 template <Range R>
 inline constexpr bool is_coconext_unsigned_v<Unsigned<R>> = true;
-
-template <Range R>
-inline constexpr bool uses_Bits<Unsigned<R>> = true;
 
 }  // namespace detail
 


### PR DESCRIPTION
The new implementation exposes the `Bits` object in types that satisfy it so we can avoid having to do a copy through BitArray.

The new implementation is a Niebloid in the `details` namespace so that users can't use `bits(object)` and get the underlying Bits via ADL, they must call `coconext::types::detail::bits` directly, meaning they knowingly opt-into using private functionality.

The concept was rewritten to test the Niebloid, so all users have to do is have a `value_` member and made the Niebloid class a friend and it just works.